### PR TITLE
fix: prevent stale config updates from toggling settings

### DIFF
--- a/scripts/run-video-subtitle-fixture-test.cjs
+++ b/scripts/run-video-subtitle-fixture-test.cjs
@@ -120,6 +120,50 @@ async function persistExtensionConfig(extensionPage, patch) {
   }
 }
 
+function comparableConfigWithoutVideoToggle(value) {
+  const comparable = {...value};
+  delete comparable.videoTranslationEnabled;
+  delete comparable.__fluentConfigRevision;
+  return JSON.stringify(comparable);
+}
+
+async function sampleStableVideoToggleState(page, control, expected, durationMs = 6000) {
+  const samples = [];
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < durationMs) {
+    const ui = await page.evaluate(() => {
+      const playerButton = document.querySelector('#fluent-read-video-subtitle-button');
+      const menuToggle = document.querySelector('#fluent-read-video-subtitle-menu [data-action="toggle-translation"]');
+      return {
+        button: playerButton?.getAttribute('aria-pressed') || '',
+        menu: menuToggle?.getAttribute('aria-checked') || '',
+        state: menuToggle?.querySelector('[data-state]')?.textContent || '',
+      };
+    });
+    const stored = await readExtensionConfig(control);
+    samples.push({
+      elapsedMs: Date.now() - startedAt,
+      ...ui,
+      stored: stored.videoTranslationEnabled,
+      revision: stored.__fluentConfigRevision,
+    });
+    await page.waitForTimeout(250);
+  }
+
+  const expectedString = String(expected);
+  const expectedState = expected ? '已开启' : '立即开启';
+  if (samples.some((sample) => sample.button !== expectedString
+    || sample.menu !== expectedString
+    || sample.state !== expectedState
+    || sample.stored !== expected)) {
+    throw new Error(`字幕翻译开关在稳定窗口内发生跳变：${JSON.stringify(samples)}`);
+  }
+  if (new Set(samples.map((sample) => sample.revision)).size !== 1) {
+    throw new Error(`字幕翻译开关稳定后仍在重复写配置：${JSON.stringify(samples)}`);
+  }
+  return samples;
+}
+
 const OFFLINE_YOUTUBE_FIXTURE_HTML = `<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><title>YouTube subtitle fixture</title><script>var ytInitialPlayerResponse={"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https://www.youtube.com/api/timedtext?v=fixture-original-slow&lang=en&kind=download","languageCode":"en","name":{"simpleText":"English"}}]}}};</script></head>
 <body><main><div id="movie_player" class="html5-video-player"></div></main></body></html>`;
@@ -342,6 +386,19 @@ async function main() {
     if (initialPopupVideoState.enabled) {
       throw new Error(`新配置的视频字幕翻译应默认关闭：${JSON.stringify(initialPopupVideoState)}`);
     }
+
+    // 文档页过去只在启动时复制一次整份配置；它保持打开时，随后保存任一文档
+    // 选项会把旧的字幕开关连同最新 revision 一起回灌。先以关闭状态打开文档页，
+    // 再从其他上下文开启字幕，验证字段级保存不会覆盖刚更新的全局字段。
+    const documentConfigPage = await createPage();
+    await documentConfigPage.goto(`chrome-extension://${extensionId}/document.html`, { waitUntil: 'domcontentloaded' });
+    await activatePage(documentConfigPage);
+    await documentConfigPage.locator('input[type="file"]').setInputFiles({
+      name: 'stale-config-probe.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('FluentRead cross-context configuration probe.', 'utf8'),
+    });
+    await documentConfigPage.locator('select[aria-label="文档源语言"]').waitFor({state: 'visible', timeout: 15000});
     await persistExtensionConfig(control, {
       on: true,
       from: 'auto',
@@ -353,6 +410,18 @@ async function main() {
       videoSubtitleDisplayMode: 'bilingual',
       useCache: false,
     });
+    await documentConfigPage.locator('select[aria-label="文档源语言"]').selectOption('en');
+    await documentConfigPage.waitForFunction(async () => {
+      const response = await chrome.runtime.sendMessage({type: 'configStorageRead', key: 'local:config'});
+      return response?.success === true
+        && response.value?.from === 'en'
+        && response.value?.videoTranslationEnabled === true;
+    }, null, {timeout: 10000});
+    const crossContextDocumentConfig = await readExtensionConfig(control);
+    if (crossContextDocumentConfig.from !== 'en' || crossContextDocumentConfig.videoTranslationEnabled !== true) {
+      throw new Error(`文档页旧快照覆盖了字幕开关：${JSON.stringify(crossContextDocumentConfig)}`);
+    }
+    await documentConfigPage.close();
     const popupFeature = await control.evaluate(() => ({
       cardPresent: Boolean(document.querySelector('[data-feature="video-subtitle"]')),
       beta: document.querySelector('[data-feature="video-subtitle"] .beta-badge')?.textContent?.trim() || '',
@@ -535,6 +604,35 @@ async function main() {
       || !menu.rect || menu.rect.width <= 0 || menu.rect.height <= 0) {
       throw new Error(`播放器菜单校验失败：${JSON.stringify(menu)}`);
     }
+
+    await page.evaluate(() => {
+      const edges = [];
+      let last = '';
+      const record = () => {
+        const playerButton = document.querySelector('#fluent-read-video-subtitle-button');
+        const menuToggle = document.querySelector('#fluent-read-video-subtitle-menu [data-action="toggle-translation"]');
+        const next = JSON.stringify({
+          button: playerButton?.getAttribute('aria-pressed') || '',
+          menu: menuToggle?.getAttribute('aria-checked') || '',
+          state: menuToggle?.querySelector('[data-state]')?.textContent || '',
+        });
+        if (next === last) return;
+        last = next;
+        edges.push(JSON.parse(next));
+      };
+      record();
+      const observer = new MutationObserver(record);
+      observer.observe(document.documentElement, {
+        subtree: true,
+        childList: true,
+        characterData: true,
+        attributes: true,
+        attributeFilter: ['aria-pressed', 'aria-checked'],
+      });
+      window.__fluentReadVideoToggleEdges = edges;
+      window.__fluentReadVideoToggleObserver = observer;
+    });
+    const beforeDisableConfig = await readExtensionConfig(control);
     await page.locator('#fluent-read-video-subtitle-menu [data-action="toggle-translation"]').press('Enter');
     await page.waitForFunction(() => {
       const action = document.querySelector('#fluent-read-video-subtitle-menu [data-action="toggle-translation"]');
@@ -556,9 +654,33 @@ async function main() {
       || disabledMenu.minHeight !== '42px' || disabledMenu.border === 'rgba(0, 0, 0, 0)') {
       throw new Error(`关闭状态的字幕翻译入口不够醒目：${JSON.stringify(disabledMenu)}`);
     }
+    const disabledStabilitySamples = await sampleStableVideoToggleState(page, control, false);
+    const afterDisableConfig = await readExtensionConfig(control);
+    if (afterDisableConfig.__fluentConfigRevision !== beforeDisableConfig.__fluentConfigRevision + 1
+      || comparableConfigWithoutVideoToggle(afterDisableConfig) !== comparableConfigWithoutVideoToggle(beforeDisableConfig)) {
+      throw new Error(`关闭字幕翻译产生了额外配置差异：${JSON.stringify({beforeDisableConfig, afterDisableConfig})}`);
+    }
     await page.locator('#fluent-read-video-subtitle-menu').screenshot({ path: path.join(artifactsDir, 'video-subtitle-fixture-menu-disabled.png') });
     await page.locator('#fluent-read-video-subtitle-menu [data-action="toggle-translation"]').press('Enter');
     await page.waitForFunction(() => document.querySelector('#fluent-read-video-subtitle-menu [data-action="toggle-translation"] [data-state]')?.textContent === '已开启', null, { timeout: 10000 });
+    const enabledStabilitySamples = await sampleStableVideoToggleState(page, control, true);
+    const afterEnableConfig = await readExtensionConfig(control);
+    if (afterEnableConfig.__fluentConfigRevision !== afterDisableConfig.__fluentConfigRevision + 1
+      || comparableConfigWithoutVideoToggle(afterEnableConfig) !== comparableConfigWithoutVideoToggle(afterDisableConfig)) {
+      throw new Error(`开启字幕翻译产生了额外配置差异：${JSON.stringify({afterDisableConfig, afterEnableConfig})}`);
+    }
+    const videoToggleEdges = await page.evaluate(() => {
+      window.__fluentReadVideoToggleObserver?.disconnect();
+      return window.__fluentReadVideoToggleEdges || [];
+    });
+    const expectedVideoToggleEdges = [
+      {button: 'true', menu: 'true', state: '已开启'},
+      {button: 'false', menu: 'false', state: '立即开启'},
+      {button: 'true', menu: 'true', state: '已开启'},
+    ];
+    if (JSON.stringify(videoToggleEdges) !== JSON.stringify(expectedVideoToggleEdges)) {
+      throw new Error(`字幕翻译开关出现了多余状态边沿：${JSON.stringify(videoToggleEdges)}`);
+    }
     await page.locator('#fluent-read-video-subtitle-menu').screenshot({ path: path.join(artifactsDir, 'video-subtitle-fixture-menu.png') });
 
     const downloadSources = ['Download translated subtitle.', 'Offline viewing stays in sync.'];
@@ -1136,6 +1258,18 @@ async function main() {
       popupVideoServiceOptions,
       popupVideoFontSizeOptions,
       popupVideoFontSizePersisted,
+      crossContextDocumentConfig: {
+        from: crossContextDocumentConfig.from,
+        videoTranslationEnabled: crossContextDocumentConfig.videoTranslationEnabled,
+        revision: crossContextDocumentConfig.__fluentConfigRevision,
+      },
+      videoToggleStability: {
+        edges: videoToggleEdges,
+        disabledRevision: disabledStabilitySamples[0]?.revision,
+        enabledRevision: enabledStabilitySamples[0]?.revision,
+        disabledSamples: disabledStabilitySamples.length,
+        enabledSamples: enabledStabilitySamples.length,
+      },
       beforeRedraw,
       nativeCaptionPlacement,
       duringRedraw,

--- a/src/app/background/configMessageHandlers.ts
+++ b/src/app/background/configMessageHandlers.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/app/background/configMessageHandlers.ts
  * 文件职责：集中组装后台配置消息处理器，使保存、翻译计数、历史恢复和自动备份恢复共享同一条修改队列。
- * 主要内容：连接配置 store 与四类 handler，注入当前修订号、扩展 URL 校验和 mutation coordinator，并输出供 message runtime 注册的处理器集合。
+ * 主要内容：连接配置 store 与四类 handler，注入整份替换/字段 patch 规则、当前修订号、扩展 URL 校验和 mutation coordinator，并输出供 message runtime 注册的处理器集合。
  * 模块边界：本文件属于后台 composition root，只负责依赖接线；消息参数校验位于 handlers，配置归一化、持久化和恢复规则位于 services/config。
  */
 import {
@@ -11,6 +11,7 @@ import {
     configReady,
     getConfigRevision,
     incrementConfigCount,
+    prepareConfigPatchRequest,
     prepareConfigSaveRequest,
     saveConfig,
 } from '@/src/services/config/store';
@@ -51,6 +52,7 @@ export function createConfigBackgroundHandlers<TContext extends ConfigPersistenc
         createConfigPersistenceHandler({
             ready: configReady,
             getCurrentConfig: () => config,
+            prepareConfigPatchRequest,
             prepareConfigSaveRequest,
             saveConfig,
             getCurrentRevision: getConfigRevision,

--- a/src/app/background/handlers/configPersistence.ts
+++ b/src/app/background/handlers/configPersistence.ts
@@ -1,16 +1,19 @@
 /**
  * @file src/app/background/handlers/configPersistence.ts
- * 文件职责：在后台可信边界接收配置保存请求，规范化客户端身份与序号，并协调配置快照的串行持久化和响应。
- * 主要内容：声明 persistConfig 协议及依赖，校验普通对象、clientId 与非负 sequence，屏蔽同客户端过期序号，共享同序号在途结果并允许失败后重试，最后返回实际提交 revision。
+ * 文件职责：在后台可信边界接收整份配置替换或字段补丁，规范化客户端身份与序号，并协调串行持久化和响应。
+ * 主要内容：声明 persistConfig replace/patch 协议及依赖，校验普通对象、mode、clientId 与非负 sequence，屏蔽同客户端过期序号，共享同序号在途结果并允许失败后重试，最后返回实际提交 revision。
  * 模块边界：这里只处理跨上下文消息和保存编排，不定义 Config 字段、不直接操作 browser.storage，也不负责历史裁剪；校验、凭据拆分和存储事务由注入的配置服务承担。
  */
 import type {BackgroundMessageHandler} from '../messageRouter';
 
 export const CONFIG_PERSIST_MESSAGE_TYPE = 'persistConfig' as const;
+export type ConfigPersistenceMode = 'replace' | 'patch';
 
 export interface ConfigPersistenceMessage {
     type: typeof CONFIG_PERSIST_MESSAGE_TYPE;
+    mode?: unknown;
     config?: unknown;
+    expected?: unknown;
     clientId?: unknown;
     sequence?: unknown;
     baseRevision?: unknown;
@@ -56,6 +59,12 @@ export interface ConfigPersistenceDependencies<TConfig> {
         currentConfig: TConfig,
         allowCredentialUpdates: boolean,
     ) => TConfig;
+    readonly prepareConfigPatchRequest: (
+        incomingPatch: Record<string, unknown>,
+        expectedPatch: Record<string, unknown>,
+        currentConfig: TConfig,
+        allowCredentialUpdates: boolean,
+    ) => TConfig;
     readonly saveConfig: (config: TConfig, options: {recordHistory: true}) => Promise<void>;
     readonly isExtensionUrl: (url: string) => boolean;
     readonly getCurrentRevision?: () => number;
@@ -63,7 +72,9 @@ export interface ConfigPersistenceDependencies<TConfig> {
 }
 
 interface ParsedConfigPersistenceRequest {
+    mode: ConfigPersistenceMode;
     config: Record<string, unknown>;
+    expected?: Record<string, unknown>;
     clientId: string;
     sequence: number;
     baseRevision?: number;
@@ -99,6 +110,18 @@ function parseBaseRevision(value: unknown): number | undefined {
     throw new TypeError('配置保存 baseRevision 必须是非负安全整数');
 }
 
+function parsePersistenceMode(value: unknown): ConfigPersistenceMode {
+    if (value === undefined || value === 'replace') return 'replace';
+    if (value === 'patch') return 'patch';
+    throw new TypeError('配置保存 mode 必须是 replace 或 patch');
+}
+
+function parseExpectedPatch(value: unknown, mode: ConfigPersistenceMode): Record<string, unknown> | undefined {
+    if (mode === 'replace') return undefined;
+    if (!isPlainRecord(value)) throw new TypeError('配置 patch 缺少有效 expected');
+    return value;
+}
+
 function parseConfigPersistenceMessage(
     message: ConfigPersistenceMessage,
     context: ConfigPersistenceContext,
@@ -112,8 +135,11 @@ function parseConfigPersistenceMessage(
 
     // 步骤 2：只有扩展自身页面可以更新凭据；content/page 消息只能保存公开字段。
     const senderUrl = typeof context.sender?.url === 'string' ? context.sender.url : '';
+    const mode = parsePersistenceMode(message.mode);
     return {
+        mode,
         config: message.config,
+        expected: parseExpectedPatch(message.expected, mode),
         clientId,
         sequence,
         baseRevision: parseBaseRevision(message.baseRevision),
@@ -165,18 +191,27 @@ export function createConfigPersistenceHandler<TConfig>(
                     await dependencies.ready;
 
                     const currentRevision = dependencies.getCurrentRevision?.();
-                    if (request.baseRevision !== undefined
+                    if (request.mode === 'replace'
+                        && request.baseRevision !== undefined
                         && currentRevision !== undefined
                         && request.baseRevision !== currentRevision) {
                         throw new Error(`配置已更新（当前 revision ${currentRevision}），请同步后重试`);
                     }
 
                     // 步骤 2：使用注入的 prepare/save 保持凭据策略、规范化和历史记录行为。
-                    const prepared = dependencies.prepareConfigSaveRequest(
-                        request.config,
-                        dependencies.getCurrentConfig(),
-                        request.allowCredentialUpdates,
-                    );
+                    const currentConfig = dependencies.getCurrentConfig();
+                    const prepared = request.mode === 'patch'
+                        ? dependencies.prepareConfigPatchRequest(
+                            request.config,
+                            request.expected!,
+                            currentConfig,
+                            request.allowCredentialUpdates,
+                        )
+                        : dependencies.prepareConfigSaveRequest(
+                            request.config,
+                            currentConfig,
+                            request.allowCredentialUpdates,
+                        );
                     await dependencies.saveConfig(prepared, {recordHistory: true});
                     if (request.sequence) {
                         committedSequenceByClient.set(request.clientId, Math.max(

--- a/src/app/document-translation/DocumentApp.vue
+++ b/src/app/document-translation/DocumentApp.vue
@@ -1,8 +1,8 @@
 <!--
  @file src/app/document-translation/DocumentApp.vue
  文件职责：实现独立文档翻译页面的完整 Vue 应用，承载文件导入、格式化预览、分段翻译、人工校订和双语文件导出的用户流程。
- 主要内容：支持 PDF、EPUB、DOCX、HTML、TXT、Markdown、字幕与 JSON 等格式，管理拖放/选择、服务与模型配置、翻译进度、PDF 位图预览、章节或部件导航、译文编辑和下载状态。
- 模块边界：组件负责页面交互与响应式状态，不自行解析二进制格式、不实现翻译队列或导出编码；解析渲染来自 document-translation feature，运行时适配由本目录 runtime 注入。
+ 主要内容：支持 PDF、EPUB、DOCX、HTML、TXT、Markdown、字幕与 JSON 等格式，管理拖放/选择、配置实时同步与字段级保存、翻译进度、PDF 位图预览、章节或部件导航、译文编辑和下载状态。
+ 模块边界：组件负责页面交互与响应式状态，不自行解析二进制格式、不实现翻译队列、配置存储协议或导出编码；解析渲染来自 document-translation feature，配置协调来自 services/config，运行时适配由本目录 runtime 注入。
 -->
 <!-- 文档页面归 app 层所有；WXT 入口只负责启动。 -->
 <template>
@@ -425,10 +425,11 @@ import {
   options,
   parseDocument,
   parseDocumentFile,
-  requestConfigSave,
+  requestConfigPatch,
   resolveConfiguredModel,
   runtimeConfig,
   servicesType,
+  subscribeConfig,
   translateDocumentSegments,
   type DocumentRenderMode,
   type ParsedDocument,
@@ -443,6 +444,31 @@ interface PdfPreviewPageState {
   originalUrl: string;
   translatedUrl: string;
   loading: boolean;
+}
+
+type DocumentConfigPatch = Partial<Pick<Config,
+  'from' | 'to' | 'documentService' | 'documentModel' | 'documentCustomModel'
+>>;
+type DocumentModelMapping = Config['documentModel'];
+
+function sameDocumentModelMapping(left: DocumentModelMapping, right: DocumentModelMapping): boolean {
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  return [...keys].every((key) => left[key] === right[key]);
+}
+
+function mergeChangedDocumentModelMapping(
+  latest: DocumentModelMapping,
+  previous: DocumentModelMapping,
+  next: DocumentModelMapping,
+): DocumentModelMapping {
+  const merged = {...latest};
+  const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
+  keys.forEach((key) => {
+    if (previous[key] === next[key]) return;
+    if (Object.prototype.hasOwnProperty.call(next, key)) merged[key] = next[key];
+    else delete merged[key];
+  });
+  return merged;
 }
 
 const config = reactive(new Config());
@@ -468,6 +494,8 @@ let abortController: AbortController | null = null;
 const documentFileLoads = createDocumentFileLoadGuard();
 let translationRequestId = 0;
 let lastSerialized = '';
+let applyingExternalConfig = false;
+let unsubscribeConfig: (() => void) | undefined;
 let noticeTimer: ReturnType<typeof setTimeout> | undefined;
 let pdfPreviewTimer: ReturnType<typeof setTimeout> | undefined;
 let pdfPreviewRequest = 0;
@@ -701,12 +729,44 @@ async function hydrateConfig(): Promise<void> {
 }
 void hydrateConfig();
 
-watch(config, (value) => {
-  if (!hydrated.value) return;
-  const serialized = JSON.stringify(value);
+unsubscribeConfig = subscribeConfig((nextConfig) => {
+  const serialized = JSON.stringify(nextConfig);
   if (serialized === lastSerialized) return;
   lastSerialized = serialized;
-  void requestConfigSave(value, browser.runtime.sendMessage.bind(browser.runtime)).catch((error) => {
+  applyingExternalConfig = true;
+  try {
+    Object.assign(config, nextConfig);
+  } finally {
+    applyingExternalConfig = false;
+  }
+});
+
+watch(config, (value) => {
+  if (!hydrated.value || applyingExternalConfig) return;
+  const serialized = JSON.stringify(value);
+  if (serialized === lastSerialized) return;
+  const previous = JSON.parse(lastSerialized) as Config;
+  lastSerialized = serialized;
+  const patch: DocumentConfigPatch = {};
+  if (value.from !== previous.from) patch.from = value.from;
+  if (value.to !== previous.to) patch.to = value.to;
+  if (value.documentService !== previous.documentService) patch.documentService = value.documentService;
+  if (!sameDocumentModelMapping(value.documentModel, previous.documentModel)) {
+    patch.documentModel = mergeChangedDocumentModelMapping(
+      runtimeConfig.documentModel,
+      previous.documentModel,
+      value.documentModel,
+    );
+  }
+  if (!sameDocumentModelMapping(value.documentCustomModel, previous.documentCustomModel)) {
+    patch.documentCustomModel = mergeChangedDocumentModelMapping(
+      runtimeConfig.documentCustomModel,
+      previous.documentCustomModel,
+      value.documentCustomModel,
+    );
+  }
+  if (Object.keys(patch).length === 0) return;
+  void requestConfigPatch(patch, browser.runtime.sendMessage.bind(browser.runtime)).catch((error) => {
     console.warn('[FluentRead] 保存文档翻译设置失败', error);
   });
 }, {deep: true, flush: 'sync'});
@@ -884,6 +944,7 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+  unsubscribeConfig?.();
   documentFileLoads.invalidate();
   translationRequestId += 1;
   abortController?.abort();

--- a/src/app/document-translation/index.ts
+++ b/src/app/document-translation/index.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/app/document-translation/index.ts
  * 文件职责：汇总文档翻译页面所需的公开业务、配置和运行时能力，形成 DocumentApp 唯一的 app 层依赖入口。
- * 主要内容：转发文档解析/格式/预览 API、Config 与凭据校验、服务模型目录、配置读取保存、分段翻译、下载生成以及平台能力过滤与不可用提示。
+ * 主要内容：转发文档解析/格式/预览 API、Config 与凭据校验、服务模型目录、配置读取、字段级保存与实时订阅、分段翻译、下载生成以及平台能力过滤与不可用提示。
  * 模块边界：该文件只整理稳定公开面，不执行页面挂载、不持有配置副本，也不暴露 document feature 内部实现；实际适配在 runtime，UI 状态在 DocumentApp。
  */
 export * from '@/src/features/document-translation/public';
@@ -17,7 +17,8 @@ export {
 export {
     config as runtimeConfig,
     configReady,
-    requestConfigSave,
+    requestConfigPatch,
+    subscribeConfig,
 } from '@/src/services/config/store';
 export {createDocumentDownload, translateDocumentSegments} from './runtime';
 export {

--- a/src/app/popup/PopupApp.vue
+++ b/src/app/popup/PopupApp.vue
@@ -555,6 +555,7 @@ import browser from 'webextension-polyfill';
 import {
   config as runtimeConfig,
   configReady,
+  requestConfigPatch,
   requestConfigSave,
   subscribeConfig,
 } from '@/src/services/config/store';
@@ -618,7 +619,9 @@ const drawerSettingsSection: Record<DrawerName, SettingsSection> = {
   image: 'settings-image-translation',
   video: 'settings-video',
 };
-const persistConfig = (value: unknown) => requestConfigSave(value, browser.runtime.sendMessage.bind(browser.runtime));
+const sendConfigMessage = browser.runtime.sendMessage.bind(browser.runtime);
+const persistConfigPatch = (value: unknown) => requestConfigPatch(value, sendConfigMessage);
+const persistConfigReplace = (value: unknown) => requestConfigSave(value, sendConfigMessage);
 
 const allServiceOptions = computed(() => options.services.filter((item: any) => !item.disabled));
 const serviceOptions = computed(() => filterAvailableTranslationServices(allServiceOptions.value));
@@ -759,7 +762,7 @@ watch(() => JSON.stringify(config.value), async serialized => {
   lastSerialized = serialized;
   const snapshot = normalizeConfig(config.value);
   try {
-    await persistConfig(snapshot);
+    await persistConfigPatch(snapshot);
   } catch (error) {
     // 保存失败后允许下一次交互重试，不能让去重标记永久吞掉同一快照。
     if (lastSerialized === serialized) lastSerialized = '';
@@ -833,11 +836,13 @@ function saveOnPageHide() {
 }
 window.addEventListener('pagehide', saveOnPageHide);
 
-// Firefox 可能同时触发 pagehide 和 unmounted；只提交一次最新快照。
+// Firefox 可能同时触发 pagehide 和 unmounted；只补交一次最终快照。
+// 这是一层 best-effort 兜底而非持久化 barrier；revision 边界会拒绝过期 replace，
+// 普通交互则始终使用字段 patch。
 function persistOnPageExit() {
   if (!hydrated.value || pageExitSaveStarted) return;
   pageExitSaveStarted = true;
-  void persistConfig(config.value).catch((error) => console.warn('[FluentRead] popup 关闭前后台保存设置失败', error));
+  void persistConfigReplace(config.value).catch((error) => console.warn('[FluentRead] popup 关闭前后台保存设置失败', error));
 }
 
 function showNotice(message: string, type: 'success' | 'error' = 'success') {

--- a/src/features/floating-ball/content/runtime.ts
+++ b/src/features/floating-ball/content/runtime.ts
@@ -1,11 +1,11 @@
 /**
  * @file src/features/floating-ball/content/runtime.ts
  * 文件职责：协调悬浮球组件在网页中的创建、恢复位置、显隐、权威翻译状态同步和卸载，并向组件注入全文翻译切换与打开设置页的动作。
- * 主要内容：维护单例 Shadow UI、迟到挂载 requestId、全文会话订阅与 position-change 消息，提供 mountFloatingBall、toggleFloatingBallTranslation、unmountFloatingBall 三个生命周期入口。
+ * 主要内容：维护单例 Shadow UI、迟到挂载 requestId、全文会话订阅与 position-change 字段补丁，提供 mountFloatingBall、toggleFloatingBallTranslation、unmountFloatingBall 三个生命周期入口。
  * 模块边界：运行时只拥有挂载和桥接职责，不实现拖拽视觉或全文翻译算法；FloatingBall.vue 负责交互，full-page feature 提供翻译动作，配置持久化通过 services/config 完成。
  */
 import FloatingBall from '@/src/features/floating-ball/ui/FloatingBall.vue';
-import {config, requestConfigSave} from '@/src/services/config/store';
+import {config, requestConfigPatch} from '@/src/services/config/store';
 import browser from 'webextension-polyfill';
 import {
   autoTranslateEnglishPage,
@@ -61,12 +61,9 @@ export function mountFloatingBall(ctx?: ContentScriptContext) {
       },
       // 添加位置变化事件监听
       onPositionChanged: (newPosition: 'left' | 'right') => {
-        // 保存位置到配置
-        config.floatingBallPosition = newPosition;
-
-        // 保存配置到存储
-        void requestConfigSave(
-          config,
+        // 只提交位置字段；配置服务会立即乐观同步，并在后台基于最新快照合并。
+        void requestConfigPatch(
+          {floatingBallPosition: newPosition},
           browser.runtime.sendMessage.bind(browser.runtime),
         ).catch((error: unknown) => console.error('Failed to save config:', error));
       },

--- a/src/features/settings/ui/SettingsSections.vue
+++ b/src/features/settings/ui/SettingsSections.vue
@@ -610,6 +610,7 @@ import ConfigManagement from './ConfigManagement.vue';
 import {
   config as runtimeConfig,
   configReady,
+  requestConfigPatch,
   requestConfigSave,
   subscribeConfig,
 } from '@/src/services/config/store';
@@ -638,7 +639,9 @@ function updateTheme(theme: string) {
 }
 // 配置信息
 const config = ref(new Config());
-const persistConfig = (value: unknown) => requestConfigSave(value, browser.runtime.sendMessage.bind(browser.runtime));
+const sendConfigMessage = browser.runtime.sendMessage.bind(browser.runtime);
+const persistConfigPatch = (value: unknown) => requestConfigPatch(value, sendConfigMessage);
+const persistConfigReplace = (value: unknown) => requestConfigSave(value, sendConfigMessage);
 let lastSerialized = '';
 let hydrated = false;
 let applyingExternalConfig = false;
@@ -668,19 +671,20 @@ watch(() => JSON.stringify(config.value), (serialized) => {
   if (serialized === lastSerialized) return;
   lastSerialized = serialized;
   const snapshot = normalizeConfig(config.value);
-  void persistConfig(snapshot).catch((error) => {
+  void persistConfigPatch(snapshot).catch((error) => {
     // 失败时释放去重标记，下一次修改或 pagehide 仍能提交最新快照。
     if (lastSerialized === serialized) lastSerialized = '';
     console.warn('[FluentRead] 保存设置失败', error);
   });
 }, { flush: 'sync' });
 
-// 设置页关闭前提交最新快照，避免 Firefox 销毁页面时丢失最后一次修改。
+// 设置页关闭前 best-effort 补交最终快照；页面仍可能在消息真正发送前销毁。
 // pagehide 和 unmounted 可能连续触发，只提交一次，避免重复写入和重复历史。
+// revision 边界会拒绝过期 replace，普通交互则始终使用字段 patch。
 function persistOnPageExit() {
   if (!hydrated || pageExitSaveStarted) return;
   pageExitSaveStarted = true;
-  void persistConfig(config.value).catch((error) => console.warn('[FluentRead] 设置页关闭前后台保存失败', error));
+  void persistConfigReplace(config.value).catch((error) => console.warn('[FluentRead] 设置页关闭前后台保存失败', error));
 }
 
 onUnmounted(() => {

--- a/src/features/settings/ui/services/ServiceConfiguration.vue
+++ b/src/features/settings/ui/services/ServiceConfiguration.vue
@@ -262,7 +262,7 @@ import type { Config } from '@/src/core/config/model'
 import { defaultOption, options as optionConfig } from '@/src/core/config/catalog'
 import { isValidCustomBody } from '@/src/core/config/customBody'
 import browser from 'webextension-polyfill'
-import { requestConfigSave } from '@/src/services/config/store'
+import { requestConfigSave, waitForConfigPersistenceQueue } from '@/src/services/config/store'
 import { CONNECTION_TEST_MESSAGE, getMimoEndpoint, MINIMAX_ENDPOINTS } from '@/src/core/config/constants'
 import { ElMessage, ElMessageBox } from 'element-plus'
 
@@ -350,6 +350,7 @@ async function testConnection(): Promise<void> {
   connectionTestMessage.value = '正在保存当前配置并请求服务…'
 
   try {
+    await waitForConfigPersistenceQueue()
     await requestConfigSave(config.value, browser.runtime.sendMessage.bind(browser.runtime))
     const response = await browser.runtime.sendMessage({
       type: CONNECTION_TEST_MESSAGE,

--- a/src/features/translation-center/ui/TranslationCenter.vue
+++ b/src/features/translation-center/ui/TranslationCenter.vue
@@ -1,7 +1,7 @@
 <!--
  * @file src/features/translation-center/ui/TranslationCenter.vue
  * 文件职责：实现多翻译服务并排对比工作台，允许输入文本、选择和交换语言、增删服务、拖动排序、并发翻译、单项重试及复制结果。
- * 主要内容：组件持久化语言和服务顺序，按浏览器能力隐藏不可用项，维护每张卡片的 idle/loading/success/error 状态，支持搜索服务、指针与键盘排序、复制全部和最大长度约束。
+ * 主要内容：组件用字段级补丁持久化语言和服务顺序，按浏览器能力隐藏不可用项，维护每张卡片的 idle/loading/success/error 状态，支持搜索服务、指针与键盘排序、复制全部和最大长度约束。
  * 模块边界：该 UI 不实现 provider 协议或凭据存储；翻译统一调用 app/translation client，服务目录来自 core/config，Options 外层负责组件挂载且原配置在能力不足时保持不变。
  -->
 <template>
@@ -10,7 +10,7 @@
     <div class="translation-center-toolbar">
       <div class="language-picker-group">
         <label for="translation-center-source">源语言</label>
-        <select id="translation-center-source" v-model="sourceLanguage" aria-label="翻译中心源语言" @change="persistTranslationCenterConfig">
+        <select id="translation-center-source" v-model="sourceLanguage" aria-label="翻译中心源语言" @change="persistTranslationCenterConfig('source')">
           <option v-for="item in sourceLanguageOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
         </select>
       </div>
@@ -28,7 +28,7 @@
 
       <div class="language-picker-group">
         <label for="translation-center-target">目标语言</label>
-        <select id="translation-center-target" v-model="targetLanguage" aria-label="翻译中心目标语言" @change="persistTranslationCenterConfig">
+        <select id="translation-center-target" v-model="targetLanguage" aria-label="翻译中心目标语言" @change="persistTranslationCenterConfig('target')">
           <option v-for="item in targetLanguageOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
         </select>
       </div>
@@ -226,7 +226,7 @@ import {
   isTranslationServiceAvailable,
 } from '@/src/services/translation/capabilities'
 import { options, servicesType } from '@/src/core/config/catalog'
-import { config, configReady, requestConfigSave, subscribeConfig } from '@/src/services/config/store'
+import { config, configReady, requestConfigPatch, subscribeConfig } from '@/src/services/config/store'
 import { translateText } from '@/src/app/translation/client'
 
 type TranslationCardStatus = 'idle' | 'loading' | 'success' | 'error'
@@ -245,6 +245,13 @@ type ServiceOption = {
   label: string
   description?: string
   disabled?: boolean
+}
+
+type TranslationCenterConfigField = 'services' | 'source' | 'target'
+type TranslationCenterConfigPatch = {
+  translationCenterServices?: string[]
+  translationCenterSourceLanguage?: string
+  translationCenterTargetLanguage?: string
 }
 
 const DEFAULT_COMPARISON_SERVICES = ['freeTranslation', 'google', 'openai', 'deepseek', 'gemini', 'deeplx']
@@ -344,18 +351,32 @@ function hasSameOrder(left: string[], right: string[]): boolean {
   return left.length === right.length && left.every((service, index) => service === right[index])
 }
 
-function persistTranslationCenterConfig(): void {
+function persistTranslationCenterConfig(...fields: TranslationCenterConfigField[]): void {
   if (!configHydrated) return
-  const available = [...getCurrentServiceOrder()]
-  const stored = Array.isArray(config.translationCenterServices) ? config.translationCenterServices : []
-  config.translationCenterServices = stored.flatMap(service => {
-    if (!isTranslationServiceAvailable(service)) return [service]
-    const replacement = available.shift()
-    return replacement ? [replacement] : []
-  }).concat(available)
-  config.translationCenterSourceLanguage = sourceLanguage.value
-  config.translationCenterTargetLanguage = targetLanguage.value
-  void requestConfigSave(config, browser.runtime.sendMessage.bind(browser.runtime)).catch(error => {
+  const requestedFields = new Set(fields)
+  const patch: TranslationCenterConfigPatch = {}
+  if (requestedFields.has('services')) {
+    const available = [...getCurrentServiceOrder()]
+    const stored = Array.isArray(config.translationCenterServices) ? config.translationCenterServices : []
+    const translationCenterServices = stored.flatMap(service => {
+      if (!isTranslationServiceAvailable(service)) return [service]
+      const replacement = available.shift()
+      return replacement ? [replacement] : []
+    }).concat(available)
+    if (!hasSameOrder(translationCenterServices, stored)) {
+      patch.translationCenterServices = translationCenterServices
+    }
+  }
+  if (requestedFields.has('source')
+    && sourceLanguage.value !== config.translationCenterSourceLanguage) {
+    patch.translationCenterSourceLanguage = sourceLanguage.value
+  }
+  if (requestedFields.has('target')
+    && targetLanguage.value !== config.translationCenterTargetLanguage) {
+    patch.translationCenterTargetLanguage = targetLanguage.value
+  }
+  if (Object.keys(patch).length === 0) return
+  void requestConfigPatch(patch, browser.runtime.sendMessage.bind(browser.runtime)).catch(error => {
     console.warn('[FluentRead] 翻译中心配置保存失败', error)
   })
 }
@@ -375,7 +396,7 @@ function hydrateTranslationCenterConfig(nextConfig = config): void {
 function addService(service: string): void {
   if (selectedServiceValues.value.has(service)) return
   cards.value.push(createCard(service))
-  persistTranslationCenterConfig()
+  persistTranslationCenterConfig('services')
   serviceSearchQuery.value = ''
   servicePickerOpen.value = false
 }
@@ -383,7 +404,7 @@ function addService(service: string): void {
 function removeService(service: string): void {
   if (cards.value.length <= 1) return
   cards.value = cards.value.filter(card => card.service !== service)
-  persistTranslationCenterConfig()
+  persistTranslationCenterConfig('services')
 }
 
 function swapLanguages(): void {
@@ -391,7 +412,7 @@ function swapLanguages(): void {
   const nextSource = sourceLanguage.value
   sourceLanguage.value = targetLanguage.value
   targetLanguage.value = nextSource
-  persistTranslationCenterConfig()
+  persistTranslationCenterConfig('source', 'target')
 }
 
 function reorderCards(fromService: string, targetService: string): void {
@@ -403,7 +424,7 @@ function reorderCards(fromService: string, targetService: string): void {
   const [movedCard] = nextCards.splice(fromIndex, 1)
   nextCards.splice(targetIndex, 0, movedCard)
   cards.value = nextCards
-  persistTranslationCenterConfig()
+  persistTranslationCenterConfig('services')
 }
 
 function startPointerDrag(service: string, event: PointerEvent): void {
@@ -439,7 +460,7 @@ function moveCard(service: string, offset: number): void {
   const [movedCard] = nextCards.splice(fromIndex, 1)
   nextCards.splice(targetIndex, 0, movedCard)
   cards.value = nextCards
-  persistTranslationCenterConfig()
+  persistTranslationCenterConfig('services')
 }
 
 function endCardDrag(): void {

--- a/src/features/video-subtitle/content/runtime.ts
+++ b/src/features/video-subtitle/content/runtime.ts
@@ -5,7 +5,7 @@
  * 模块边界：本文件只在 content 页面编排，不拦截 fetch/XHR 也不实现翻译 provider；MAIN-world bridge 在独立模块捕获 timedtext，解析算法在 youtubeSubtitleData，翻译经 app client。
  */
 import browser from 'webextension-polyfill';
-import { config, requestConfigSave, subscribeConfig } from '@/src/services/config/store';
+import { config, requestConfigPatch, subscribeConfig } from '@/src/services/config/store';
 import { options, servicesType } from '@/src/core/config/catalog';
 import {
   normalizeVideoSubtitleFontSize,
@@ -1289,9 +1289,10 @@ export function mountVideoSubtitleTranslation(): () => void {
   };
 
   const persistVideoConfig = (patch: VideoConfigPatch) => {
-    const nextConfig = { ...config, ...patch };
-    void requestConfigSave(
-      nextConfig,
+    // requestConfigPatch 会在返回 Promise 前乐观更新共享 config；连续点击会读取
+    // 用户刚看到的状态，同时后台只在最新权威配置上合并这几个视频字段。
+    void requestConfigPatch(
+      patch,
       browser.runtime.sendMessage.bind(browser.runtime),
     ).catch((error) => {
       console.warn('[FluentRead] 视频字幕设置保存失败', error);
@@ -1500,7 +1501,7 @@ export function mountVideoSubtitleTranslation(): () => void {
     );
     menu.appendChild(title);
 
-    menu.appendChild(createMenuItem('toggle-translation', '开启字幕翻译'));
+    menu.appendChild(createMenuItem('toggle-translation', '字幕翻译'));
     const serviceCaption = createTextElement('span', 'fluent-read-video-menu-caption', '翻译服务');
     const serviceValue = createTextElement('span', 'fluent-read-video-menu-value', '');
     serviceValue.dataset.serviceLabel = 'true';

--- a/src/features/vocabulary/ui/VocabularyBook.vue
+++ b/src/features/vocabulary/ui/VocabularyBook.vue
@@ -1,7 +1,7 @@
 <!--
  * @file src/features/vocabulary/ui/VocabularyBook.vue
  * 文件职责：实现设置页本地单词本与主动复习界面，覆盖 Beta 开关、统计、筛选分页、记忆卡、掌握/重学、删除撤销以及 JSON/Anki 迁移。
- * 主要内容：组件通过 runtime 消息读取和修改词条，使用学习模型协调稳定复习队列与页面生命周期，处理键盘评分、主题、时间刷新、隐私导出确认、大文件导入警告和跨页面变更通知。
+ * 主要内容：组件通过 runtime 消息读取和修改词条，使用字段级配置补丁保存 Beta 开关，并协调稳定复习队列、页面生命周期、键盘评分、主题、时间刷新、隐私导出确认、大文件导入警告和跨页面变更通知。
  * 模块边界：UI 不直接访问 Dexie 或上传学习数据；数据库操作集中在后台 repository/handler，配置通过 services/config 保存，导出的上下文和来源只有用户明确勾选时才包含。
  -->
 <template>
@@ -171,7 +171,7 @@ import browser from 'webextension-polyfill';
 import {
   config as runtimeConfig,
   configReady,
-  requestConfigSave,
+  requestConfigPatch,
   subscribeConfig,
 } from '@/src/services/config/store';
 import {
@@ -364,16 +364,13 @@ async function runLoadEntriesLoop(): Promise<void> {
 
 async function setBetaEnabled(enabled: boolean): Promise<void> {
   if (configBusy.value) return;
-  const previous = runtimeConfig.vocabularyBookEnabled;
   configBusy.value = true;
-  runtimeConfig.vocabularyBookEnabled = enabled;
   betaEnabled.value = enabled;
   try {
-    await requestConfigSave(runtimeConfig, browser.runtime.sendMessage.bind(browser.runtime));
+    await requestConfigPatch({vocabularyBookEnabled: enabled}, browser.runtime.sendMessage.bind(browser.runtime));
     showToast(enabled ? '单词本 Beta 已开启' : '收藏入口已关闭，学习数据仍保留');
   } catch (cause) {
-    runtimeConfig.vocabularyBookEnabled = previous;
-    betaEnabled.value = previous;
+    betaEnabled.value = runtimeConfig.vocabularyBookEnabled === true;
     showToast(cause instanceof Error ? cause.message : '设置保存失败');
   } finally {
     configBusy.value = false;

--- a/src/services/config/store.ts
+++ b/src/services/config/store.ts
@@ -2,13 +2,14 @@
  * @file src/services/config/store.ts
  *
  * 文件职责：协调 FluentRead 配置、凭据与历史记录在后台加密配置仓库中的读取、订阅、保存和并发持久化。
- * 主要内容：维护 config 响应式状态和监听器，区分公开配置与加密持久凭据，序列化 persist/history 消息，处理 debounce、revision 冲突、旧会话凭据迁移及 undo/redo 请求。 可核对的公开符号包括 CONFIG_STORAGE_KEY、CONFIG_HISTORY_STORAGE_KEY、CONFIG_PERSIST_MESSAGE、CONFIG_HISTORY_MESSAGE、config、flushConfigHistory、configReady、configHistoryReady。
+ * 主要内容：维护 config 响应式状态和监听器，区分公开配置与加密持久凭据，串行发送整份替换或字段级 patch，处理乐观更新回滚、revision 冲突、旧会话凭据迁移、历史 debounce 及 undo/redo 请求。
  * 模块边界：本文件位于配置 application service 层，可协调 core 规则与浏览器存储端口；不包含设置页面组件，也不实现具体翻译供应商协议，调用方应通过公开服务 API 订阅或提交配置。
  */
 
 import {configStorage as storage} from '@/src/platform/storage/configStorageRuntime';
 import { Config, normalizeConfig } from '@/src/core/config/model';
 import {
+    CONFIG_CREDENTIAL_FIELDS,
     LOCAL_CREDENTIALS_STORAGE_KEY,
     SESSION_CREDENTIALS_STORAGE_KEY,
     credentialsEqual,
@@ -71,10 +72,16 @@ let lastPersistedSerialized = '';
 let writeRevision = 0;
 let writeQueue: Promise<void> = Promise.resolve();
 let latestRequestedSerialized = '';
+let latestRequestedMode: ConfigPersistenceMode | null = null;
 let persistedConfigRevision = 0;
 let requestSequence = 0;
 let requestGeneration = 0;
 let requestQueue: Promise<void> = Promise.resolve();
+let lastEnqueuedRemoteRequestSequence = 0;
+let lastCommittedRemoteRequestSequence = 0;
+let lastCommittedRemoteRequestRevision = 0;
+let lastCommittedRemoteRequestGeneration = -1;
+let lastCommittedRemoteRequestMode: ConfigPersistenceMode | null = null;
 let activeRequestSerialized = '';
 let hasDeferredStoredConfigChange = false;
 let deferredStoredConfigChange: unknown;
@@ -82,6 +89,12 @@ const completedCountOperations = new Map<string, {delta: number; count: number}>
 const activeCountOperations = new Map<string, {delta: number; promise: Promise<number>}>();
 const CONFIG_COUNT_OPERATION_CACHE_LIMIT = 1_024;
 const CONFIG_COUNT_OPERATIONS_FIELD = '__fluentCountOperations' as const;
+const CONFIG_PATCH_PROTECTED_FIELDS = new Set<string>([
+    'count',
+    'videoServiceDefaultMigrated',
+]);
+const CONFIG_KNOWN_FIELDS = new Set<string>(Object.keys(new Config()));
+const CONFIG_CREDENTIAL_FIELD_SET = new Set<string>(CONFIG_CREDENTIAL_FIELDS);
 const requestClientId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 let historyState: ConfigHistoryState;
 let historyInitialized = false;
@@ -92,6 +105,8 @@ let historyWriteQueue: Promise<void> = Promise.resolve();
 let pendingHistorySnapshot: RestorableConfig | null = null;
 let pendingHistoryTimer: ReturnType<typeof setTimeout> | undefined;
 let historyFlushPromise: Promise<void> | null = null;
+
+type ConfigPersistenceMode = 'replace' | 'patch';
 
 // 所有运行时模块共享同一个可变配置对象；存储层负责把跨上下文变更同步进来。
 export const config = new Config();
@@ -430,10 +445,14 @@ function handleStoredConfigChange(value: unknown, options: StoredConfigChangeOpt
     if (storedRevision) persistedConfigRevision = storedRevision;
 
     // 一个更高 revision 且无法归属于本页面保存请求的快照，必然来自恢复、导入
-    // 或其他页面。立即采用它并取消排队的旧整份快照，不能只借用它的 revision。
-    if (revisionAdvanced && !isLocalEcho && latestRequestedSerialized) {
+    // 或其他页面。replace 请求逐个捕获该 generation，因此即使队尾后来换成
+    // patch，队列中更早的旧整份快照也会失效；patch 自身则交给字段级 CAS。
+    if (revisionAdvanced && !isLocalEcho) {
         requestGeneration += 1;
-        latestRequestedSerialized = '';
+        if (latestRequestedSerialized && latestRequestedMode === 'replace') {
+            latestRequestedSerialized = '';
+            latestRequestedMode = null;
+        }
     }
     // 同一个短生命周期页面可能在极短时间内产生多个快照。storage.watch
     // 可能先回传前一个快照，不能让它覆盖页面尚未完成发送的最新快照。
@@ -449,11 +468,15 @@ function handleStoredConfigChange(value: unknown, options: StoredConfigChangeOpt
     if (persistedCountOperations) {
         replaceCompletedCountOperations(persistedCountOperations, normalized.count);
     }
-    if (serialized === lastPersistedSerialized) return;
+    const runtimeAlreadyMatches = serialized === serializeConfig(config);
+    if (serialized === lastPersistedSerialized && runtimeAlreadyMatches) return;
 
     // 外部上下文已经产生了新快照，使尚未写入的旧快照失效。
     writeRevision += 1;
     lastPersistedSerialized = serialized;
+    // patch 在请求发出前已经乐观更新并通知订阅者。确认回声只更新持久化
+    // revision/去重基线，不能再次 apply 同值导致 UI 重绘或监听器重复执行。
+    if (runtimeAlreadyMatches) return;
     applyConfig(normalized);
 }
 
@@ -738,6 +761,71 @@ export async function requestConfigCountIncrement(
     return response.count;
 }
 
+function isConfigObject(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function configPatchValuesEqual(left: unknown, right: unknown): boolean {
+    if (Object.is(left, right)) return true;
+    if (Array.isArray(left) || Array.isArray(right)) {
+        return Array.isArray(left)
+            && Array.isArray(right)
+            && left.length === right.length
+            && left.every((item, index) => configPatchValuesEqual(item, right[index]));
+    }
+    if (!isConfigObject(left) || !isConfigObject(right)) return false;
+    const leftKeys = Object.keys(left).sort();
+    const rightKeys = Object.keys(right).sort();
+    return leftKeys.length === rightKeys.length
+        && leftKeys.every((key, index) => (
+            key === rightKeys[index]
+            && configPatchValuesEqual(left[key], right[key])
+        ));
+}
+
+function createConfigPatch(
+    value: unknown,
+    currentValue: unknown,
+    allowCredentialUpdates: boolean,
+    omitUnchanged = true,
+): Record<string, unknown> {
+    if (!isConfigObject(value)) return {};
+    const currentConfig = normalizeConfig(currentValue);
+    const requestedFields = Object.fromEntries(
+        Object.entries(value).filter(([key]) => (
+            CONFIG_KNOWN_FIELDS.has(key)
+            && !CONFIG_PATCH_PROTECTED_FIELDS.has(key)
+            && (allowCredentialUpdates || !CONFIG_CREDENTIAL_FIELD_SET.has(key))
+        )),
+    );
+    if (Object.keys(requestedFields).length === 0) return {};
+
+    const normalized = normalizeConfig({
+        ...currentConfig,
+        ...requestedFields,
+        count: currentConfig.count,
+        videoServiceDefaultMigrated: currentConfig.videoServiceDefaultMigrated,
+    });
+    return Object.fromEntries(
+        Object.keys(requestedFields)
+            .filter((key) => !omitUnchanged || !configPatchValuesEqual(
+                normalized[key as keyof Config],
+                currentConfig[key as keyof Config],
+            ))
+            .map((key) => [key, normalized[key as keyof Config]]),
+    );
+}
+
+function createConfigPatchExpectedValues(
+    patch: Record<string, unknown>,
+    currentValue: unknown,
+): Record<string, unknown> {
+    const currentConfig = normalizeConfig(currentValue);
+    return Object.fromEntries(
+        Object.keys(patch).map((key) => [key, currentConfig[key as keyof Config]]),
+    );
+}
+
 /**
  * 网页/content 发来的保存请求只能修改公开配置；凭据必须由 popup/options
  * 等扩展 origin 明确更新，避免无凭据的 content 快照清空后台持久记录。
@@ -762,6 +850,36 @@ export function prepareConfigSaveRequest(
         count: currentConfig.count,
         videoServiceDefaultMigrated: currentConfig.videoServiceDefaultMigrated,
     }, extractConfigCredentials(currentConfig)));
+}
+
+/**
+ * 字段级配置修改在后台 mutation 临界区内基于最新配置合并。补丁只接受当前
+ * Config 已知顶层字段；统计和迁移标记永远由后台保留，content 也不能修改凭据。
+ */
+export function prepareConfigPatchRequest(
+    value: unknown,
+    expectedValue: unknown,
+    currentValue: unknown = config,
+    allowCredentialUpdates = false,
+): Config {
+    const currentConfig = normalizeConfig(currentValue);
+    // 后台必须对 wire patch 中每个合法字段执行 CAS；即使别的页面已经写成
+    // 相同目标值，也不能先按“当前无变化”删掉该字段并绕过 expected 校验。
+    const patch = createConfigPatch(value, currentConfig, allowCredentialUpdates, false);
+    const expected = isConfigObject(expectedValue) ? expectedValue : {};
+    const conflicts = Object.keys(patch).filter((key) => (
+        !Object.prototype.hasOwnProperty.call(expected, key)
+        || !configPatchValuesEqual(currentConfig[key as keyof Config], expected[key])
+    ));
+    if (conflicts.length > 0) {
+        throw new Error(`配置字段已更新，请同步后重试：${conflicts.join(', ')}`);
+    }
+    return normalizeConfig({
+        ...currentConfig,
+        ...patch,
+        count: currentConfig.count,
+        videoServiceDefaultMigrated: currentConfig.videoServiceDefaultMigrated,
+    });
 }
 
 export function getConfigHistorySnapshot(): ConfigHistoryState {
@@ -810,19 +928,64 @@ export async function saveConfig(value: unknown = config, options: SaveConfigOpt
 type ConfigMessageResponse = { success?: boolean; error?: string; revision?: number } | undefined;
 type ConfigMessageSender = (message: {
     type: typeof CONFIG_PERSIST_MESSAGE;
+    mode?: ConfigPersistenceMode;
     config: Config;
+    expected?: Config;
     clientId: string;
     sequence: number;
     baseRevision: number;
 }) => Promise<ConfigMessageResponse>;
 
-export async function requestConfigSave(value: unknown = config, sendMessage?: ConfigMessageSender): Promise<void> {
-    const normalized = normalizeConfig(value);
+async function reconcileFailedConfigRequest(fallbackConfig?: Config): Promise<void> {
+    let deferred = takeDeferredStoredConfigChange();
+    let storedValue: unknown;
+    try {
+        storedValue = deferred.hasValue
+            ? deferred.value
+            : await storage.getItem<unknown>(CONFIG_STORAGE_KEY);
+        // storage.getItem 期间可能又收到更新，以最后一个 watch 快照为准。
+        deferred = takeDeferredStoredConfigChange();
+    } catch (error) {
+        if (fallbackConfig && serializeConfig(config) !== serializeConfig(fallbackConfig)) {
+            applyConfig(fallbackConfig);
+        }
+        console.warn('[FluentRead] 配置保存失败后的权威快照回读失败', error);
+        return;
+    } finally {
+        activeRequestSerialized = '';
+    }
+
+    const latestValue = deferred.hasValue ? deferred.value : storedValue;
+    if (parseStoredConfig(latestValue)) {
+        handleStoredConfigChange(latestValue);
+    } else if (fallbackConfig && serializeConfig(config) !== serializeConfig(fallbackConfig)) {
+        applyConfig(fallbackConfig);
+    }
+}
+
+interface ConfigMutationRequest {
+    mode: ConfigPersistenceMode;
+    normalized: Config;
+    messageConfig: Config | Record<string, unknown>;
+    messageExpected?: Record<string, unknown>;
+    rollbackConfig?: Config;
+}
+
+async function requestConfigMutation(
+    mutation: ConfigMutationRequest,
+    sendMessage?: ConfigMessageSender,
+): Promise<void> {
+    const {mode, normalized, messageConfig, messageExpected, rollbackConfig} = mutation;
     const serialized = serializeConfig(normalized);
+    const enqueuedBaseRevision = persistedConfigRevision;
     // 必须在第一个 await 前登记最新请求；否则即使 configReady 已 resolved，微任务
     // 让出期间到达的旧 storage 回声也会被误当外部更新并回滚本地编辑。
     latestRequestedSerialized = serialized;
+    latestRequestedMode = mode;
+    const predecessorRemoteSequence = sendMessage ? lastEnqueuedRemoteRequestSequence : 0;
     const sequence = ++requestSequence;
+    if (sendMessage) lastEnqueuedRemoteRequestSequence = sequence;
+    if (mode === 'patch' && serializeConfig(config) !== serialized) applyConfig(normalized);
 
     if (!sendMessage) {
         try {
@@ -831,8 +994,19 @@ export async function requestConfigSave(value: unknown = config, sendMessage?: C
                 throw new Error('配置安全水合未完成，暂不保存；请重新加载扩展后重试');
             }
             await saveConfig(normalized, {recordHistory: true, immediateHistory: true});
+        } catch (error) {
+            if (mode === 'patch' && latestRequestedSerialized === serialized) {
+                requestGeneration += 1;
+                latestRequestedSerialized = '';
+                latestRequestedMode = null;
+                await reconcileFailedConfigRequest(rollbackConfig);
+            }
+            throw error;
         } finally {
-            if (latestRequestedSerialized === serialized) latestRequestedSerialized = '';
+            if (latestRequestedSerialized === serialized) {
+                latestRequestedSerialized = '';
+                latestRequestedMode = null;
+            }
         }
         return;
     }
@@ -848,51 +1022,73 @@ export async function requestConfigSave(value: unknown = config, sendMessage?: C
                 throw new Error('配置安全水合未完成，暂不保存；请重新加载扩展后重试');
             }
             // 外部恢复/导入导致 revision 冲突后，不能继续发送已经排队的旧整份快照。
-            if (generation !== requestGeneration) {
+            if (mode === 'replace' && generation !== requestGeneration) {
                 throw new Error('配置已更新，请根据最新配置重新修改');
             }
 
             activeRequestSerialized = serialized;
+            // replace 必须绑定入队时看到的基线，不能在排队后借用外部页面推进的
+            // persistedConfigRevision。唯一允许继承的是同一 client 队列中已经确认
+            // 成功的 replace 直接前驱，这样连续整份快照仍可按 revision 1 -> 2 -> 3
+            // 提交，而 patch 吸收的外部字段不会成为旧 replace 的授权基线。
+            const canInheritPredecessorRevision = predecessorRemoteSequence > 0
+                && lastCommittedRemoteRequestSequence === predecessorRemoteSequence
+                && lastCommittedRemoteRequestGeneration === generation
+                // patch 的提交 revision 可能已经吸收外部字段；旧整份 replace
+                // 不能借用该 revision，否则会把这些外部字段回写成自己的旧快照。
+                && lastCommittedRemoteRequestMode === 'replace';
+            const baseRevision = canInheritPredecessorRevision
+                ? Math.max(enqueuedBaseRevision, lastCommittedRemoteRequestRevision)
+                : enqueuedBaseRevision;
             let response: ConfigMessageResponse;
             try {
                 response = await sendMessage({
                     type: CONFIG_PERSIST_MESSAGE,
-                    config: normalized,
+                    ...(mode === 'patch' ? {mode} : {}),
+                    // replace 发送完整 Config；patch 只发送已过滤的已知字段。runtime
+                    // wire schema 在后台按 mode 区分，这里的断言保持旧 sender 回调兼容。
+                    config: messageConfig as Config,
+                    ...(mode === 'patch' ? {expected: messageExpected as unknown as Config} : {}),
                     clientId: requestClientId,
                     sequence,
-                    // 在真正发送时读取版本，让同一页面的连续编辑按前一次提交后的 revision 串行。
-                    baseRevision: persistedConfigRevision,
+                    baseRevision,
                 });
             } catch (error) {
                 activeRequestSerialized = '';
-                const deferred = takeDeferredStoredConfigChange();
-                if (deferred.hasValue) handleStoredConfigChange(deferred.value);
+                if (mode === 'patch' && latestRequestedSerialized === serialized) {
+                    requestGeneration += 1;
+                    latestRequestedSerialized = '';
+                    latestRequestedMode = null;
+                    await reconcileFailedConfigRequest(rollbackConfig);
+                } else {
+                    const deferred = takeDeferredStoredConfigChange();
+                    if (deferred.hasValue) handleStoredConfigChange(deferred.value);
+                }
                 throw error;
             }
 
             if (response?.success === false) {
                 requestGeneration += 1;
-                latestRequestedSerialized = '';
-                let deferred = takeDeferredStoredConfigChange();
-                let storedValue: unknown;
-                try {
-                    storedValue = deferred.hasValue
-                        ? deferred.value
-                        : await storage.getItem<unknown>(CONFIG_STORAGE_KEY);
-                    // storage.getItem 期间可能又收到更新，以最后一个 watch 快照为准。
-                    deferred = takeDeferredStoredConfigChange();
-                } finally {
-                    activeRequestSerialized = '';
+                if (latestRequestedSerialized === serialized) {
+                    latestRequestedSerialized = '';
+                    latestRequestedMode = null;
                 }
-                handleStoredConfigChange(deferred.hasValue ? deferred.value : storedValue);
+                await reconcileFailedConfigRequest(mode === 'patch' ? rollbackConfig : undefined);
                 throw new Error(response.error || '后台保存配置失败');
             }
             if (typeof response?.revision !== 'number'
                 || !Number.isSafeInteger(response.revision)
                 || response.revision < 0) {
                 activeRequestSerialized = '';
-                const deferred = takeDeferredStoredConfigChange();
-                if (deferred.hasValue) handleStoredConfigChange(deferred.value);
+                if (mode === 'patch' && latestRequestedSerialized === serialized) {
+                    requestGeneration += 1;
+                    latestRequestedSerialized = '';
+                    latestRequestedMode = null;
+                    await reconcileFailedConfigRequest(rollbackConfig);
+                } else {
+                    const deferred = takeDeferredStoredConfigChange();
+                    if (deferred.hasValue) handleStoredConfigChange(deferred.value);
+                }
                 throw new Error('后台保存配置没有返回有效 revision');
             }
 
@@ -908,7 +1104,15 @@ export async function requestConfigSave(value: unknown = config, sendMessage?: C
                     // 后续 storage.watch 仍会补齐后台保留的 canonical 字段。
                     activeRequestSerialized = '';
                     persistedConfigRevision = Math.max(persistedConfigRevision, response.revision);
-                    if (latestRequestedSerialized === serialized) applyConfig(normalized);
+                    if (latestRequestedSerialized === serialized
+                        && serializeConfig(config) !== serialized) applyConfig(normalized);
+                    if (mode === 'replace' && generation !== requestGeneration) {
+                        throw new Error('配置已由其他页面更新，请根据最新配置重新修改');
+                    }
+                    lastCommittedRemoteRequestSequence = sequence;
+                    lastCommittedRemoteRequestRevision = response.revision;
+                    lastCommittedRemoteRequestGeneration = generation;
+                    lastCommittedRemoteRequestMode = mode;
                     return;
                 }
                 deferred = takeDeferredStoredConfigChange();
@@ -928,19 +1132,101 @@ export async function requestConfigSave(value: unknown = config, sendMessage?: C
                 });
             } else {
                 persistedConfigRevision = Math.max(persistedConfigRevision, response.revision);
-                if (latestRequestedSerialized === serialized) applyConfig(normalized);
+                if (latestRequestedSerialized === serialized) {
+                    const storedBase = parseStoredConfig(storedValue);
+                    const storedBaseConfig = storedBase
+                        ? normalizeConfig(mergeConfigCredentials(
+                            storedBase,
+                            extractConfigCredentials(config),
+                        ))
+                        : null;
+                    const optimisticResult = mode === 'patch' && storedBaseConfig
+                        ? prepareConfigPatchRequest(
+                            messageConfig,
+                            createConfigPatchExpectedValues(
+                                messageConfig as unknown as Record<string, unknown>,
+                                storedBaseConfig,
+                            ),
+                            storedBaseConfig,
+                            trustedCredentialStorageContext,
+                        )
+                        : normalized;
+                    if (serializeConfig(config) !== serializeConfig(optimisticResult)) {
+                        applyConfig(optimisticResult);
+                    }
+                }
             }
-            if (generation !== requestGeneration) {
+            if (mode === 'replace' && generation !== requestGeneration) {
                 throw new Error('配置已由其他页面更新，请根据最新配置重新修改');
             }
+            lastCommittedRemoteRequestSequence = sequence;
+            lastCommittedRemoteRequestRevision = response.revision;
+            lastCommittedRemoteRequestGeneration = generation;
+            lastCommittedRemoteRequestMode = mode;
         });
     requestQueue = request.then(() => undefined, () => undefined);
 
     try {
         await request;
+    } catch (error) {
+        if (mode === 'patch'
+            && latestRequestedSerialized === serialized
+            && serializeConfig(config) === serialized) {
+            requestGeneration += 1;
+            latestRequestedSerialized = '';
+            latestRequestedMode = null;
+            await reconcileFailedConfigRequest(rollbackConfig);
+        }
+        throw error;
     } finally {
-        if (latestRequestedSerialized === serialized) latestRequestedSerialized = '';
+        if (latestRequestedSerialized === serialized) {
+            latestRequestedSerialized = '';
+            latestRequestedMode = null;
+        }
     }
+}
+
+/**
+ * 等待当前配置消息队列排空。等待期间若又有请求接到队尾，会继续等待新的
+ * queue 引用；调用完成之后才入队的请求不属于本次 barrier。
+ */
+export async function waitForConfigPersistenceQueue(): Promise<void> {
+    let pendingQueue = requestQueue;
+    while (true) {
+        await pendingQueue;
+        if (pendingQueue === requestQueue) return;
+        pendingQueue = requestQueue;
+    }
+}
+
+export async function requestConfigSave(value: unknown = config, sendMessage?: ConfigMessageSender): Promise<void> {
+    const normalized = normalizeConfig(value);
+    return requestConfigMutation({mode: 'replace', normalized, messageConfig: normalized}, sendMessage);
+}
+
+/**
+ * 提交字段级配置补丁。调用端先乐观应用合法字段；后台在共享 mutation 队列内
+ * 基于最新配置合并，因此无关字段不会被旧整份快照覆盖。失败时回读权威存储回滚。
+ */
+export async function requestConfigPatch(value: unknown, sendMessage?: ConfigMessageSender): Promise<void> {
+    if (!initialized) await configReady;
+    const previousConfig = normalizeConfig(config);
+    const patch = createConfigPatch(value, previousConfig, trustedCredentialStorageContext);
+    if (Object.keys(patch).length === 0) return;
+    const expected = createConfigPatchExpectedValues(patch, previousConfig);
+    const normalized = prepareConfigPatchRequest(
+        patch,
+        expected,
+        previousConfig,
+        trustedCredentialStorageContext,
+    );
+    return requestConfigMutation({
+        mode: 'patch',
+        normalized,
+        messageConfig: patch,
+        messageExpected: expected,
+        rollbackConfig: previousConfig,
+    }, sendMessage);
 }
 
 export async function applyConfigHistoryAction(action: ConfigHistoryAction, version?: number): Promise<ConfigHistoryState> {

--- a/tests/backgroundConfigPersistenceHandler.test.ts
+++ b/tests/backgroundConfigPersistenceHandler.test.ts
@@ -11,6 +11,8 @@ import {createBackgroundMessageRouter} from '@/src/app/background/messageRouter'
 interface TestConfig {
     marker: string;
     allowCredentialUpdates?: boolean;
+    videoTranslationEnabled?: boolean;
+    theme?: string;
 }
 
 function createDependencies(overrides: Partial<ConfigPersistenceDependencies<TestConfig>> = {}) {
@@ -22,6 +24,11 @@ function createDependencies(overrides: Partial<ConfigPersistenceDependencies<Tes
             marker: String(incomingConfig.marker),
             allowCredentialUpdates,
         })),
+        prepareConfigPatchRequest: vi.fn((incomingPatch, _expectedPatch, currentConfig, allowCredentialUpdates) => ({
+            ...currentConfig,
+            ...incomingPatch,
+            allowCredentialUpdates,
+        })) as ConfigPersistenceDependencies<TestConfig>['prepareConfigPatchRequest'],
         saveConfig: vi.fn(async () => undefined),
         isExtensionUrl: vi.fn((url) => url.startsWith('chrome-extension://extension-id/')),
         getCurrentRevision: vi.fn(() => 4),
@@ -57,6 +64,89 @@ describe('background config persistence handler', () => {
             {marker: 'extension-save', allowCredentialUpdates: true},
             {recordHistory: true},
         );
+        expect(dependencies.prepareConfigPatchRequest).not.toHaveBeenCalled();
+    });
+
+    it('patch 忽略旧 baseRevision，并在临界区基于最新配置只合并目标字段', async () => {
+        const latestConfig: TestConfig = {
+            marker: 'latest-external-value',
+            videoTranslationEnabled: true,
+            theme: 'dark',
+        };
+        const prepareConfigPatchRequest = vi.fn((
+            incomingPatch: Record<string, unknown>,
+            _expectedPatch: Record<string, unknown>,
+            current: TestConfig,
+        ) => ({
+            ...current,
+            marker: String(incomingPatch.marker),
+        }));
+        const dependencies = createDependencies({
+            getCurrentConfig: () => latestConfig,
+            getCurrentRevision: () => 9,
+            prepareConfigPatchRequest,
+        });
+        const handler = createConfigPersistenceHandler(dependencies);
+
+        await expect(handler.handle({
+            type: CONFIG_PERSIST_MESSAGE_TYPE,
+            mode: 'patch',
+            config: {marker: 'patched-field'},
+            expected: {marker: 'latest-external-value'},
+            clientId: 'content-video',
+            sequence: 1,
+            baseRevision: 4,
+        }, {sender: {url: 'https://www.youtube.com/watch?v=test'}}))
+            .resolves.toEqual({success: true, revision: 9});
+
+        expect(prepareConfigPatchRequest).toHaveBeenCalledWith(
+            {marker: 'patched-field'},
+            {marker: 'latest-external-value'},
+            latestConfig,
+            false,
+        );
+        expect(dependencies.prepareConfigSaveRequest).not.toHaveBeenCalled();
+        expect(dependencies.saveConfig).toHaveBeenCalledWith({
+            marker: 'patched-field',
+            videoTranslationEnabled: true,
+            theme: 'dark',
+        }, {recordHistory: true});
+    });
+
+    it('patch 的目标字段在 base 后变化时拒绝迟到写入', async () => {
+        const latestConfig: TestConfig = {
+            marker: 'external-new-value',
+            videoTranslationEnabled: true,
+        };
+        const prepareConfigPatchRequest = vi.fn((
+            incomingPatch: Record<string, unknown>,
+            expectedPatch: Record<string, unknown>,
+            current: TestConfig,
+        ) => {
+            if (current.marker !== expectedPatch.marker) {
+                throw new Error('配置字段已更新，请同步后重试：marker');
+            }
+            return {...current, marker: String(incomingPatch.marker)};
+        });
+        const dependencies = createDependencies({
+            getCurrentConfig: () => latestConfig,
+            getCurrentRevision: () => 9,
+            prepareConfigPatchRequest,
+        });
+        const handler = createConfigPersistenceHandler(dependencies);
+
+        await expect(handler.handle({
+            type: CONFIG_PERSIST_MESSAGE_TYPE,
+            mode: 'patch',
+            config: {marker: 'late-local-value'},
+            expected: {marker: 'old-base-value'},
+            clientId: 'late-content',
+            sequence: 1,
+            baseRevision: 4,
+        }, {})).rejects.toThrow('marker');
+
+        expect(dependencies.saveConfig).not.toHaveBeenCalled();
+        expect(latestConfig).toEqual({marker: 'external-new-value', videoTranslationEnabled: true});
     });
 
     it('content sender 使用 legacy clientId fallback，且不能更新凭据', async () => {
@@ -299,6 +389,8 @@ describe('background config persistence handler', () => {
         [{type: CONFIG_PERSIST_MESSAGE_TYPE, config: {}, sequence: 1.5}, 'sequence'],
         [{type: CONFIG_PERSIST_MESSAGE_TYPE, config: {}, baseRevision: -1}, 'baseRevision'],
         [{type: CONFIG_PERSIST_MESSAGE_TYPE, config: {}, baseRevision: 1.5}, 'baseRevision'],
+        [{type: CONFIG_PERSIST_MESSAGE_TYPE, mode: 'merge', config: {}}, 'mode'],
+        [{type: CONFIG_PERSIST_MESSAGE_TYPE, mode: 'patch', config: {}}, 'expected'],
     ])('拒绝非法配置保存消息 %#', async (message, field) => {
         const handler = createConfigPersistenceHandler(createDependencies());
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -699,6 +699,156 @@ describe('统一配置存储', () => {
         expect(extensionPrepared.videoServiceDefaultMigrated).toBe(true);
     });
 
+    it('字段补丁只接受已知目标字段，并保留最新配置、统计、迁移状态与 content 凭据边界', async () => {
+        const configStore = await loadConfigModule(storedConfig);
+        await configStore.configReady;
+        const current = normalizeConfig({
+            ...configStore.config,
+            to: 'ja',
+            theme: 'dark',
+            videoTranslationEnabled: true,
+            videoSubtitleVisible: true,
+            count: 42,
+            token: {openai: 'background-secret'},
+            futureNonSensitiveSetting: {enabled: true},
+        });
+
+        const contentPrepared = configStore.prepareConfigPatchRequest({
+            videoSubtitleVisible: false,
+            count: 0,
+            videoServiceDefaultMigrated: false,
+            token: {openai: 'content-stale-secret'},
+            unknownFutureToggle: true,
+        }, {
+            videoSubtitleVisible: true,
+        }, current, false);
+        const extensionPrepared = configStore.prepareConfigPatchRequest({
+            token: {openai: 'new-extension-secret'},
+        }, {
+            token: {openai: 'background-secret'},
+        }, current, true);
+
+        expect(contentPrepared).toMatchObject({
+            to: 'ja',
+            theme: 'dark',
+            videoTranslationEnabled: true,
+            videoSubtitleVisible: false,
+            count: 42,
+            videoServiceDefaultMigrated: true,
+            token: {openai: 'background-secret'},
+        });
+        expect(contentPrepared).not.toHaveProperty('unknownFutureToggle');
+        expect(contentPrepared).toHaveProperty('futureNonSensitiveSetting', {enabled: true});
+        expect(extensionPrepared.token).toEqual({openai: 'new-extension-secret'});
+        expect(extensionPrepared.count).toBe(42);
+        expect(() => configStore.prepareConfigPatchRequest({
+            videoSubtitleVisible: false,
+        }, {
+            videoSubtitleVisible: false,
+        }, current, false)).toThrow('videoSubtitleVisible');
+        expect(() => configStore.prepareConfigPatchRequest({
+            videoSubtitleVisible: true,
+        }, {
+            videoSubtitleVisible: false,
+        }, current, false)).toThrow('videoSubtitleVisible');
+    });
+
+    it('字段补丁先乐观更新，后台失败后回读权威快照并自动回滚', async () => {
+        const canonical = sanitizeConfigCredentials(normalizeConfig({
+            ...storedConfig,
+            videoTranslationEnabled: false,
+        }));
+        const configStore = await loadConfigModule({...canonical, __fluentConfigRevision: 4});
+        await configStore.configReady;
+        const sendMessage = vi.fn(async (message: {
+            mode?: string;
+            config: Config;
+            expected?: Config;
+            baseRevision: number;
+        }) => {
+            expect(configStore.config.videoTranslationEnabled).toBe(true);
+            expect(message).toMatchObject({
+                mode: 'patch',
+                config: {videoTranslationEnabled: true},
+                expected: {videoTranslationEnabled: false},
+                baseRevision: 4,
+            });
+            return {success: false, error: 'patch failed'};
+        });
+
+        await expect(configStore.requestConfigPatch({
+            videoTranslationEnabled: true,
+            unknownFutureToggle: true,
+        }, sendMessage)).rejects.toThrow('patch failed');
+
+        expect(configStore.config.videoTranslationEnabled).toBe(false);
+        expect(configStore.getConfigRevision()).toBe(4);
+        expect(configStore.config).not.toHaveProperty('unknownFutureToggle');
+    });
+
+    it('字段补丁确认回声不重复 apply 或通知订阅者', async () => {
+        const canonical = sanitizeConfigCredentials(normalizeConfig({
+            ...storedConfig,
+            videoTranslationEnabled: false,
+        }));
+        const configStore = await loadConfigModule({...canonical, __fluentConfigRevision: 4});
+        await configStore.configReady;
+        const listener = vi.fn();
+        const unsubscribe = configStore.subscribeConfig(listener);
+        listener.mockClear();
+        const sendMessage = vi.fn(async () => {
+            expect(configStore.config.videoTranslationEnabled).toBe(true);
+            expect(listener).toHaveBeenCalledOnce();
+            const committed = {
+                ...canonical,
+                videoTranslationEnabled: true,
+                __fluentConfigRevision: 5,
+            };
+            storageState.set('local:config', committed);
+            storageWatchers.get('local:config')!(committed);
+            return {success: true, revision: 5};
+        });
+
+        await configStore.requestConfigPatch({videoTranslationEnabled: true}, sendMessage);
+
+        expect(configStore.config.videoTranslationEnabled).toBe(true);
+        expect(configStore.getConfigRevision()).toBe(5);
+        expect(listener).toHaveBeenCalledOnce();
+        unsubscribe();
+    });
+
+    it('字段补丁冲突后回读同字段的权威新值', async () => {
+        const canonical = sanitizeConfigCredentials(normalizeConfig(storedConfig));
+        const configStore = await loadConfigModule({...canonical, __fluentConfigRevision: 4});
+        await configStore.configReady;
+        const sendMessage = vi.fn(async (message: {
+            mode?: string;
+            config: Config;
+            expected?: Config;
+            baseRevision: number;
+        }) => {
+            expect(configStore.config.to).toBe('ja');
+            expect(message).toMatchObject({
+                mode: 'patch',
+                config: {to: 'ja'},
+                expected: {to: 'zh-Hans'},
+                baseRevision: 4,
+            });
+            storageState.set('local:config', {
+                ...canonical,
+                to: 'ko',
+                __fluentConfigRevision: 5,
+            });
+            return {success: false, error: '配置字段已更新，请同步后重试：to'};
+        });
+
+        await expect(configStore.requestConfigPatch({to: 'ja'}, sendMessage))
+            .rejects.toThrow('to');
+
+        expect(configStore.config.to).toBe('ko');
+        expect(configStore.getConfigRevision()).toBe(5);
+    });
+
     it('先写入并读回 local 凭据，再清理旧 config/history 明文', async () => {
         const secret = 'legacy-secret-sentinel';
         const legacyConfig = {
@@ -942,6 +1092,309 @@ describe('统一配置存储', () => {
 
         expect(sent).toEqual(['en', 'ja']);
         expect(baseRevisions).toEqual([1, 2]);
+    });
+
+    it('配置持久化 barrier 等待已排队及等待期间追加的请求', async () => {
+        const canonical = sanitizeConfigCredentials(normalizeConfig(storedConfig));
+        const configStore = await loadConfigModule({...canonical, __fluentConfigRevision: 4});
+        await configStore.configReady;
+        const configWatch = storageMock.watch.mock.calls[0][1];
+        let releaseFirstPatch!: () => void;
+        let releaseSecondPatch!: () => void;
+        const firstPatchGate = new Promise<void>((resolve) => { releaseFirstPatch = resolve; });
+        const secondPatchGate = new Promise<void>((resolve) => { releaseSecondPatch = resolve; });
+        const sent: Array<{mode: string; baseRevision: number}> = [];
+        const sendMessage = vi.fn(async (message: {
+            mode?: 'replace' | 'patch';
+            config: Config;
+            expected?: Config;
+            baseRevision: number;
+        }) => {
+            sent.push({mode: message.mode || 'replace', baseRevision: message.baseRevision});
+            if (message.mode === 'patch' && 'videoTranslationEnabled' in message.config) {
+                await firstPatchGate;
+                const committed = {
+                    ...canonical,
+                    videoTranslationEnabled: true,
+                    __fluentConfigRevision: 5,
+                };
+                storageState.set('local:config', committed);
+                configWatch(committed);
+                return {success: true, revision: 5};
+            }
+            if (message.mode === 'patch') {
+                await secondPatchGate;
+                const committed = {
+                    ...canonical,
+                    videoTranslationEnabled: true,
+                    theme: 'dark',
+                    __fluentConfigRevision: 6,
+                };
+                storageState.set('local:config', committed);
+                configWatch(committed);
+                return {success: true, revision: 6};
+            }
+
+            expect(message.baseRevision).toBe(6);
+            const committed = {
+                ...canonical,
+                videoTranslationEnabled: true,
+                theme: 'dark',
+                to: 'ja',
+                __fluentConfigRevision: 7,
+            };
+            storageState.set('local:config', committed);
+            configWatch(committed);
+            return {success: true, revision: 7};
+        });
+
+        const firstPatch = configStore.requestConfigPatch({videoTranslationEnabled: true}, sendMessage);
+        await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledOnce());
+        let barrierResolved = false;
+        const barrier = configStore.waitForConfigPersistenceQueue().then(() => { barrierResolved = true; });
+        const secondPatch = configStore.requestConfigPatch({theme: 'dark'}, sendMessage);
+
+        await Promise.resolve();
+        expect(barrierResolved).toBe(false);
+        releaseFirstPatch();
+        await firstPatch;
+        await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(2));
+        expect(barrierResolved).toBe(false);
+        releaseSecondPatch();
+        await Promise.all([secondPatch, barrier]);
+
+        expect(barrierResolved).toBe(true);
+        expect(configStore.getConfigRevision()).toBe(6);
+        await configStore.requestConfigSave({...configStore.config, to: 'ja'}, sendMessage);
+        expect(sent).toEqual([
+            {mode: 'patch', baseRevision: 4},
+            {mode: 'patch', baseRevision: 4},
+            {mode: 'replace', baseRevision: 6},
+        ]);
+        expect(configStore.config).toMatchObject({
+            to: 'ja',
+            theme: 'dark',
+            videoTranslationEnabled: true,
+        });
+        expect(configStore.getConfigRevision()).toBe(7);
+    });
+
+    it('字段补丁与整份替换共用请求队列，replace 不继承 patch revision', async () => {
+        const configStore = await loadConfigModule(storedConfig);
+        await configStore.configReady;
+        const sent: Array<{mode: string; to: string; sequence: number; baseRevision: number}> = [];
+        let releasePatch!: () => void;
+        const patchGate = new Promise<void>((resolve) => { releasePatch = resolve; });
+        const sendMessage = vi.fn(async (message: {
+            mode?: 'replace' | 'patch';
+            config: Config;
+            sequence: number;
+            baseRevision: number;
+        }) => {
+            sent.push({
+                mode: message.mode || 'replace',
+                to: String(message.config.to),
+                sequence: message.sequence,
+                baseRevision: message.baseRevision,
+            });
+            if (message.mode === 'patch') await patchGate;
+            return {success: true, revision: message.baseRevision + 1};
+        });
+
+        const patch = configStore.requestConfigPatch({to: 'en'}, sendMessage);
+        const replace = configStore.requestConfigSave({...configStore.config, to: 'ja'}, sendMessage);
+        await vi.waitFor(() => expect(sent).toHaveLength(1));
+        releasePatch();
+        await Promise.all([patch, replace]);
+
+        expect(sent).toEqual([
+            {mode: 'patch', to: 'en', sequence: 1, baseRevision: 1},
+            {mode: 'replace', to: 'ja', sequence: 2, baseRevision: 1},
+        ]);
+    });
+
+    it('排队 replace 不借用已吸收外部字段的 patch revision 覆盖新值', async () => {
+        const canonical = sanitizeConfigCredentials(normalizeConfig(storedConfig));
+        const configStore = await loadConfigModule({...canonical, __fluentConfigRevision: 4});
+        await configStore.configReady;
+        const configWatch = storageMock.watch.mock.calls[0][1];
+        const sent: Array<{mode: string; baseRevision: number}> = [];
+        const sendMessage = vi.fn(async (message: {
+            mode?: 'replace' | 'patch';
+            config: Config;
+            expected?: Config;
+            baseRevision: number;
+        }) => {
+            sent.push({mode: message.mode || 'replace', baseRevision: message.baseRevision});
+            if (message.mode === 'patch') {
+                expect(message).toMatchObject({
+                    config: {to: 'ja'},
+                    expected: {to: canonical.to},
+                    baseRevision: 4,
+                });
+                const external = {
+                    ...canonical,
+                    theme: 'dark',
+                    __fluentConfigRevision: 5,
+                };
+                storageState.set('local:config', external);
+                configWatch(external);
+                const committed = {
+                    ...external,
+                    to: 'ja',
+                    __fluentConfigRevision: 6,
+                };
+                storageState.set('local:config', committed);
+                configWatch(committed);
+                return {success: true, revision: 6};
+            }
+
+            expect(message.config).toMatchObject({
+                to: 'ja',
+                theme: canonical.theme,
+            });
+            expect(message.baseRevision).toBe(4);
+            return {success: false, error: '配置已更新（当前 revision 6）'};
+        });
+
+        const patch = configStore.requestConfigPatch({to: 'ja'}, sendMessage);
+        // patch 的乐观值 X1 已进入 runtime，但外部 Y1 尚未到达当前上下文。
+        const staleReplace = configStore.requestConfigSave(normalizeConfig(configStore.config), sendMessage);
+        const [patchResult, replaceResult] = await Promise.allSettled([patch, staleReplace]);
+
+        expect(patchResult.status).toBe('fulfilled');
+        expect(replaceResult).toMatchObject({
+            status: 'rejected',
+            reason: expect.objectContaining({message: expect.stringContaining('revision 6')}),
+        });
+        expect(sent).toEqual([
+            {mode: 'patch', baseRevision: 4},
+            {mode: 'replace', baseRevision: 4},
+        ]);
+        expect(configStore.config).toMatchObject({to: 'ja', theme: 'dark'});
+        expect(configStore.getConfigRevision()).toBe(6);
+    });
+
+    it('外部 revision 会取消混合队列中的旧 replace，但保留可做字段 CAS 的 patch', async () => {
+        const canonical = sanitizeConfigCredentials(normalizeConfig(storedConfig));
+        const configStore = await loadConfigModule({...canonical, __fluentConfigRevision: 4});
+        await configStore.configReady;
+        const configWatch = storageMock.watch.mock.calls[0][1];
+        const sendMessage = vi.fn(async (message: {
+            mode?: 'replace' | 'patch';
+            config: Config;
+            expected?: Config;
+            baseRevision: number;
+        }) => {
+            expect(message).toMatchObject({
+                mode: 'patch',
+                config: {videoTranslationEnabled: true},
+                expected: {videoTranslationEnabled: false},
+                // patch 的 baseRevision 只是协议兼容字段，后台依赖 expected 做 CAS。
+                baseRevision: 4,
+            });
+            const committed = {
+                ...canonical,
+                to: 'ko',
+                videoTranslationEnabled: true,
+                __fluentConfigRevision: 6,
+            };
+            storageState.set('local:config', committed);
+            configWatch(committed);
+            return {success: true, revision: 6};
+        });
+
+        const staleReplace = configStore.requestConfigSave({...configStore.config, to: 'en'}, sendMessage);
+        const patch = configStore.requestConfigPatch({videoTranslationEnabled: true}, sendMessage);
+        const external = {
+            ...canonical,
+            to: 'ko',
+            __fluentConfigRevision: 5,
+        };
+        storageState.set('local:config', external);
+        configWatch(external);
+
+        await expect(staleReplace).rejects.toThrow('根据最新配置重新修改');
+        await expect(patch).resolves.toBeUndefined();
+
+        expect(sendMessage).toHaveBeenCalledOnce();
+        expect(configStore.config).toMatchObject({
+            to: 'ko',
+            videoTranslationEnabled: true,
+        });
+        expect(configStore.getConfigRevision()).toBe(6);
+    });
+
+    it('active replace 期间 deferred 的外部更新会取消所有旧 replace，但后续 patch 仍可 CAS', async () => {
+        const canonical = sanitizeConfigCredentials(normalizeConfig(storedConfig));
+        const configStore = await loadConfigModule({...canonical, __fluentConfigRevision: 4});
+        await configStore.configReady;
+        const configWatch = storageMock.watch.mock.calls[0][1];
+        let releaseActiveReplace!: () => void;
+        const activeReplaceGate = new Promise<void>((resolve) => { releaseActiveReplace = resolve; });
+        const sent: Array<{mode: string; to: string; baseRevision: number}> = [];
+        const sendMessage = vi.fn(async (message: {
+            mode?: 'replace' | 'patch';
+            config: Config;
+            expected?: Config;
+            baseRevision: number;
+        }) => {
+            sent.push({
+                mode: message.mode || 'replace',
+                to: String(message.config.to ?? ''),
+                baseRevision: message.baseRevision,
+            });
+            if (message.mode !== 'patch') {
+                await activeReplaceGate;
+                return {success: true, revision: 5};
+            }
+
+            expect(message).toMatchObject({
+                mode: 'patch',
+                config: {videoTranslationEnabled: true},
+                expected: {videoTranslationEnabled: false},
+                baseRevision: 4,
+            });
+            const committed = {
+                ...canonical,
+                to: 'ko',
+                videoTranslationEnabled: true,
+                __fluentConfigRevision: 7,
+            };
+            storageState.set('local:config', committed);
+            configWatch(committed);
+            return {success: true, revision: 7};
+        });
+
+        const activeReplace = configStore.requestConfigSave({...configStore.config, to: 'en'}, sendMessage);
+        await vi.waitFor(() => expect(sent).toEqual([
+            {mode: 'replace', to: 'en', baseRevision: 4},
+        ]));
+        const staleReplace = configStore.requestConfigSave({...configStore.config, to: 'ja'}, sendMessage);
+        const patch = configStore.requestConfigPatch({videoTranslationEnabled: true}, sendMessage);
+        const external = {
+            ...canonical,
+            to: 'ko',
+            __fluentConfigRevision: 6,
+        };
+        storageState.set('local:config', external);
+        // activeRequestSerialized 存在时先 deferred，待 R0 响应后再判定为更高外部版本。
+        configWatch(external);
+        releaseActiveReplace();
+
+        await expect(activeReplace).rejects.toThrow('其他页面更新');
+        await expect(staleReplace).rejects.toThrow('根据最新配置重新修改');
+        await expect(patch).resolves.toBeUndefined();
+
+        expect(sent).toEqual([
+            {mode: 'replace', to: 'en', baseRevision: 4},
+            {mode: 'patch', to: '', baseRevision: 4},
+        ]);
+        expect(configStore.config).toMatchObject({
+            to: 'ko',
+            videoTranslationEnabled: true,
+        });
+        expect(configStore.getConfigRevision()).toBe(7);
     });
 
     it('一次 revision 冲突会刷新当前配置并取消已经排队的旧快照', async () => {

--- a/tests/contentUiRuntime.test.ts
+++ b/tests/contentUiRuntime.test.ts
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => ({
     translationProgressPanelEnabled: true,
   },
   createVueShadowUi: vi.fn(),
-  requestConfigSave: vi.fn(),
+  requestConfigPatch: vi.fn(),
   sendMessage: vi.fn(),
   autoTranslateEnglishPage: vi.fn(),
   isFullPageTranslationActive: vi.fn(),
@@ -18,7 +18,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@/src/services/config/store', () => ({
   config: mocks.config,
-  requestConfigSave: mocks.requestConfigSave,
+  requestConfigPatch: mocks.requestConfigPatch,
 }));
 vi.mock('@/src/platform/shadow-ui', () => ({createVueShadowUi: mocks.createVueShadowUi}));
 vi.mock('webextension-polyfill', () => ({
@@ -68,7 +68,7 @@ beforeEach(() => {
   });
   for (const mock of [
     mocks.createVueShadowUi,
-    mocks.requestConfigSave,
+    mocks.requestConfigPatch,
     mocks.sendMessage,
     mocks.autoTranslateEnglishPage,
     mocks.isFullPageTranslationActive,
@@ -76,7 +76,9 @@ beforeEach(() => {
     mocks.subscribeFullPageTranslationProgress,
     mocks.unsubscribeFullPageTranslationProgress,
   ]) mock.mockReset();
-  mocks.requestConfigSave.mockResolvedValue(undefined);
+  mocks.requestConfigPatch.mockImplementation(async (patch: Record<string, unknown>) => {
+    Object.assign(mocks.config, patch);
+  });
   mocks.sendMessage.mockResolvedValue({success: true});
   mocks.autoTranslateEnglishPage.mockResolvedValue(undefined);
   mocks.isFullPageTranslationActive.mockReturnValue(false);
@@ -128,7 +130,7 @@ describe('悬浮球 content runtime', () => {
     await Promise.resolve();
     expect(mocks.sendMessage).toHaveBeenCalledWith({type: 'openOptionsPage'});
     expect(mocks.config.floatingBallPosition).toBe('left');
-    expect(mocks.requestConfigSave).toHaveBeenCalledWith(mocks.config, expect.any(Function));
+    expect(mocks.requestConfigPatch).toHaveBeenCalledWith({floatingBallPosition: 'left'}, expect.any(Function));
 
     mocks.isFullPageTranslationActive.mockReturnValueOnce(true);
     options.props.onTranslationToggle(true);
@@ -160,7 +162,7 @@ describe('悬浮球 content runtime', () => {
     const [, options] = mocks.createVueShadowUi.mock.calls[1];
 
     mocks.sendMessage.mockRejectedValueOnce(new Error('settings failed'));
-    mocks.requestConfigSave.mockRejectedValueOnce(new Error('save failed'));
+    mocks.requestConfigPatch.mockRejectedValueOnce(new Error('save failed'));
     options.props.onSettingsClick();
     options.props.onPositionChanged('right');
     mocks.isFullPageTranslationActive.mockReturnValueOnce(false);

--- a/tests/settingsUiArchitecture.test.ts
+++ b/tests/settingsUiArchitecture.test.ts
@@ -138,6 +138,7 @@ describe('options UI composition architecture', () => {
     expect(popup).toContain('@/src/ui/components/CustomHotkeyInput.vue')
     expect(popup).toContain('@/src/ui/components/ServiceIcon.vue')
     expect(popup).toContain('@/src/platform/browser/ids')
+    expect(popup).toContain('requestConfigPatch')
     expect(popup).toContain('requestConfigSave')
     expect(popup).not.toMatch(/\bsaveConfig\b/u)
     expect(popup).not.toMatch(/(?:!tab\?\.id|filter\(tab\s*=>\s*tab\.id\))/u)
@@ -155,12 +156,65 @@ describe('options UI composition architecture', () => {
     expect(settings).toContain('selectedVideoServiceUnavailableMessage')
     expect(settings).toContain('Chrome内置AI翻译（当前浏览器不可用）')
     expect(document).toContain('filterAvailableTranslationServices(options.services)')
-    expect(document).toContain('requestConfigSave')
+    expect(document).toContain('requestConfigPatch')
+    expect(document).toContain('subscribeConfig')
     expect(document).not.toMatch(/\bsaveConfig\b/u)
     expect(document).toContain('documentServiceUnavailableMessage')
     expect(translationCenter).toContain('filterAvailableTranslationServices(options.services)')
     expect(translationCenter).toContain('原配置会保留')
     expect(translationCenter).toContain('if (!isTranslationServiceAvailable(service)) return [service]')
+  })
+
+  it('persists document and translation-center edits as precise field patches', () => {
+    const document = source('src/app/document-translation/DocumentApp.vue')
+    const translationCenter = source('src/features/translation-center/ui/TranslationCenter.vue')
+
+    expect(document).toContain('const patch: DocumentConfigPatch = {}')
+    expect(document).toContain('if (value.from !== previous.from) patch.from = value.from')
+    expect(document).toContain('if (value.documentService !== previous.documentService)')
+    expect(document).toContain('mergeChangedDocumentModelMapping(')
+    expect(document).toContain('runtimeConfig.documentModel')
+    expect(document).toContain('runtimeConfig.documentCustomModel')
+    expect(document).not.toContain('documentModel: value.documentModel')
+    expect(document).not.toContain('documentCustomModel: value.documentCustomModel')
+
+    expect(translationCenter).toContain("persistTranslationCenterConfig('source')")
+    expect(translationCenter).toContain("persistTranslationCenterConfig('target')")
+    expect(translationCenter).toContain("persistTranslationCenterConfig('services')")
+    expect(translationCenter).toContain("persistTranslationCenterConfig('source', 'target')")
+    expect(translationCenter).toContain('const requestedFields = new Set(fields)')
+    expect(translationCenter).toContain('if (Object.keys(patch).length === 0) return')
+  })
+
+  it('uses patches for ordinary autosaves while retaining a best-effort page-exit snapshot', () => {
+    const popup = source('src/app/popup/PopupApp.vue')
+    const settings = source('src/features/settings/ui/SettingsSections.vue')
+
+    for (const content of [popup, settings]) {
+      expect(content).toContain('requestConfigPatch')
+      expect(content).toContain('requestConfigSave')
+      expect(content).toContain('persistConfigPatch(snapshot)')
+      expect(content).toContain('persistConfigReplace(config.value)')
+      expect(content).toContain('best-effort')
+      expect(content).toContain('revision 边界会拒绝过期 replace')
+      expect(content).not.toContain('replace 作为队列 flush/barrier')
+    }
+  })
+
+  it('persists the latest service configuration before testing its connection', () => {
+    const serviceConfiguration = source('src/features/settings/ui/services/ServiceConfiguration.vue')
+    const testConnectionStart = serviceConfiguration.indexOf('async function testConnection(): Promise<void>')
+    const testConnectionEnd = serviceConfiguration.indexOf('function resetCustomTemplate(): void', testConnectionStart)
+    const testConnection = serviceConfiguration.slice(testConnectionStart, testConnectionEnd)
+    const waitIndex = testConnection.indexOf('await waitForConfigPersistenceQueue()')
+    const saveIndex = testConnection.indexOf('await requestConfigSave(config.value')
+    const connectionTestIndex = testConnection.indexOf('type: CONNECTION_TEST_MESSAGE')
+
+    expect(testConnectionStart).toBeGreaterThanOrEqual(0)
+    expect(testConnectionEnd).toBeGreaterThan(testConnectionStart)
+    expect(waitIndex).toBeGreaterThanOrEqual(0)
+    expect(saveIndex).toBeGreaterThan(waitIndex)
+    expect(connectionTestIndex).toBeGreaterThan(saveIndex)
   })
 
   it('puts service selection, webpage assistance and translated-text display in General', () => {

--- a/tests/vocabularyBookComponentLifecycle.test.ts
+++ b/tests/vocabularyBookComponentLifecycle.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 import vue from '@vitejs/plugin-vue';
@@ -17,7 +18,7 @@ interface ComponentTestState {
   };
   config: Record<string, unknown>;
   configReady: Promise<void>;
-  requestConfigSave: () => Promise<void>;
+  requestConfigPatch: () => Promise<void>;
   subscribeConfig: () => () => void;
 }
 
@@ -53,7 +54,7 @@ function componentMocks(): Plugin {
           `const state = globalThis.${TEST_STATE_KEY};`,
           'export const config = state.config;',
           'export const configReady = state.configReady;',
-          'export const requestConfigSave = state.requestConfigSave;',
+          'export const requestConfigPatch = state.requestConfigPatch;',
           'export const subscribeConfig = state.subscribeConfig;',
         ].join('\n');
       }
@@ -68,6 +69,16 @@ afterEach(() => {
 });
 
 describe('VocabularyBook mounted lifecycle', () => {
+  it('refreshes failed optimistic updates from authoritative config without rewriting it', () => {
+    const component = readFileSync(resolve(
+      process.cwd(),
+      'src/features/vocabulary/ui/VocabularyBook.vue',
+    ), 'utf8');
+
+    expect(component).toContain('betaEnabled.value = runtimeConfig.vocabularyBookEnabled === true;');
+    expect(component).not.toContain('runtimeConfig.vocabularyBookEnabled = previous;');
+  });
+
   it('does not subscribe, register listeners, or list after unmounting before configReady', async () => {
     const calls = {
       runtimeAdd: 0,
@@ -96,7 +107,7 @@ describe('VocabularyBook mounted lifecycle', () => {
         to: 'zh-CN',
       },
       configReady,
-      requestConfigSave: async () => undefined,
+      requestConfigPatch: async () => undefined,
       subscribeConfig: () => {
         calls.subscribe += 1;
         return () => undefined;


### PR DESCRIPTION
## Summary
- add field-level config patches with expected-value conflict handling
- prevent queued stale full snapshots from borrowing newer revisions
- migrate cross-context autosaves and the video subtitle toggle to precise patches
- harden connection-test queue ordering and the browser regression fixture

## Testing
- `pnpm test:regression:all` — 147 files / 1524 cases; strict coverage gate; Chrome MV3, Firefox MV2, userscript, and docs builds
- isolated Edge production-extension fixture — cross-context document save preserved the video toggle; exact true → false → true edges; 23 stable samples per state; no page, console, or unexpected-network errors
- `git diff --check`

## Browser proof boundary
The automated UI proof uses an offline YouTube fixture with the production extension in an isolated background Edge profile. A live YouTube attempt confirmed the player button mounted with the correct enabled state, but hidden background controls and trusted-event boundaries prevented a reliable automated menu click, so it is not reported as a full live-site pass.