### PR TITLE
fix: stabilize floating logo click and drag behavior

### DIFF
--- a/scripts/run-full-page-translation-test.cjs
+++ b/scripts/run-full-page-translation-test.cjs
@@ -3,7 +3,7 @@
 // 这个脚本只使用临时 Edge profile 和真实 Alt+T 键盘手势，回归全文翻译的
 // 识别、按钮特殊处理、富文本结构、动态节点、Shadow DOM 以及恢复流程。
 // 传入 --verify-floating-ui 时，还会从 closed Shadow DOM 读取悬浮球透明度、
-// 展开/收起、勾选标记几何与离屏任务下的进度面板显隐。
+// 展开/收起、中间 Logo 点击稳定性、勾选标记几何与离屏任务下的进度面板显隐。
 // 它不会连接用户正在使用的浏览器 profile，也不会通过 JS 合成键盘事件。
 
 const fs = require('node:fs');
@@ -504,6 +504,7 @@ async function readFloatingUiState(page) {
       host: Boolean(floatingHost),
       ball: Boolean(ball),
       ballClass: cdpAttribute(ball, 'class'),
+      ballStyle: cdpAttribute(ball, 'style'),
       position: cdpAttribute(ball, 'data-position'),
       expanded: hasCdpClass(ball, 'floating-ball-expanded'),
       translated: hasCdpClass(ball, 'is-translating'),
@@ -619,6 +620,99 @@ async function clickFloatingTranslateTool(page, state) {
     await session.send('Input.dispatchMouseEvent', {type: 'mouseReleased', x, y, button: 'left', buttons: 0, clickCount: 1});
   } finally {
     await session.detach().catch(() => {});
+  }
+}
+
+async function clickFloatingMain(page, state) {
+  const box = state.mainBox;
+  if (!box) throw new Error(`无法取得悬浮球中间 Logo 几何位置：${JSON.stringify(state)}`);
+  const x = (box.left + box.right) / 2;
+  const y = (box.top + box.bottom) / 2;
+  const session = await page.context().newCDPSession(page);
+  try {
+    await session.send('Input.dispatchMouseEvent', {type: 'mouseMoved', x, y});
+    await session.send('Input.dispatchMouseEvent', {type: 'mousePressed', x, y, button: 'left', buttons: 1, clickCount: 1});
+    await page.waitForTimeout(30);
+    const pressed = await readFloatingUiState(page);
+    // 夹带 5px 的真实指针抖动，证明未越过 6px 拖动阈值的普通点击仍保持原位。
+    await session.send('Input.dispatchMouseEvent', {type: 'mouseMoved', x: x + 5, y, button: 'left', buttons: 1});
+    await page.waitForTimeout(30);
+    const jittered = await readFloatingUiState(page);
+    await session.send('Input.dispatchMouseEvent', {type: 'mouseReleased', x: x + 5, y, button: 'left', buttons: 0, clickCount: 1});
+    return {pressed, jittered};
+  } finally {
+    await session.detach().catch(() => {});
+  }
+}
+
+async function dragFloatingMain(page, state, targetX) {
+  const box = state.mainBox;
+  if (!box) throw new Error(`无法取得悬浮球拖动前的几何位置：${JSON.stringify(state)}`);
+  const viewport = await page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }));
+  const visibleLeft = Math.max(1, box.left);
+  const visibleRight = Math.min(viewport.width - 1, box.right);
+  const visibleTop = Math.max(1, box.top);
+  const visibleBottom = Math.min(viewport.height - 1, box.bottom);
+  const startX = (visibleLeft + visibleRight) / 2;
+  const startY = (visibleTop + visibleBottom) / 2;
+  const session = await page.context().newCDPSession(page);
+  try {
+    await session.send('Input.dispatchMouseEvent', {type: 'mouseMoved', x: startX, y: startY});
+    await session.send('Input.dispatchMouseEvent', {type: 'mousePressed', x: startX, y: startY, button: 'left', buttons: 1, clickCount: 1});
+    await session.send('Input.dispatchMouseEvent', {type: 'mouseMoved', x: targetX, y: startY, button: 'left', buttons: 1});
+    await page.waitForTimeout(50);
+    const during = await readFloatingUiState(page);
+    await session.send('Input.dispatchMouseEvent', {type: 'mouseReleased', x: targetX, y: startY, button: 'left', buttons: 0, clickCount: 1});
+    return during;
+  } finally {
+    await session.detach().catch(() => {});
+  }
+}
+
+async function movePointerAwayFromFloatingUi(page) {
+  const session = await page.context().newCDPSession(page);
+  try {
+    await session.send('Input.dispatchMouseEvent', {type: 'mouseMoved', x: 100, y: 100});
+  } finally {
+    await session.detach().catch(() => {});
+  }
+}
+
+function assertFloatingMainClickStable(before, after, beforeUrl, afterUrl) {
+  const tolerance = 1;
+  const geometryStable = before.mainBox && after.mainBox &&
+    ['left', 'top', 'right', 'bottom'].every((key) => Math.abs(before.mainBox[key] - after.mainBox[key]) <= tolerance);
+  if (!geometryStable || !before.expanded || !after.expanded || before.position !== after.position ||
+      before.translated !== after.translated || before.ballStyle !== after.ballStyle ||
+      after.ballClass.includes('dragging') || beforeUrl !== afterUrl) {
+    throw new Error(`点击中间 Logo 不应改变悬浮球或页面状态：${JSON.stringify({before, after, beforeUrl, afterUrl})}`);
+  }
+}
+
+async function readFloatingInteractionDomState(page) {
+  return page.evaluate(() => ({
+    url: location.href,
+    bilingualCount: document.querySelectorAll('.fluent-read-bilingual-content').length,
+    loadingCount: document.querySelectorAll('.fluent-read-loading').length,
+  }));
+}
+
+function assertFloatingInteractionDomStable(before, after, label) {
+  if (JSON.stringify(before) !== JSON.stringify(after)) {
+    throw new Error(`${label} 不应改变页面译文、加载态或 URL：${JSON.stringify({before, after})}`);
+  }
+}
+
+function assertFloatingMainDragKeepsPageStable(before, during, after, beforeUrl, afterUrl) {
+  const centerY = state => state.mainBox ? (state.mainBox.top + state.mainBox.bottom) / 2 : Number.NaN;
+  const centerX = state => state.mainBox ? (state.mainBox.left + state.mainBox.right) / 2 : Number.NaN;
+  const verticalStable = Math.abs(centerY(before) - centerY(during)) <= 1 &&
+    Math.abs(centerY(before) - centerY(after)) <= 1;
+  const horizontalMoved = Math.abs(centerX(before) - centerX(after)) > 100;
+  if (before.position === after.position || after.position !== 'left' || before.translated !== after.translated ||
+      !during.ballClass.includes('dragging') || after.ballClass.includes('dragging') ||
+      !verticalStable || !horizontalMoved || beforeUrl !== afterUrl) {
+    throw new Error(`拖动中间 Logo 应平稳地只改变停靠位置：${JSON.stringify({before, during, after, beforeUrl, afterUrl})}`);
   }
 }
 
@@ -899,6 +993,89 @@ async function main() {
         '等待低干扰悬浮球初始状态超时',
       );
       assertCollapsedFloatingUi(floatingUiEvidence.initial, false, '初始');
+      await movePointerToFloatingMain(page, floatingUiEvidence.initial);
+      await waitForFloatingUiState(
+        page,
+        state => isExpandedFloatingUiState(state),
+        args.timeout,
+        '等待中间 Logo 点击前悬浮球展开超时',
+      );
+      await page.waitForTimeout(520);
+      floatingUiEvidence.expandedBeforeMainClick = await readFloatingUiState(page);
+      assertExpandedFloatingUi(floatingUiEvidence.expandedBeforeMainClick, '中间 Logo 点击前');
+      const urlBeforeMainClick = page.url();
+      const requestCountBeforeMainClick = translationFixtureServer.requestCount();
+      const domBeforeMainClick = await readFloatingInteractionDomState(page);
+      const mainClickStages = await clickFloatingMain(page, floatingUiEvidence.expandedBeforeMainClick);
+      floatingUiEvidence.pressedDuringMainClick = mainClickStages.pressed;
+      floatingUiEvidence.jitteredDuringMainClick = mainClickStages.jittered;
+      assertFloatingMainClickStable(
+        floatingUiEvidence.expandedBeforeMainClick,
+        floatingUiEvidence.pressedDuringMainClick,
+        urlBeforeMainClick,
+        page.url(),
+      );
+      assertFloatingMainClickStable(
+        floatingUiEvidence.expandedBeforeMainClick,
+        floatingUiEvidence.jitteredDuringMainClick,
+        urlBeforeMainClick,
+        page.url(),
+      );
+      await page.waitForTimeout(520);
+      floatingUiEvidence.afterMainClick = await readFloatingUiState(page);
+      assertFloatingMainClickStable(
+        floatingUiEvidence.expandedBeforeMainClick,
+        floatingUiEvidence.afterMainClick,
+        urlBeforeMainClick,
+        page.url(),
+      );
+      const domAfterMainClick = await readFloatingInteractionDomState(page);
+      floatingUiEvidence.mainClickDom = {before: domBeforeMainClick, after: domAfterMainClick};
+      assertFloatingInteractionDomStable(domBeforeMainClick, domAfterMainClick, '点击中间 Logo');
+      floatingUiEvidence.mainClickTranslationRequests = {
+        before: requestCountBeforeMainClick,
+        after: translationFixtureServer.requestCount(),
+      };
+      if (floatingUiEvidence.mainClickTranslationRequests.before !== floatingUiEvidence.mainClickTranslationRequests.after) {
+        throw new Error(`点击中间 Logo 不应发起翻译请求：${JSON.stringify(floatingUiEvidence.mainClickTranslationRequests)}`);
+      }
+      await movePointerAwayFromFloatingUi(page);
+      floatingUiEvidence.collapsedAfterMainClick = await waitForFloatingUiState(
+        page,
+        state => isCollapsedFloatingUiState(state, false),
+        args.timeout,
+        '等待中间 Logo 点击验证后悬浮球收起超时',
+      );
+      const urlBeforeMainDrag = page.url();
+      const requestCountBeforeMainDrag = translationFixtureServer.requestCount();
+      const domBeforeMainDrag = await readFloatingInteractionDomState(page);
+      floatingUiEvidence.duringMainDrag = await dragFloatingMain(page, floatingUiEvidence.collapsedAfterMainClick, 72);
+      await waitForFloatingUiState(
+        page,
+        state => state.position === 'left' && isCollapsedFloatingUiState(state, false),
+        args.timeout,
+        '等待中间 Logo 真正拖动后停靠左侧超时',
+      );
+      await page.waitForTimeout(520);
+      floatingUiEvidence.afterMainDrag = await readFloatingUiState(page);
+      assertCollapsedFloatingUi(floatingUiEvidence.afterMainDrag, false, '中间 Logo 拖动后');
+      assertFloatingMainDragKeepsPageStable(
+        floatingUiEvidence.collapsedAfterMainClick,
+        floatingUiEvidence.duringMainDrag,
+        floatingUiEvidence.afterMainDrag,
+        urlBeforeMainDrag,
+        page.url(),
+      );
+      const domAfterMainDrag = await readFloatingInteractionDomState(page);
+      floatingUiEvidence.mainDragDom = {before: domBeforeMainDrag, after: domAfterMainDrag};
+      assertFloatingInteractionDomStable(domBeforeMainDrag, domAfterMainDrag, '拖动中间 Logo');
+      floatingUiEvidence.mainDragTranslationRequests = {
+        before: requestCountBeforeMainDrag,
+        after: translationFixtureServer.requestCount(),
+      };
+      if (floatingUiEvidence.mainDragTranslationRequests.before !== floatingUiEvidence.mainDragTranslationRequests.after) {
+        throw new Error(`拖动中间 Logo 不应发起翻译请求：${JSON.stringify(floatingUiEvidence.mainDragTranslationRequests)}`);
+      }
     }
 
     const initialClamp = await page.evaluate(() => {
@@ -1068,6 +1245,12 @@ async function main() {
     });
 
     if (args.verifyFloatingUi) {
+      await page.evaluate(() => {
+        const paragraph = document.createElement('p');
+        paragraph.id = 'floating-ui-progress-only-fixture';
+        paragraph.textContent = `A newly visible uncached paragraph keeps the progress-only assertion observable ${crypto.randomUUID()}.`;
+        document.body.prepend(paragraph);
+      });
       await readConfig(context, args.timeout, {disableFloatingBall: true}, createIsolatedPage);
       floatingUiEvidence.progressOnlyInitial = await waitForFloatingUiState(
         page,
@@ -1084,7 +1267,8 @@ async function main() {
         '等待无悬浮球时展开实际进度面板超时',
       );
       await page.waitForFunction(
-        () => Boolean(document.querySelector('#paragraph-one .fluent-read-bilingual-content')),
+        () => Boolean(document.querySelector('#paragraph-one .fluent-read-bilingual-content') &&
+          document.querySelector('#floating-ui-progress-only-fixture .fluent-read-bilingual-content')),
         undefined,
         {timeout: args.timeout},
       );
@@ -1104,6 +1288,7 @@ async function main() {
         args.timeout,
         '等待仅进度面板模式恢复原文超时',
       );
+      await movePointerAwayFromFloatingUi(page);
       await readConfig(context, args.timeout, {disableFloatingBall: false}, createIsolatedPage);
       floatingUiEvidence.remountedBeforeRetranslate = await waitForFloatingUiState(
         page,

--- a/scripts/testing/run-full-regression.mjs
+++ b/scripts/testing/run-full-regression.mjs
@@ -30,6 +30,7 @@ const LOCAL_BROWSER_FIXTURES = [
         id: 'full-page-translation',
         label: 'full-page translation browser regression',
         script: 'scripts/run-full-page-translation-test.cjs',
+        args: ['--verify-floating-ui'],
         backgroundArgs: ['--background'],
         supportsHeaded: true,
     },
@@ -311,6 +312,7 @@ function browserFixtureArgs(fixture, options) {
         args.push('--extension-dir', options.extensionDir);
     }
     if (options.timeout) args.push('--timeout', options.timeout);
+    if (fixture.args) args.push(...fixture.args);
 
     if (options.headed && fixture.supportsHeaded) {
         args.push('--headed');

--- a/src/features/floating-ball/ui/FloatingBall.vue
+++ b/src/features/floating-ball/ui/FloatingBall.vue
@@ -1,7 +1,7 @@
 <!--
  * @file src/features/floating-ball/ui/FloatingBall.vue
  * 文件职责：呈现低干扰、可拖拽和按需展开的页面悬浮球，并把全文翻译状态、拖动停靠、打开设置和键盘关闭整合为可复用 Vue 组件。
- * 主要内容：组件根据停靠位置控制收起透明度与勾选标记，使用 Pointer Capture 区分点击与拖拽，限制球体在视口内，发出位置变更与动作事件，并通过受控状态同步图标和文案。
+ * 主要内容：组件根据停靠位置控制收起透明度与勾选标记，使用指针位移阈值区分点击与拖拽，限制球体在视口内，发出位置变更与动作事件，并通过受控状态同步图标和文案。
  * 模块边界：它只负责视觉与局部交互，不直接调用浏览器消息、保存配置或执行全文翻译；这些副作用由 content/runtime 通过 props、事件和 defineExpose 桥接。
  -->
 <template>
@@ -39,6 +39,7 @@
     </button>
 
     <div
+      ref="floatingBallMain"
       class="floating-ball-main floating-ball-item"
       role="img"
       aria-label="FluentRead"
@@ -75,7 +76,7 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import type { PropType, CSSProperties } from 'vue';
 
 const DRAG_THRESHOLD = 6;
-const BALL_SIZE = 42;
+const BALL_SIZE = 48;
 
 const props = defineProps({
   position: {
@@ -113,6 +114,11 @@ interface PointerDragState {
   pointerId: number;
   startX: number;
   startY: number;
+  pointerOffsetX: number;
+  pointerOffsetY: number;
+  mainWidth: number;
+  mainHeight: number;
+  dockHeight: number;
   moved: boolean;
 }
 
@@ -123,6 +129,7 @@ const draggedY = ref<number | null>(null);
 const internalPosition = ref<'left' | 'right' | null>(null);
 const isTranslating = ref(props.initialTranslating);
 const floatingBall = ref<HTMLElement | null>(null);
+const floatingBallMain = ref<HTMLElement | null>(null);
 const dragState = ref<PointerDragState | null>(null);
 
 const currentDisplayPosition = computed(() => internalPosition.value || props.position);
@@ -139,10 +146,7 @@ function clamp(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value));
 }
 
-function updatePositionStyle() {
-  if (isDragging.value) return;
-
-  const containerHeight = floatingBall.value?.getBoundingClientRect().height || BALL_SIZE;
+function applyDockPositionStyle(containerHeight: number) {
   const halfHeight = containerHeight / 2;
   const centerY = draggedY.value === null
     ? '50%'
@@ -156,27 +160,29 @@ function updatePositionStyle() {
   };
 }
 
+function updatePositionStyle() {
+  if (isDragging.value) return;
+  applyDockPositionStyle(floatingBall.value?.getBoundingClientRect().height || BALL_SIZE);
+}
+
 function startDrag(event: PointerEvent) {
   if (event.pointerType === 'mouse' && event.button !== 0) return;
 
   event.preventDefault();
-  isExpanded.value = false;
-  isDragging.value = true;
+  const dockRect = floatingBall.value?.getBoundingClientRect();
+  const rect = floatingBallMain.value?.getBoundingClientRect() || dockRect;
+  const mainWidth = rect?.width || BALL_SIZE;
+  const mainHeight = rect?.height || BALL_SIZE;
   dragState.value = {
     pointerId: event.pointerId,
     startX: event.clientX,
     startY: event.clientY,
+    pointerOffsetX: rect ? event.clientX - rect.left : mainWidth / 2,
+    pointerOffsetY: rect ? event.clientY - rect.top : mainHeight / 2,
+    mainWidth,
+    mainHeight,
+    dockHeight: dockRect?.height || mainHeight,
     moved: false,
-  };
-
-  const containerHeight = floatingBall.value?.getBoundingClientRect().height || BALL_SIZE;
-  const startLeft = clamp(event.clientX - BALL_SIZE / 2, 0, Math.max(0, window.innerWidth - BALL_SIZE));
-  const startTop = clamp(event.clientY - containerHeight / 2, 0, Math.max(0, window.innerHeight - containerHeight));
-  positionStyle.value = {
-    left: `${startLeft}px`,
-    top: `${startTop}px`,
-    right: 'auto',
-    transform: 'none',
   };
 
   window.addEventListener('pointermove', handlePointerMove);
@@ -188,13 +194,23 @@ function handlePointerMove(event: PointerEvent) {
   const currentDrag = dragState.value;
   if (!currentDrag || currentDrag.pointerId !== event.pointerId) return;
 
-  if (Math.hypot(event.clientX - currentDrag.startX, event.clientY - currentDrag.startY) > DRAG_THRESHOLD) {
+  if (!currentDrag.moved) {
+    if (Math.hypot(event.clientX - currentDrag.startX, event.clientY - currentDrag.startY) <= DRAG_THRESHOLD) return;
     currentDrag.moved = true;
+    isExpanded.value = false;
+    isDragging.value = true;
   }
 
-  const containerHeight = floatingBall.value?.getBoundingClientRect().height || BALL_SIZE;
-  const nextLeft = clamp(event.clientX - BALL_SIZE / 2, 0, Math.max(0, window.innerWidth - BALL_SIZE));
-  const nextTop = clamp(event.clientY - containerHeight / 2, 0, Math.max(0, window.innerHeight - containerHeight));
+  const nextLeft = clamp(
+    event.clientX - currentDrag.pointerOffsetX,
+    0,
+    Math.max(0, window.innerWidth - currentDrag.mainWidth),
+  );
+  const nextTop = clamp(
+    event.clientY - currentDrag.pointerOffsetY,
+    0,
+    Math.max(0, window.innerHeight - currentDrag.mainHeight),
+  );
   positionStyle.value = {
     left: `${nextLeft}px`,
     top: `${nextTop}px`,
@@ -209,19 +225,22 @@ function finishPointerInteraction(event: PointerEvent) {
 
   removePointerListeners();
   dragState.value = null;
-  isDragging.value = false;
-
-  if (currentDrag.moved) {
-    const rect = floatingBall.value?.getBoundingClientRect();
-    const finalCenterY = rect ? rect.top + rect.height / 2 : event.clientY;
-    const nextPosition = event.clientX < window.innerWidth / 2 ? 'left' : 'right';
-    const halfHeight = (rect?.height || BALL_SIZE) / 2;
-    draggedY.value = clamp(finalCenterY, halfHeight, Math.max(halfHeight, window.innerHeight - halfHeight));
-    internalPosition.value = nextPosition;
-    props.onPositionChanged(nextPosition);
-    nextTick(updatePositionStyle);
+  if (!currentDrag.moved) {
+    isDragging.value = false;
     return;
   }
+
+  const rect = floatingBallMain.value?.getBoundingClientRect();
+  const finalCenterY = rect ? rect.top + rect.height / 2 : event.clientY;
+  const nextPosition = event.clientX < window.innerWidth / 2 ? 'left' : 'right';
+  const halfHeight = currentDrag.dockHeight / 2;
+  draggedY.value = clamp(finalCenterY, halfHeight, Math.max(halfHeight, window.innerHeight - halfHeight));
+  internalPosition.value = nextPosition;
+  props.onPositionChanged(nextPosition);
+  applyDockPositionStyle(currentDrag.dockHeight);
+  nextTick(() => {
+    isDragging.value = false;
+  });
 }
 
 function cancelPointerInteraction(event: PointerEvent) {
@@ -230,8 +249,14 @@ function cancelPointerInteraction(event: PointerEvent) {
 
   removePointerListeners();
   dragState.value = null;
-  isDragging.value = false;
-  updatePositionStyle();
+  if (!currentDrag.moved) {
+    isDragging.value = false;
+    return;
+  }
+  applyDockPositionStyle(currentDrag.dockHeight);
+  nextTick(() => {
+    isDragging.value = false;
+  });
 }
 
 function removePointerListeners() {

--- a/tests/floatingUiPresentation.test.ts
+++ b/tests/floatingUiPresentation.test.ts
@@ -67,6 +67,22 @@ describe('低干扰悬浮 UI', () => {
     )).toContain('right: -1px');
   });
 
+  it('中间 Logo 只有越过拖动阈值后才改变位置', () => {
+    const floatingBall = source('src/features/floating-ball/ui/FloatingBall.vue');
+    const startDrag = floatingBall.match(/function startDrag\([^)]*\) \{([\s\S]*?)\n\}/u)?.[1] ?? '';
+    const handlePointerMove = floatingBall.match(/function handlePointerMove\([^)]*\) \{([\s\S]*?)\n\}/u)?.[1] ?? '';
+
+    expect(startDrag).not.toContain('isExpanded.value = false');
+    expect(startDrag).not.toContain('isDragging.value = true');
+    expect(startDrag).not.toContain('positionStyle.value =');
+    expect(handlePointerMove).toContain('<= DRAG_THRESHOLD) return');
+    expect(handlePointerMove).toContain('currentDrag.moved = true');
+    expect(handlePointerMove).toContain('isExpanded.value = false');
+    expect(handlePointerMove).toContain('isDragging.value = true');
+    expect(handlePointerMove).toContain('event.clientX - currentDrag.pointerOffsetX');
+    expect(handlePointerMove).toContain('event.clientY - currentDrag.pointerOffsetY');
+  });
+
   it('进度面板使用半透明背景，并由活动请求而非离屏候选决定显隐', () => {
     const panel = source('src/features/full-page-translation/ui/TranslationProgressPanel.vue');
     const panelRule = cssRule(panel, '.fr-translation-progress');

--- a/tests/fullRegressionRunner.test.ts
+++ b/tests/fullRegressionRunner.test.ts
@@ -97,6 +97,9 @@ describe('full regression runner', () => {
         }
 
         const userscriptSmoke = browserSteps.find((step: {id: string}) => step.id === 'userscript-smoke');
+        const fullPageTranslation = browserSteps.find((step: {id: string}) => step.id === 'full-page-translation');
+        expect(fullPageTranslation).toBeDefined();
+        expect(fullPageTranslation!.args).toContain('--verify-floating-ui');
         expect(userscriptSmoke).toBeDefined();
         expect(userscriptSmoke!.args).toContain('--artifact');
         expect(userscriptSmoke!.args).toContain(resolve(PROJECT_ROOT, '.output/userscript/fluent-read.user.js'));


### PR DESCRIPTION
## Summary

- Keep the center floating logo stationary on clicks and pointer jitter within the 6px drag threshold.
- Start movement only after a real drag, preserve the pointer offset, and dock without vertical rebound on release.
- Extend the isolated browser regression to verify inert clicks, stable dragging, and unchanged translation/page state.

## Tests

- `pnpm exec vitest run tests/floatingUiPresentation.test.ts tests/fullRegressionRunner.test.ts` — 10 passed
- `pnpm test:regression` — 177 passed
- `pnpm compile`
- `pnpm build`
- `pnpm build:firefox`
- `pnpm test:audit`
- Isolated Edge floating UI regression with `--verify-floating-ui` — click/jitter geometry stayed unchanged, real drag still docked, translate/restore/retranslate passed, with no console errors or unexpected network requests
- `git diff --check`