### PR TITLE
fix: 段落识别被 outerHTML 体积误伤，剔除属性噪声后再判断大小

### DIFF
--- a/entrypoints/main/dom.ts
+++ b/entrypoints/main/dom.ts
@@ -172,12 +172,21 @@ function shouldSkipNode(node: any, tag: string): boolean {
 
 // 检查文本长度
 function checkTextSize(node: any): boolean {
-    // 1. 若文本内容长度超过 3072
-    // 2. 或者 outerHTML 长度超过 4096，都视为过长
+    // 1. 若文本内容长度超过 3072，视为过长
+    // 2. 若 outerHTML 长度超过 4096，剔除属性值（如维基百科 data-mw 的巨型 JSON 属性）后，
+    //    再按真实的 HTML 结构体积判断，避免因冗长属性虚高而误伤含大量引用的正常段落
     // 3. 少于3个字符
-    return node.textContent.length > 3072 ||
-        (node.outerHTML && node.outerHTML.length > 4096) ||
-        node.textContent.length < 3;
+    if (node.textContent.length > 3072) return true;
+
+    if (node.outerHTML && node.outerHTML.length > 4096) {
+        const structureLength = node.outerHTML.replace(
+            /<[^>]*>/g,
+            (m: string) => m.replace(/\s[a-zA-Z-]+(=("[^"]*"|'[^']*'))?/g, '')
+        ).length;
+        if (structureLength > 4096) return true;
+    }
+
+    return node.textContent.length < 3;
 }
 
 // 检查节点内容是否主要为数字


### PR DESCRIPTION
# 问题
`checkTextSize` 用原始 `outerHTML` 长度判断节点是否过大。维基百科等站点的引用 `<sup>` 携带巨型 data-mw JSON 属性，导致正文正常但 `outerHTML` 超过 4096 的段落被误判为过长而跳过。正常使用悬浮翻译以争端时，无法识别段落。而使用全文翻译时，观察到其退化为如下图所示的逐段碎片翻译（如[13]、[c]等引用链接和其他词条的超链接被单独翻译），整段正文反而无法翻译。

鼠标悬浮翻译在图中的 Etymology 下的段落时，点击 ctrl 无法正常识别并翻译。与 Issue #128 中展示的是同一个问题。
<img width="1710" height="912" alt="image" src="https://github.com/user-attachments/assets/182de551-9615-4c49-b957-709d878051f6" />

使用全文翻译时，会观察到其退化为逐段碎片翻译，且只有引用标记、其他词条链接等超链接识别为可翻译部分：
<img width="1504" height="1026" alt="image" src="https://github.com/user-attachments/assets/abab3f37-bd1a-41b9-a7ae-cbeaf6241b67" />

Fixes #128

# 修复
文本量仍以 textContent（>3072）为准；outerHTML 超过 4096 时先剔除属性值，再按真实的 HTML 结构体积判断，避免冗长属性虚高误伤含大量引用的正常段落。

# 验证
对 https://en.wikipedia.org/wiki/Inanna 真实页面用 jsdom 复现，修复前段落被拆成 14 个碎片、全页 109 个段落中 64 个被误拒；修复后整段识别、全页仅 1 个空段落仍跳过，且 0 回归。

运行浏览器测试，对同样文段进行翻译：
<img width="1710" height="926" alt="image" src="https://github.com/user-attachments/assets/ed3b9ff8-d4d0-4b7c-b4cd-25cf3fa68e74" />

最开始发现该问题的地方是英文维基百科 https://en.wikipedia.org/wiki/Inanna 的 Etymology 段落，在原 main 分支上，该 bug 可以稳定复现。经测试，确认上述问题已被该 PR 修复。

## Summary by Sourcery

Bug Fixes:
- Prevent normal paragraphs with large attribute payloads (e.g. Wikipedia data-mw JSON on <sup> references) from being incorrectly rejected by the text size filter.