### PR TITLE
fix: handle triple-click selections around hidden controls

### DIFF
--- a/scripts/run-selection-trigger-test.cjs
+++ b/scripts/run-selection-trigger-test.cjs
@@ -307,6 +307,23 @@ async function resetFixture(page) {
   await page.waitForTimeout(200);
 }
 
+async function resetTripleClickFixture(page, buttonVisible = false) {
+  await page.evaluate(({ targetText, visible }) => {
+    document.querySelector('#selection-test-fixture')?.remove();
+    const buttonDisplay = visible ? 'inline-block' : 'none';
+    document.body.insertAdjacentHTML('beforeend', `
+      <main id="selection-test-fixture" style="padding: 80px; font: 24px/1.7 Arial, sans-serif;">
+        <article id="selection-triple-click-review" style="max-width: 900px;">
+          <p id="target" style="margin: 0;">${targetText}</p>
+          <button id="selection-triple-click-more" type="button" style="display: ${buttonDisplay};">more</button>
+          <div id="selection-triple-click-footer"><span>1 reply</span></div>
+        </article>
+        <p id="neighbor">This neighboring paragraph must remain untouched.</p>
+      </main>`);
+  }, { targetText: TARGET_TEXT, visible: buttonVisible });
+  await page.waitForTimeout(200);
+}
+
 async function selectTarget(page, dispatchPointerUpAfterFallback = false) {
   await activateInputPage(page);
   const target = page.locator('#target');
@@ -347,6 +364,104 @@ async function selectTarget(page, dispatchPointerUpAfterFallback = false) {
   }
   assert(selectedText.length > 0, '划词测试没有产生选区');
   return { text: selectedText, method };
+}
+
+async function tripleClickTarget(page) {
+  await activateInputPage(page);
+  await page.keyboard.press('Escape');
+  const target = page.locator('#target');
+  const box = await target.boundingBox();
+  assert(box, '三击测试的目标段落没有可用几何位置');
+  await page.evaluate(() => {
+    const targetElement = document.querySelector('#target');
+    if (!targetElement) throw new Error('三击测试找不到目标段落');
+    globalThis.__fluentReadTripleClickMouseDownSequence = [];
+    targetElement.addEventListener('mousedown', (event) => {
+      globalThis.__fluentReadTripleClickMouseDownSequence.push({
+        isTrusted: event.isTrusted,
+        detail: event.detail,
+        button: event.button,
+      });
+    }, { capture: true });
+  });
+  await page.mouse.click(
+    box.x + Math.min(80, Math.max(8, box.width / 2)),
+    box.y + box.height / 2,
+    { button: 'left', clickCount: 3, delay: 80 },
+  );
+  await page.waitForTimeout(500);
+  return page.evaluate(() => {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) throw new Error('原生三击没有产生选区 Range');
+    const range = selection.getRangeAt(0);
+    const fragment = range.cloneContents();
+    const sourceButton = document.querySelector('#selection-triple-click-more');
+    const fragmentButton = fragment.querySelector('#selection-triple-click-more');
+    const rangeRects = Array.from(range.getClientRects(), rect => ({
+      left: rect.left,
+      top: rect.top,
+      right: rect.right,
+      bottom: rect.bottom,
+      width: rect.width,
+      height: rect.height,
+    }));
+    const buttonRects = sourceButton
+      ? Array.from(sourceButton.getClientRects(), rect => ({
+          left: rect.left,
+          top: rect.top,
+          right: rect.right,
+          bottom: rect.bottom,
+          width: rect.width,
+          height: rect.height,
+        }))
+      : [];
+    const rectsOverlap = (first, second) => first.right > second.left
+      && first.left < second.right
+      && first.bottom > second.top
+      && first.top < second.bottom;
+    const describeBoundary = (node, offset) => ({
+      nodeName: node.nodeName,
+      tagName: node.nodeType === Node.ELEMENT_NODE ? node.tagName : node.parentElement?.tagName || '',
+      id: node.nodeType === Node.ELEMENT_NODE ? node.id : node.parentElement?.id || '',
+      offset,
+    });
+    let intersectsButton = false;
+    if (sourceButton) {
+      try { intersectsButton = range.intersectsNode(sourceButton); } catch { /* 断开节点不应阻塞诊断。 */ }
+    }
+    const buttonStyle = sourceButton ? getComputedStyle(sourceButton) : null;
+    const selectedText = selection.toString();
+    const mouseDownSequence = globalThis.__fluentReadTripleClickMouseDownSequence || [];
+    return {
+      mouseDown: mouseDownSequence.at(-1) || null,
+      mouseDownSequence,
+      text: selectedText.trim(),
+      rawText: selectedText,
+      rangeCount: selection.rangeCount,
+      isCollapsed: selection.isCollapsed,
+      start: describeBoundary(range.startContainer, range.startOffset),
+      end: describeBoundary(range.endContainer, range.endOffset),
+      rangeRects,
+      fragment: {
+        text: fragment.textContent || '',
+        button: fragmentButton ? {
+          tagName: fragmentButton.tagName,
+          text: fragmentButton.textContent || '',
+        } : null,
+        footer: Boolean(fragment.querySelector('#selection-triple-click-footer')),
+      },
+      sourceButton: sourceButton ? {
+        text: sourceButton.textContent || '',
+        display: buttonStyle?.display || '',
+        visibility: buttonStyle?.visibility || '',
+        opacity: buttonStyle?.opacity || '',
+        rects: buttonRects,
+        intersectsRange: intersectsButton,
+        overlapsSelectionRects: buttonRects.some(buttonRect => rangeRects.some(rangeRect => rectsOverlap(buttonRect, rangeRect))),
+      } : null,
+      selectedTextIncludesButtonText: Boolean(sourceButton?.textContent && selectedText.includes(sourceButton.textContent)),
+    };
+  });
 }
 
 async function selectTextWithDomRange(page, selector, maxLength = 72) {
@@ -915,6 +1030,100 @@ async function main() {
     await closeSelectionUi(page);
     await patchStoredConfig(popup, { to: 'zh-Hans' });
     await page.waitForTimeout(700);
+    await setSelectionDelay(popup, drawer, popup, 300);
+
+    // 原生三击：普通段落和 JetBrains 评论形状都应显示入口。
+    // JetBrains 形状的 Range 会夹带一个 display:none 的 button，但可见选区只有正文。
+    await closeSelectionUi(page);
+    await setSelectionDelay(popup, drawer, popup, 0);
+    const tripleClickPopupState = await setSelectionTrigger(popup, drawer, popup, '显示图标');
+
+    await resetFixture(page);
+    const standardTripleClick = await tripleClickTarget(page);
+    assert(standardTripleClick.mouseDown?.isTrusted === true
+      && standardTripleClick.mouseDown.detail === 3
+      && standardTripleClick.mouseDown.button === 0,
+    `普通段落没有收到可信的左键三击：${JSON.stringify(standardTripleClick.mouseDown)}`);
+    assert(standardTripleClick.text === TARGET_TEXT && !standardTripleClick.fragment.button,
+      `普通段落三击 Range 形状异常：${JSON.stringify(standardTripleClick)}`);
+    await waitForSelectionUi(page, {
+      indicator: true,
+      tooltip: false,
+      indicatorClass: 'fr-selection-indicator fr-selection-indicator--icon',
+    }, '普通段落三击显示入口');
+    const standardTripleClickUi = await readSelectionUi(page);
+    result.cases.push({
+      id: 'selection.triple-click-standard-control',
+      status: 'passed',
+      selection: standardTripleClick,
+      ui: standardTripleClickUi,
+    });
+
+    await closeSelectionUi(page);
+    await resetTripleClickFixture(page, false);
+    const hiddenButtonTripleClick = await tripleClickTarget(page);
+    assert(hiddenButtonTripleClick.mouseDown?.isTrusted === true
+      && hiddenButtonTripleClick.mouseDown.detail === 3
+      && hiddenButtonTripleClick.mouseDown.button === 0,
+    `JetBrains 形状选区没有收到可信的左键三击：${JSON.stringify(hiddenButtonTripleClick.mouseDown)}`);
+    assert(hiddenButtonTripleClick.text === TARGET_TEXT
+      && hiddenButtonTripleClick.start.id === 'target'
+      && hiddenButtonTripleClick.start.offset === 0
+      && hiddenButtonTripleClick.end.id === 'selection-triple-click-footer'
+      && hiddenButtonTripleClick.end.offset === 0,
+    `JetBrains 形状的三击 Range 边界不符合前置条件：${JSON.stringify(hiddenButtonTripleClick)}`);
+    assert(hiddenButtonTripleClick.fragment.button?.tagName === 'BUTTON'
+      && hiddenButtonTripleClick.fragment.button.text === 'more'
+      && hiddenButtonTripleClick.fragment.footer,
+    `JetBrains 形状的 Range clone 没有夹带隐藏按钮和 footer 边界：${JSON.stringify(hiddenButtonTripleClick.fragment)}`);
+    assert(hiddenButtonTripleClick.sourceButton?.display === 'none'
+      && hiddenButtonTripleClick.sourceButton.rects.length === 0
+      && hiddenButtonTripleClick.sourceButton.intersectsRange
+      && !hiddenButtonTripleClick.sourceButton.overlapsSelectionRects
+      && !hiddenButtonTripleClick.selectedTextIncludesButtonText,
+    `JetBrains 形状的夹带按钮不是无可见几何的结构噪声：${JSON.stringify(hiddenButtonTripleClick.sourceButton)}`);
+    await waitForSelectionUi(page, {
+      indicator: true,
+      tooltip: false,
+      indicatorClass: 'fr-selection-indicator fr-selection-indicator--icon',
+    }, 'JetBrains 形状三击忽略隐藏按钮后显示入口');
+    const hiddenButtonTripleClickUi = await readSelectionUi(page);
+    const hiddenButtonTripleClickScreenshot = path.join(args.artifactsDir, 'selection-triple-click-hidden-button.png');
+    await page.screenshot({ path: hiddenButtonTripleClickScreenshot });
+    result.screenshots.push(hiddenButtonTripleClickScreenshot);
+    result.cases.push({
+      id: 'selection.triple-click-hidden-button-regression',
+      status: 'passed',
+      popupState: tripleClickPopupState,
+      selection: hiddenButtonTripleClick,
+      ui: hiddenButtonTripleClickUi,
+    });
+
+    // 可见交互控件仍是安全边界：同样的 DOM 顺序改为可见 button 后必须拒绝。
+    await closeSelectionUi(page);
+    await resetTripleClickFixture(page, true);
+    const visibleButtonTripleClick = await tripleClickTarget(page);
+    assert(visibleButtonTripleClick.mouseDown?.isTrusted === true
+      && visibleButtonTripleClick.mouseDown.detail === 3
+      && visibleButtonTripleClick.mouseDown.button === 0
+      && visibleButtonTripleClick.text === TARGET_TEXT
+      && visibleButtonTripleClick.fragment.button?.tagName === 'BUTTON'
+      && visibleButtonTripleClick.sourceButton?.display !== 'none'
+      && visibleButtonTripleClick.sourceButton?.rects.length > 0
+      && visibleButtonTripleClick.sourceButton?.intersectsRange,
+    `可见 button 对照没有产生预期 Range：${JSON.stringify(visibleButtonTripleClick)}`);
+    await page.waitForTimeout(500);
+    const visibleButtonTripleClickUi = await readSelectionUi(page);
+    assert(!visibleButtonTripleClickUi.indicator && !visibleButtonTripleClickUi.tooltip,
+      `三击 Range 包含可见 button 时仍显示了划词入口：${JSON.stringify(visibleButtonTripleClickUi)}`);
+    result.cases.push({
+      id: 'selection.triple-click-visible-button-rejected',
+      status: 'passed',
+      selection: visibleButtonTripleClick,
+      ui: visibleButtonTripleClickUi,
+    });
+
+    await closeSelectionUi(page);
     await setSelectionDelay(popup, drawer, popup, 300);
 
     // 视觉触发方式：Popup 改设置后不刷新页面，真实鼠标划词仍应反映新模式。

--- a/src/features/selection-translation/core.ts
+++ b/src/features/selection-translation/core.ts
@@ -261,13 +261,18 @@ function isEditableSelectionElement(element: Element): boolean {
     return false;
 }
 
-function isSelectionExcludedElement(element: Element | null): boolean {
-    if (!element) return false;
+function isIntrinsicallyExcludedSelectionElement(element: Element): boolean {
     if (isSelectionExcludedTagName(element.tagName)) return true;
 
     const role = element.getAttribute('role')?.trim().toLowerCase();
     if (role && selectionExcludedRoles.has(role)) return true;
-    if (isEditableSelectionElement(element)) return true;
+    return isEditableSelectionElement(element);
+}
+
+function isSelectionExcludedElement(element: Element | null): boolean {
+    if (!element) return false;
+    if (isIntrinsicallyExcludedSelectionElement(element)) return true;
+
     const excluded = element.closest(selectionExcludedSelector);
     if (!excluded) return false;
     // A broad marker on a body-level SPA shell should not suppress a direct user
@@ -280,9 +285,29 @@ function elementFromSelectionNode(node: Node | null): Element | null {
     return node.nodeType === 1 ? node as Element : node.parentElement;
 }
 
+function selectionExcludedDescendants(range: Range): Element[] {
+    const commonAncestor = range.commonAncestorContainer;
+    const queryRoot = commonAncestor.nodeType === 3 ? commonAncestor.parentElement : commonAncestor;
+    if (!queryRoot || !('querySelectorAll' in queryRoot)) return [];
+    return Array.from((queryRoot as ParentNode).querySelectorAll(selectionExcludedSelector));
+}
+
+function containsNonZeroClientRect(rects: DOMRectList): boolean {
+    return Array.from(rects).some(rect => rect.width > 0 || rect.height > 0);
+}
+
+function hasNonZeroClientRect(element: Element): boolean {
+    if (containsNonZeroClientRect(element.getClientRects())) return true;
+
+    const contentRange = element.ownerDocument?.createRange();
+    if (!contentRange) return false;
+    contentRange.selectNodeContents(element);
+    return containsNonZeroClientRect(contentRange.getClientRects());
+}
+
 /**
  * 划词翻译只处理页面正文，不处理原子内容或交互控件。这里同时检查选区两端
- * 与克隆内容，避免纯图片选区或跨越特殊组件的选区留下失效触发器。
+ * 与实时 DOM 中相交且具有可见几何的排除元素，避免隐藏控件误伤浏览器生成的段落选区。
  */
 export function shouldIgnoreSelection(range: Range): boolean {
     const boundaries = [
@@ -292,7 +317,15 @@ export function shouldIgnoreSelection(range: Range): boolean {
     if (boundaries.some(isSelectionExcludedElement)) return true;
 
     try {
-        return Boolean(range.cloneContents().querySelector(selectionExcludedSelector));
+        return selectionExcludedDescendants(range).some((element) => {
+            try {
+                if (!isIntrinsicallyExcludedSelectionElement(element) &&
+                    isTopLevelApplicationShell(element)) return false;
+                return range.intersectsNode(element) && hasNonZeroClientRect(element);
+            } catch {
+                return false;
+            }
+        });
     } catch {
         return false;
     }

--- a/tests/selectionTranslatorCore.test.ts
+++ b/tests/selectionTranslatorCore.test.ts
@@ -26,28 +26,62 @@ import { matchesConfiguredHotkey, matchesModifierOnlyHotkey, resolveConfiguredHo
 import { normalizeSelectionTtsVoiceOrder, selectionTtsVoiceLocale, selectionTtsVoiceOption } from '@/src/features/selection-translation/ttsConfig';
 
 interface MockElementOptions {
+    nodeType?: number;
     tagName?: string;
     role?: string;
     attributes?: Record<string, string>;
     closestMatch?: boolean;
     isContentEditable?: boolean;
     parentElement?: MockElement | null;
+    descendants?: MockElement[];
+    clientRects?: Array<{width: number; height: number}>;
+    contentRects?: Array<{width: number; height: number}>;
+    querySelectorAllThrows?: boolean;
+    getClientRectsThrows?: boolean;
+    contentRangeFailure?: 'create' | 'select' | 'rects';
 }
 
 class MockElement {
-    readonly nodeType = 1;
+    readonly nodeType: number;
     readonly tagName: string;
     readonly isContentEditable: boolean;
+    readonly ownerDocument: Document | null;
     parentElement: MockElement | null;
     private readonly attributes: Record<string, string>;
     private readonly closestMatch: boolean;
+    private readonly descendants: MockElement[];
+    private readonly clientRects: Array<{width: number; height: number}>;
+    private readonly querySelectorAllThrows: boolean;
+    private readonly getClientRectsThrows: boolean;
 
     constructor(options: MockElementOptions = {}) {
+        this.nodeType = options.nodeType ?? 1;
         this.tagName = options.tagName ?? 'P';
         this.attributes = options.attributes ?? {};
         this.closestMatch = options.closestMatch === true;
         this.isContentEditable = options.isContentEditable === true;
         this.parentElement = options.parentElement ?? null;
+        this.descendants = options.descendants ?? [];
+        this.clientRects = options.clientRects ?? [];
+        this.querySelectorAllThrows = options.querySelectorAllThrows === true;
+        this.getClientRectsThrows = options.getClientRectsThrows === true;
+        const contentRects = options.contentRects ?? [];
+        this.ownerDocument = options.contentRects !== undefined || options.contentRangeFailure !== undefined
+            ? {
+                createRange: () => {
+                    if (options.contentRangeFailure === 'create') throw new Error('content range creation failed');
+                    return {
+                        selectNodeContents: () => {
+                            if (options.contentRangeFailure === 'select') throw new Error('content range selection failed');
+                        },
+                        getClientRects: () => {
+                            if (options.contentRangeFailure === 'rects') throw new Error('content geometry failed');
+                            return contentRects;
+                        },
+                    };
+                },
+            } as unknown as Document
+            : null;
         if (options.role) this.attributes.role = options.role;
     }
 
@@ -62,21 +96,36 @@ class MockElement {
     closest(): MockElement | null {
         return this.closestMatch ? this : null;
     }
+
+    querySelectorAll(): MockElement[] {
+        if (this.querySelectorAllThrows) throw new Error('query failed');
+        return this.descendants;
+    }
+
+    getClientRects(): Array<{width: number; height: number}> {
+        if (this.getClientRectsThrows) throw new Error('geometry failed');
+        return this.clientRects;
+    }
 }
 
 function mockTextNode(parentElement: MockElement | null): Node {
     return {nodeType: 3, parentElement} as Node;
 }
 
-function mockRange(start: Node | null, end: Node | null, cloneResult: boolean | 'throw'): Range {
+interface MockRangeOptions {
+    commonAncestor?: Node;
+    intersectingNodes?: Node[];
+    intersectionFailureNodes?: Node[];
+}
+
+function mockRange(start: Node | null, end: Node | null, options: MockRangeOptions = {}): Range {
     return {
         startContainer: start,
         endContainer: end,
-        cloneContents: () => {
-            if (cloneResult === 'throw') throw new Error('clone failed');
-            return {
-                querySelector: () => cloneResult ? {} : null,
-            };
+        commonAncestorContainer: options.commonAncestor ?? new MockElement() as unknown as Node,
+        intersectsNode: (node: Node) => {
+            if (options.intersectionFailureNodes?.includes(node)) throw new Error('intersection failed');
+            return options.intersectingNodes?.includes(node) === true;
         },
     } as unknown as Range;
 }
@@ -230,27 +279,22 @@ describe('selection translator text and speech language normalization', () => {
         expect(shouldIgnoreSelection(mockRange(
             new MockElement({tagName: 'IMG'}) as unknown as Node,
             new MockElement() as unknown as Node,
-            false,
         ))).toBe(true);
         expect(shouldIgnoreSelection(mockRange(
             new MockElement({role: 'button'}) as unknown as Node,
             new MockElement() as unknown as Node,
-            false,
         ))).toBe(true);
         expect(shouldIgnoreSelection(mockRange(
             new MockElement({isContentEditable: true}) as unknown as Node,
             new MockElement() as unknown as Node,
-            false,
         ))).toBe(true);
         expect(shouldIgnoreSelection(mockRange(
             mockTextNode(new MockElement({attributes: {contenteditable: 'plaintext-only'}})),
             new MockElement() as unknown as Node,
-            false,
         ))).toBe(true);
         expect(shouldIgnoreSelection(mockRange(
             mockTextNode(new MockElement({attributes: {contenteditable: 'false'}})),
             new MockElement({closestMatch: true}) as unknown as Node,
-            false,
         ))).toBe(true);
     });
 
@@ -263,12 +307,18 @@ describe('selection translator text and speech language normalization', () => {
             </body></html>
         `);
         const text = document.querySelector('#content')?.firstChild;
+        const shell = document.querySelector('#app');
         if (!text) throw new Error('selection fixture text is missing');
+        if (!shell) throw new Error('selection fixture shell is missing');
+        Object.defineProperty(shell, 'getClientRects', {
+            value: () => [{width: 640, height: 480}],
+        });
 
         const range = {
             startContainer: text,
             endContainer: text,
-            cloneContents: () => ({querySelector: () => null}),
+            commonAncestorContainer: document,
+            intersectsNode: (node: Node) => node === shell,
         } as unknown as Range;
         expect(shouldIgnoreSelection(range)).toBe(false);
 
@@ -277,38 +327,196 @@ describe('selection translator text and speech language normalization', () => {
         protectedRegion.className = 'notranslate';
         protectedRegion.append(protectedText);
         document.querySelector('#content')?.append(' ', protectedRegion);
+        Object.defineProperty(protectedRegion, 'getClientRects', {
+            value: () => [{width: 160, height: 20}],
+        });
         const protectedRange = {
-            startContainer: protectedText,
-            endContainer: protectedText,
-            cloneContents: () => ({querySelector: () => null}),
+            startContainer: text,
+            endContainer: text,
+            commonAncestorContainer: document,
+            intersectsNode: (node: Node) => node === shell || node === protectedRegion,
         } as unknown as Range;
         expect(shouldIgnoreSelection(protectedRange)).toBe(true);
 
-        const shell = document.querySelector('#app');
+        const button = document.createElement('button');
+        button.textContent = 'Visible action';
+        document.querySelector('#content')?.append(' ', button);
+        Object.defineProperty(button, 'getClientRects', {
+            value: () => [{width: 100, height: 24}],
+        });
+        const controlRange = {
+            startContainer: text,
+            endContainer: text,
+            commonAncestorContainer: document,
+            intersectsNode: (node: Node) => node === shell || node === button,
+        } as unknown as Range;
+        expect(shouldIgnoreSelection(controlRange)).toBe(true);
+
         const shellRange = {
             startContainer: shell,
             endContainer: shell,
-            cloneContents: () => ({querySelector: () => null}),
+            commonAncestorContainer: shell,
+            intersectsNode: (node: Node) => node === shell,
         } as unknown as Range;
         expect(shouldIgnoreSelection(shellRange)).toBe(true);
     });
 
-    it('在 fragment 检查失败时 fail-open，避免破坏普通文本选择', () => {
+    it('允许选区内部与 Range 相交但没有可见几何的排除元素', () => {
+        const hiddenButton = new MockElement({tagName: 'BUTTON', contentRects: []});
+        const root = new MockElement({descendants: [hiddenButton]});
+
         expect(shouldIgnoreSelection(mockRange(
-            null,
-            mockTextNode(new MockElement()),
-            false,
+            mockTextNode(root),
+            mockTextNode(root),
+            {
+                commonAncestor: root as unknown as Node,
+                intersectingNodes: [hiddenButton as unknown as Node],
+            },
         ))).toBe(false);
+    });
+
+    it('拒绝自身无盒子但内容具有可见几何的 display-contents 排除元素', () => {
+        const displayContentsButton = new MockElement({
+            tagName: 'BUTTON',
+            contentRects: [{width: 36, height: 18}],
+        });
+        const root = new MockElement({descendants: [displayContentsButton]});
+
         expect(shouldIgnoreSelection(mockRange(
-            mockTextNode(new MockElement()),
-            mockTextNode(new MockElement()),
-            true,
+            mockTextNode(root),
+            mockTextNode(root),
+            {
+                commonAncestor: root as unknown as Node,
+                intersectingNodes: [displayContentsButton as unknown as Node],
+            },
         ))).toBe(true);
+    });
+
+    it('从 Document 和 ShadowRoot 公共祖先枚举实时排除元素', () => {
+        for (const nodeType of [9, 11]) {
+            const visibleButton = new MockElement({tagName: 'BUTTON', clientRects: [{width: 20, height: 16}]});
+            const queryRoot = new MockElement({nodeType, descendants: [visibleButton]});
+            const textParent = new MockElement();
+
+            expect(shouldIgnoreSelection(mockRange(
+                mockTextNode(textParent),
+                mockTextNode(textParent),
+                {
+                    commonAncestor: queryRoot as unknown as Node,
+                    intersectingNodes: [visibleButton as unknown as Node],
+                },
+            ))).toBe(true);
+        }
+    });
+
+    it('只拒绝选区内部与 Range 相交且具有非零几何的排除元素', () => {
+        const visibleButton = new MockElement({
+            tagName: 'BUTTON',
+            clientRects: [{width: 0, height: 0}, {width: 24, height: 18}],
+        });
+        const root = new MockElement({descendants: [visibleButton]});
+
         expect(shouldIgnoreSelection(mockRange(
-            mockTextNode(new MockElement()),
-            mockTextNode(new MockElement()),
-            'throw',
+            mockTextNode(root),
+            mockTextNode(root),
+            {commonAncestor: root as unknown as Node},
         ))).toBe(false);
+        expect(shouldIgnoreSelection(mockRange(
+            mockTextNode(root),
+            mockTextNode(root),
+            {
+                commonAncestor: root as unknown as Node,
+                intersectingNodes: [visibleButton as unknown as Node],
+            },
+        ))).toBe(true);
+    });
+
+    it('选区端点位于排除元素内时保持严格拒绝，不受内部元素几何影响', () => {
+        const button = new MockElement({tagName: 'BUTTON'});
+        const hiddenRoot = new MockElement({descendants: [button]});
+
+        expect(shouldIgnoreSelection(mockRange(
+            mockTextNode(button),
+            mockTextNode(hiddenRoot),
+            {
+                commonAncestor: hiddenRoot as unknown as Node,
+                intersectingNodes: [button as unknown as Node],
+            },
+        ))).toBe(true);
+    });
+
+    it('实时排除元素检查失败时 fail-open，避免破坏普通文本选择', () => {
+        const textParent = new MockElement();
+        const excluded = new MockElement({tagName: 'BUTTON', clientRects: [{width: 10, height: 10}]});
+        const queryFailureRoot = new MockElement({querySelectorAllThrows: true});
+        const intersectionRoot = new MockElement({descendants: [excluded]});
+        const missingOwnerDocument = new MockElement({tagName: 'BUTTON'});
+        const missingOwnerDocumentRoot = new MockElement({descendants: [missingOwnerDocument]});
+        const geometryFailure = new MockElement({tagName: 'BUTTON', getClientRectsThrows: true});
+        const geometryRoot = new MockElement({descendants: [geometryFailure]});
+        const contentRangeFailures = (['create', 'select', 'rects'] as const).map(failure => (
+            new MockElement({tagName: 'BUTTON', contentRangeFailure: failure})
+        ));
+
+        expect(shouldIgnoreSelection(mockRange(
+            mockTextNode(textParent),
+            mockTextNode(textParent),
+            {commonAncestor: queryFailureRoot as unknown as Node},
+        ))).toBe(false);
+        expect(shouldIgnoreSelection(mockRange(
+            mockTextNode(textParent),
+            mockTextNode(textParent),
+            {
+                commonAncestor: intersectionRoot as unknown as Node,
+                intersectingNodes: [excluded as unknown as Node],
+                intersectionFailureNodes: [excluded as unknown as Node],
+            },
+        ))).toBe(false);
+        expect(shouldIgnoreSelection(mockRange(
+            mockTextNode(textParent),
+            mockTextNode(textParent),
+            {
+                commonAncestor: missingOwnerDocumentRoot as unknown as Node,
+                intersectingNodes: [missingOwnerDocument as unknown as Node],
+            },
+        ))).toBe(false);
+        expect(shouldIgnoreSelection(mockRange(
+            mockTextNode(textParent),
+            mockTextNode(textParent),
+            {
+                commonAncestor: geometryRoot as unknown as Node,
+                intersectingNodes: [geometryFailure as unknown as Node],
+            },
+        ))).toBe(false);
+        for (const contentRangeFailure of contentRangeFailures) {
+            const contentGeometryRoot = new MockElement({descendants: [contentRangeFailure]});
+            expect(shouldIgnoreSelection(mockRange(
+                mockTextNode(textParent),
+                mockTextNode(textParent),
+                {
+                    commonAncestor: contentGeometryRoot as unknown as Node,
+                    intersectingNodes: [contentRangeFailure as unknown as Node],
+                },
+            ))).toBe(false);
+        }
+    });
+
+    it('单个排除元素检查失败时继续识别后续可见排除元素', () => {
+        const geometryFailure = new MockElement({tagName: 'BUTTON', getClientRectsThrows: true});
+        const visibleButton = new MockElement({tagName: 'BUTTON', clientRects: [{width: 20, height: 16}]});
+        const root = new MockElement({descendants: [geometryFailure, visibleButton]});
+
+        expect(shouldIgnoreSelection(mockRange(
+            mockTextNode(root),
+            mockTextNode(root),
+            {
+                commonAncestor: root as unknown as Node,
+                intersectingNodes: [
+                    geometryFailure as unknown as Node,
+                    visibleButton as unknown as Node,
+                ],
+            },
+        ))).toBe(true);
     });
 
     it('maps translation language codes to browser speech language codes', () => {


### PR DESCRIPTION
## Summary

- ignore hidden interactive descendants that browsers may structurally include in triple-click paragraph ranges
- keep visible controls, editable regions, code/media, and `notranslate` boundaries excluded
- add trusted triple-click browser regression coverage for standard, hidden-button, and visible-button cases

## Verification

- `pnpm exec vitest run --reporter=basic` — 154 files / 2238 tests passed
- `pnpm compile`
- `pnpm build`
- `pnpm build:firefox` — build verification only
- `pnpm build:userscript`
- isolated production Edge selection matrix — 32/32 cases passed, with no extension console errors
- live JetBrains Marketplace review — trusted triple-click `[1,2,3]` selected 265 characters and showed the indicator; drag selection also showed the indicator

Reproduction page: https://plugins.jetbrains.com/plugin/24765-multi-project-workspace/reviews
