### PR TITLE
fix: make translation failure actions reliable

### DIFF
--- a/scripts/run-full-page-translation-test.cjs
+++ b/scripts/run-full-page-translation-test.cjs
@@ -12,6 +12,9 @@ const os = require('node:os');
 const path = require('node:path');
 const { createRequire } = require('node:module');
 
+const FAILURE_ACTION_LINK_SELECTOR = '#translation-error-link';
+const FAILURE_ACTION_TEXT_MARKER = 'This block link fails once';
+
 function parseArgs(argv) {
   const args = {
     url: null,
@@ -97,6 +100,7 @@ async function readRequestBody(request) {
 async function startTranslationFixtureServer(unexpectedNetworkRequests = [], responseDelayMs = 0) {
   let requestCount = 0;
   let translatedItemCount = 0;
+  let failureActionAttempts = 0;
   const server = http.createServer(async (request, response) => {
     const requestUrl = new URL(request.url || '/', 'http://127.0.0.1');
     if (request.method === 'POST' && requestUrl.pathname === '/translate') {
@@ -110,6 +114,20 @@ async function startTranslationFixtureServer(unexpectedNetworkRequests = [], res
       translatedItemCount += Array.isArray(payload) ? payload.length : 0;
       if (responseDelayMs > 0) {
         await new Promise((resolve) => setTimeout(resolve, responseDelayMs));
+      }
+      const matchesFailureActionLink = Array.isArray(payload) && payload.some((text) =>
+        String(text).includes(FAILURE_ACTION_TEXT_MARKER));
+      if (matchesFailureActionLink) {
+        failureActionAttempts += 1;
+        if (failureActionAttempts === 1) {
+          response.writeHead(400, {
+            'access-control-allow-origin': '*',
+            'cache-control': 'no-store',
+            'content-type': 'application/json; charset=utf-8',
+          });
+          response.end(JSON.stringify({error: 'fixture link fails on its first translation attempt'}));
+          return;
+        }
       }
       response.writeHead(200, {
         'access-control-allow-origin': '*',
@@ -151,6 +169,7 @@ async function startTranslationFixtureServer(unexpectedNetworkRequests = [], res
     blockedUrl: `${baseUrl}/blocked`,
     requestCount: () => requestCount,
     translatedItemCount: () => translatedItemCount,
+    failureActionAttempts: () => failureActionAttempts,
     close: () => new Promise((resolve) => server.close(resolve)),
   };
 }
@@ -371,6 +390,23 @@ async function toggleFullPage(page, activatePage) {
   await page.keyboard.down('Alt');
   await page.keyboard.press('t');
   await page.keyboard.up('Alt');
+}
+
+async function toggleHoverTranslation(page, selector, activatePage) {
+  await activatePage(page);
+  const target = page.locator(selector);
+  await target.scrollIntoViewIfNeeded();
+  const box = await target.boundingBox();
+  if (!box || box.width <= 0 || box.height <= 0) {
+    throw new Error(`悬浮翻译目标不可见：${selector}`);
+  }
+  // 链接本身绝不能为了“激活页面”而先点击。只移动真实指针，再发送可信 Control 手势。
+  await page.mouse.move(
+    box.x + Math.min(16, box.width / 2),
+    box.y + Math.min(14, box.height / 2),
+  );
+  await page.keyboard.down('Control');
+  await page.keyboard.up('Control');
 }
 
 async function installShortcutDiagnostics(page) {
@@ -711,6 +747,256 @@ function assertRestored(state) {
       !state.buttonIconPresent || state.buttonBilingualCount !== 0 || state.cancelButtonBilingualCount !== 0) {
     throw new Error(`按钮恢复不完整：${JSON.stringify(state)}`);
   }
+}
+
+async function readFailureActionState(page) {
+  return page.evaluate((selector) => {
+    const link = document.querySelector(selector);
+    const wrapper = link?.querySelector(':scope > .fluent-read-retry-wrapper');
+    const retry = wrapper?.querySelector('.fluent-read-retry');
+    const reason = wrapper?.querySelector('.fluent-read-reason');
+    const retryIcon = retry?.querySelector('.fluent-read-action-icon');
+    const reasonIcon = reason?.querySelector('.fluent-read-action-icon');
+    const geometry = (element) => {
+      if (!element) return null;
+      const rect = element.getBoundingClientRect();
+      return {
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        width: rect.width,
+        height: rect.height,
+      };
+    };
+    const presentation = (element) => {
+      if (!element) return null;
+      const style = getComputedStyle(element);
+      return {
+        role: element.getAttribute('role') || '',
+        tabIndex: element.getAttribute('tabindex'),
+        text: element.textContent?.replace(/\s+/gu, ' ').trim() || '',
+        display: style.display,
+        alignItems: style.alignItems,
+        flexWrap: style.flexWrap,
+        gap: style.gap,
+        color: style.color,
+        backgroundColor: style.backgroundColor,
+        borderRadius: style.borderRadius,
+        cursor: style.cursor,
+        fontSize: style.fontSize,
+        lineHeight: style.lineHeight,
+        pointerEvents: style.pointerEvents,
+        textDecorationLine: style.textDecorationLine,
+        geometry: geometry(element),
+      };
+    };
+    const noticeHost = document.querySelector('#fluent-read-page-notice-host');
+    const notice = noticeHost?.shadowRoot?.querySelector('.page-notice');
+    return {
+      url: location.href,
+      href: link instanceof HTMLAnchorElement ? link.href : '',
+      hrefAttribute: link?.getAttribute('href') || '',
+      hidden: Boolean(link?.hasAttribute('hidden')),
+      linkDisplay: link ? getComputedStyle(link).display : '',
+      linkGeometry: geometry(link),
+      activations: Number(globalThis.__fluentReadFailureLinkActivations || 0),
+      wrapperCount: link?.querySelectorAll(':scope > .fluent-read-retry-wrapper').length || 0,
+      translationCount: link?.querySelectorAll(':scope > .fluent-read-bilingual-content').length || 0,
+      translationText: link?.querySelector(':scope > .fluent-read-bilingual-content')?.textContent?.trim() || '',
+      wrapper: presentation(wrapper),
+      retry: presentation(retry),
+      reason: presentation(reason),
+      retryIcon: presentation(retryIcon),
+      reasonIcon: presentation(reasonIcon),
+      notice: {
+        present: Boolean(notice),
+        role: notice?.getAttribute('role') || '',
+        detail: notice?.querySelector('.notice-detail')?.textContent?.trim() || '',
+      },
+    };
+  }, FAILURE_ACTION_LINK_SELECTOR);
+}
+
+function assertFailureLinkInvariant(state, baseline, phase) {
+  if (state.url !== baseline.url || state.href !== baseline.href ||
+      state.hrefAttribute !== baseline.hrefAttribute || state.activations !== 0) {
+    throw new Error(`${phase} 触发了原链接：${JSON.stringify({baseline, state})}`);
+  }
+}
+
+function assertFailureActionPresentation(state) {
+  const hasArea = (item) => Boolean(item?.geometry && item.geometry.width > 0 && item.geometry.height > 0);
+  const isFlexDisplay = (display) => display === 'flex' || display === 'inline-flex';
+  const transparent = new Set(['transparent', 'rgba(0, 0, 0, 0)']);
+  const issues = [];
+  if (state.wrapperCount !== 1 || state.wrapper?.role !== 'group' ||
+      !isFlexDisplay(state.wrapper?.display) || state.wrapper?.pointerEvents !== 'auto' ||
+      state.wrapper?.flexWrap !== 'wrap' ||
+      !hasArea(state.wrapper)) issues.push('wrapper 不可见或不是 inline-flex group');
+  for (const [name, action, expectedText] of [
+    ['retry', state.retry, '重试'],
+    ['reason', state.reason, '错误原因'],
+  ]) {
+    if (action?.role !== '' || action?.tabIndex !== null || !isFlexDisplay(action?.display) ||
+        action?.cursor !== 'pointer' || action?.pointerEvents !== 'auto' ||
+        action?.textDecorationLine !== 'none' || action?.text !== expectedText || !hasArea(action) ||
+        transparent.has(action?.backgroundColor) || !action?.borderRadius || action.borderRadius === '0px') {
+      issues.push(`${name} action 样式或语义无效`);
+    }
+  }
+  for (const [name, icon, action] of [
+    ['retry', state.retryIcon, state.retry],
+    ['reason', state.reasonIcon, state.reason],
+  ]) {
+    if (!hasArea(icon) || !hasArea(action) || !isFlexDisplay(icon?.display) ||
+        icon.geometry.width > action.geometry.height || icon.geometry.height > action.geometry.height) {
+      issues.push(`${name} icon 几何无效`);
+    }
+  }
+  const retryBox = state.retry?.geometry;
+  const reasonBox = state.reason?.geometry;
+  const wrapperBox = state.wrapper?.geometry;
+  const linkBox = state.linkGeometry;
+  if (retryBox && reasonBox) {
+    const retryCenter = (retryBox.top + retryBox.bottom) / 2;
+    const reasonCenter = (reasonBox.top + reasonBox.bottom) / 2;
+    if (reasonBox.left < retryBox.right - 0.5 || Math.abs(retryCenter - reasonCenter) > 2) {
+      issues.push('两个 action 重叠或未对齐');
+    }
+  }
+  if (wrapperBox && linkBox && (wrapperBox.left < linkBox.left - 1 || wrapperBox.right > linkBox.right + 1 ||
+      wrapperBox.top < linkBox.top - 1 || wrapperBox.bottom > linkBox.bottom + 1)) {
+    issues.push('失败操作超出链接几何边界');
+  }
+  if (issues.length > 0) {
+    throw new Error(`链接失败操作样式断言失败：${issues.join('；')}；${JSON.stringify(state)}`);
+  }
+}
+
+async function runFailureActionScenario({
+  page,
+  context,
+  args,
+  createIsolatedPage,
+  activateTestPage,
+  translationFixtureServer,
+  artifactsDir,
+}) {
+  const microsoftConfig = await readConfig(
+    context,
+    args.timeout,
+    {service: 'microsoft'},
+    createIsolatedPage,
+  );
+  if (microsoftConfig.config.service !== 'microsoft') {
+    throw new Error(`链接失败 fixture 无法切换到确定性微软服务：${microsoftConfig.config.service}`);
+  }
+  await page.waitForTimeout(250);
+  await page.evaluate((selector) => {
+    const link = document.querySelector(selector);
+    if (!(link instanceof HTMLAnchorElement)) throw new Error('缺少链接失败 fixture');
+    link.hidden = false;
+    globalThis.__fluentReadFailureLinkActivations = 0;
+  }, FAILURE_ACTION_LINK_SELECTOR);
+  await page.waitForSelector(FAILURE_ACTION_LINK_SELECTOR, {state: 'visible', timeout: args.timeout});
+
+  const baseline = await readFailureActionState(page);
+  if (baseline.linkDisplay !== 'block' || baseline.hidden || !baseline.href.includes('#translation-error-destination')) {
+    throw new Error(`链接失败 fixture 初始状态无效：${JSON.stringify(baseline)}`);
+  }
+
+  await toggleHoverTranslation(page, FAILURE_ACTION_LINK_SELECTOR, activateTestPage);
+  await page.waitForSelector(
+    `${FAILURE_ACTION_LINK_SELECTOR} > .fluent-read-retry-wrapper`,
+    {state: 'visible', timeout: args.timeout},
+  );
+  const failed = await readFailureActionState(page);
+  assertFailureLinkInvariant(failed, baseline, '首次失败后');
+  assertFailureActionPresentation(failed);
+  if (translationFixtureServer.failureActionAttempts() !== 1 || failed.translationCount !== 0) {
+    throw new Error(`链接没有在首次翻译后进入失败态：${JSON.stringify({
+      attempts: translationFixtureServer.failureActionAttempts(),
+      failed,
+    })}`);
+  }
+
+  const screenshots = [];
+  if (artifactsDir) {
+    const failureScreenshot = path.join(artifactsDir, 'full-page-link-failure.png');
+    await page.screenshot({path: failureScreenshot, fullPage: false});
+    screenshots.push(failureScreenshot);
+  }
+
+  await page.locator(`${FAILURE_ACTION_LINK_SELECTOR} .fluent-read-reason`).click();
+  await page.waitForFunction(() => Boolean(
+    document.querySelector('#fluent-read-page-notice-host')?.shadowRoot?.querySelector('.page-notice .notice-detail'),
+  ), undefined, {timeout: args.timeout});
+  const afterReason = await readFailureActionState(page);
+  assertFailureLinkInvariant(afterReason, baseline, '点击错误原因后');
+  if (!afterReason.notice.present || afterReason.notice.role !== 'alert' || !afterReason.notice.detail) {
+    throw new Error(`点击错误原因后没有显示通知：${JSON.stringify(afterReason)}`);
+  }
+  if (artifactsDir) {
+    const reasonScreenshot = path.join(artifactsDir, 'full-page-link-error-reason.png');
+    await page.screenshot({path: reasonScreenshot, fullPage: false});
+    screenshots.push(reasonScreenshot);
+  }
+
+  await page.locator(`${FAILURE_ACTION_LINK_SELECTOR} .fluent-read-retry`).click();
+  await page.waitForFunction((selector) => {
+    const link = document.querySelector(selector);
+    return Boolean(link?.querySelector(':scope > .fluent-read-bilingual-content')) &&
+      !link?.querySelector(':scope > .fluent-read-retry-wrapper');
+  }, FAILURE_ACTION_LINK_SELECTOR, {timeout: args.timeout});
+  const retried = await readFailureActionState(page);
+  assertFailureLinkInvariant(retried, baseline, '点击重试成功后');
+  if (translationFixtureServer.failureActionAttempts() !== 2 || retried.translationCount !== 1 ||
+      !/[\u3400-\u9fff]/u.test(retried.translationText)) {
+    throw new Error(`链接手动重试没有在第二次成功：${JSON.stringify({
+      attempts: translationFixtureServer.failureActionAttempts(),
+      retried,
+    })}`);
+  }
+  if (artifactsDir) {
+    const successScreenshot = path.join(artifactsDir, 'full-page-link-retry-success.png');
+    await page.screenshot({path: successScreenshot, fullPage: false});
+    screenshots.push(successScreenshot);
+  }
+
+  await toggleHoverTranslation(page, FAILURE_ACTION_LINK_SELECTOR, activateTestPage);
+  await page.waitForFunction((selector) => {
+    const link = document.querySelector(selector);
+    return Boolean(link) && !link.querySelector('.fluent-read-bilingual-content, .fluent-read-retry-wrapper');
+  }, FAILURE_ACTION_LINK_SELECTOR, {timeout: args.timeout});
+  const restored = await readFailureActionState(page);
+  assertFailureLinkInvariant(restored, baseline, '链接恢复后');
+  await page.evaluate((selector) => {
+    const link = document.querySelector(selector);
+    if (link) link.hidden = true;
+  }, FAILURE_ACTION_LINK_SELECTOR);
+
+  const freeConfig = await readConfig(
+    context,
+    args.timeout,
+    {service: 'freeTranslation'},
+    createIsolatedPage,
+  );
+  if (freeConfig.config.service !== 'freeTranslation') {
+    throw new Error(`链接失败 fixture 后没有恢复免费翻译服务：${freeConfig.config.service}`);
+  }
+  await page.waitForTimeout(250);
+
+  return {
+    baseline,
+    failed,
+    afterReason,
+    retried,
+    restored,
+    provider: 'microsoft loopback fail-once',
+    attempts: translationFixtureServer.failureActionAttempts(),
+    screenshots,
+  };
 }
 
 async function main() {
@@ -1067,6 +1353,18 @@ async function main() {
       fullPage: !args.verifyFloatingUi,
     });
 
+    // 在全文会话已恢复的干净状态下验证失败操作。专用临时配置只在这一小段切到
+    // Microsoft loopback，避免 freeTranslation 的 DeepLX/Google 回退吞掉预期失败。
+    const failureActions = await runFailureActionScenario({
+      page,
+      context,
+      args,
+      createIsolatedPage,
+      activateTestPage,
+      translationFixtureServer,
+      artifactsDir,
+    });
+
     if (args.verifyFloatingUi) {
       await readConfig(context, args.timeout, {disableFloatingBall: true}, createIsolatedPage);
       floatingUiEvidence.progressOnlyInitial = await waitForFloatingUiState(
@@ -1168,12 +1466,14 @@ async function main() {
       translated,
       restored,
       retranslated,
+      failureActions,
       floatingUi: floatingUiEvidence,
       consoleErrors: runtimeErrors,
       screenshots: artifactsDir ? [
         path.join(artifactsDir, 'full-page-translated.png'),
         path.join(artifactsDir, 'full-page-restored.png'),
         path.join(artifactsDir, 'full-page-retranslated.png'),
+        ...failureActions.screenshots,
       ] : [],
     };
     if (artifactsDir) {

--- a/src/app/content/page.css
+++ b/src/app/content/page.css
@@ -42,16 +42,99 @@
 }
 
 .fluent-read-retry-wrapper {
-    display: inline-flex;
-    align-items: center;
+    display: inline-flex !important;
+    max-width: 100% !important;
+    margin-inline-start: 0.45em !important;
+    align-items: center !important;
+    flex-wrap: wrap !important;
+    gap: 0.38em !important;
+    color: inherit !important;
+    font: inherit !important;
+    line-height: 1.2 !important;
+    vertical-align: middle !important;
+    white-space: normal !important;
+    pointer-events: auto !important;
 }
-.fluent-read-retry, .fluent-read-reason {
-    color: #428ADF;
-    text-decoration: underline;
-    text-underline-offset: 0.2em;
-    margin-left: 0.2em;
-    font-size: 1em;
-    cursor: pointer;
+
+.fluent-read-failure-action {
+    box-sizing: border-box !important;
+    display: inline-flex !important;
+    min-height: 1.7em !important;
+    margin: 0 !important;
+    padding: 0.16em 0.46em !important;
+    border: 1px solid rgba(66, 138, 223, 0.28) !important;
+    align-items: center !important;
+    gap: 0.26em !important;
+    border-radius: 999px !important;
+    color: #2f78c9 !important;
+    background: rgba(66, 138, 223, 0.08) !important;
+    box-shadow: none !important;
+    font: inherit !important;
+    font-size: 0.88em !important;
+    font-style: normal !important;
+    font-weight: 600 !important;
+    letter-spacing: normal !important;
+    line-height: 1.2 !important;
+    text-decoration: none !important;
+    text-transform: none !important;
+    white-space: nowrap !important;
+    cursor: pointer !important;
+    pointer-events: auto !important;
+    user-select: none !important;
+}
+
+.fluent-read-failure-action:hover,
+.fluent-read-failure-action:focus-visible {
+    border-color: rgba(66, 138, 223, 0.48) !important;
+    background: rgba(66, 138, 223, 0.14) !important;
+    outline: none !important;
+    box-shadow: 0 0 0 2px rgba(66, 138, 223, 0.12) !important;
+}
+
+.fluent-read-reason {
+    border-color: rgba(180, 107, 0, 0.28) !important;
+    color: #9a5b12 !important;
+    background: rgba(245, 158, 11, 0.08) !important;
+}
+
+.fluent-read-reason:hover,
+.fluent-read-reason:focus-visible {
+    border-color: rgba(180, 107, 0, 0.46) !important;
+    background: rgba(245, 158, 11, 0.14) !important;
+    box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.12) !important;
+}
+
+.fluent-read-action-icon {
+    display: inline-flex !important;
+    width: 1em !important;
+    height: 1em !important;
+    flex: 0 0 1em !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    align-items: center !important;
+    justify-content: center !important;
+    color: inherit !important;
+    line-height: 1 !important;
+    pointer-events: none !important;
+}
+
+.fluent-read-action-icon > svg {
+    display: block !important;
+    width: 100% !important;
+    height: 100% !important;
+    margin: 0 !important;
+    pointer-events: none !important;
+}
+
+.fluent-read-action-icon > svg path {
+    fill: currentColor !important;
+}
+
+.fluent-read-action-label {
+    color: inherit !important;
+    font: inherit !important;
+    line-height: inherit !important;
+    pointer-events: none !important;
 }
 
 /* 图片翻译覆盖层：翻译完成后用同尺寸位图层覆盖原图，避免原文字从译文下面透出。 */

--- a/src/features/full-page-translation/content/runtime.ts
+++ b/src/features/full-page-translation/content/runtime.ts
@@ -206,13 +206,17 @@ function notifyFullPageTranslationState(isTranslated: boolean): void {
             ));
         }
     }
-    if (typeof browser === "undefined" || !browser.runtime?.sendMessage) return;
-    void browser.runtime.sendMessage({
-        type: "fullPageTranslationState",
-        isTranslated,
-    }).catch(() => {
-        // 后台可能正在重载；页面内的翻译状态不应因此失败。
-    });
+    try {
+        if (typeof browser === "undefined" || !browser.runtime?.sendMessage) return;
+        void Promise.resolve(browser.runtime.sendMessage({
+            type: "fullPageTranslationState",
+            isTranslated,
+        })).catch(() => {
+            // 后台可能正在重载；页面内的翻译状态不应因此失败。
+        });
+    } catch {
+        // runtime API 在扩展上下文失效时可能同步抛错；页面清理仍须继续。
+    }
 }
 
 function asHTMLElement(node: unknown): HTMLElement | null {
@@ -421,6 +425,7 @@ function discardStaleAttempt(
 
 function markFailedTranslation(
     node: HTMLElement,
+    candidate: TranslationCandidate,
     attempt: NonNullable<ReturnType<typeof beginTranslation>>,
     spinner: HTMLElement | undefined,
     error: unknown,
@@ -441,8 +446,8 @@ function markFailedTranslation(
         error instanceof Error ? error.message : String(error || "翻译失败"),
         () => {
             const retryOwner = owner?.active ? owner : undefined;
-            translateNode(
-                node,
+            void translateTarget(
+                candidate,
                 retryOwner?.translationConfig.displayMode ?? currentTranslationDisplayMode(),
                 false,
                 retryOwner,
@@ -542,7 +547,7 @@ async function renderTranslation(
         setRenderedStyleAttribute(node);
         return {status: "committed"};
     } catch (error) {
-        return markFailedTranslation(node, attempt, spinner, error, owner);
+        return markFailedTranslation(node, candidate, attempt, spinner, error, owner);
     }
 }
 

--- a/src/features/full-page-translation/core/errorMessage.ts
+++ b/src/features/full-page-translation/core/errorMessage.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/features/full-page-translation/core/errorMessage.ts
  * 文件职责：把底层翻译异常字符串转换成适合全文翻译失败提示的中文用户文案，并在需要时带上当前翻译服务名称。
- * 主要内容：函数识别凭据未配置、请求超时、网络错误、频率限制、额度不足、服务异常等常见模式，返回可操作且不暴露内部堆栈的提示文本。
+ * 主要内容：函数识别扩展上下文失效、凭据未配置、请求超时、网络错误、频率限制、额度不足、服务异常等常见模式，返回可操作且不暴露内部堆栈的提示文本。
  * 模块边界：这是无副作用的错误文案映射，不记录日志、不打开设置也不处理重试；错误 UI 由 translationIndicators 调用，provider 原始异常的产生和分类属于服务层。
  */
 /**
@@ -12,6 +12,9 @@
 export function getTranslationErrorMessage(errMsg: string, serviceLabel: string): string {
   const normalizedError = errMsg.toLowerCase();
 
+  if (normalizedError.includes('extension context invalidated')) {
+    return '扩展已更新或重新加载，请刷新当前页面后再试。';
+  }
   if (/^当前翻译服务/u.test(errMsg) || /请求 ID：|\bHTTP\s+\d{3}\b/iu.test(errMsg)) {
     return errMsg;
   }

--- a/src/features/full-page-translation/ui/translationIndicators.ts
+++ b/src/features/full-page-translation/ui/translationIndicators.ts
@@ -1,11 +1,11 @@
 /**
  * @file src/features/full-page-translation/ui/translationIndicators.ts
  * 文件职责：创建全文翻译过程中插入原页面的加载指示器和失败重试提示，并将错误详情转换为页面通知或可操作的重试控件。
- * 主要内容：提供 insertLoadingSpinner 与 insertFailedTip，组装 FluentRead 专属 DOM、图标、动画和点击事件，调用错误文案映射，并把生成节点返回给调用方登记到 translation state。
+ * 主要内容：提供 insertLoadingSpinner 与 insertFailedTip，组装 FluentRead 专属 DOM、完整点击区和按宿主语义启用的键盘操作控件，隔离宿主链接导航，调用错误文案映射，并把生成节点返回给调用方登记到 translation state。
  * 模块边界：本文件不发起翻译、不判断候选，也不持有 session；重试回调由 runtime 注入，节点生命周期由 state 管理，全局页面通知通过 page-notice 公共接口显示。
  */
 // 全文翻译节点中的加载与失败反馈。
-import {sendErrorMessage} from '@/src/features/page-notice/public';
+import {showPageNotice} from '@/src/features/page-notice/public';
 import {options} from '@/src/core/config/catalog';
 import {config} from '@/src/services/config/store';
 import {getTranslationErrorMessage} from '@/src/features/full-page-translation/core/errorMessage';
@@ -19,40 +19,112 @@ const icon = {
 </svg>`,
 };
 
+const INTERACTIVE_HOST_SELECTOR = [
+  'a[href]',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  'summary',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]:not([tabindex="-1"])',
+  '[role="button"]',
+  '[role="checkbox"]',
+  '[role="combobox"]',
+  '[role="link"]',
+  '[role="menuitem"]',
+  '[role="option"]',
+  '[role="radio"]',
+  '[role="switch"]',
+  '[role="tab"]',
+  '[role="treeitem"]',
+].join(',');
+
 // 插入失败提示并处理错误
 export function insertFailedTip(
   node: HTMLElement,
   errMsg: string,
   onRetry: () => void,
 ): HTMLElement {
+  const contextInvalidated = isExtensionContextInvalidated(errMsg);
+  const keyboardAccessible = node.closest(INTERACTIVE_HOST_SELECTOR) === null;
   // 创建包装元素
   const wrapper = document.createElement("span");
   wrapper.classList.add("fluent-read-retry-wrapper");
   wrapper.setAttribute("data-fr-translation-owned", "true");
+  wrapper.setAttribute("role", "group");
+  wrapper.setAttribute("aria-label", "翻译失败操作");
+  wrapper.addEventListener("click", blockHostLinkActivation);
+  wrapper.addEventListener("auxclick", blockHostLinkActivation);
 
   // 创建重试按钮
-  const retryBtn = document.createElement("span");
-  retryBtn.textContent = '重试';
-  retryBtn.classList.add("fluent-read-retry");
-  retryBtn.addEventListener("click", handleRetryClick(node, wrapper, onRetry));
+  const retryBtn = createActionElement(
+    '重试',
+    'fluent-read-retry',
+    icon.retry,
+    contextInvalidated
+      ? handleInvalidatedRetryClick(errMsg)
+      : handleRetryClick(node, wrapper, onRetry),
+    keyboardAccessible,
+  );
 
   // 添加失败标记
   node.classList.add("fluent-read-failure");
 
   // 创建错误信息提示按钮
-  const errorTip = document.createElement("span");
-  errorTip.textContent = '错误原因';
-  errorTip.classList.add("fluent-read-reason");
-  errorTip.addEventListener("click", handleErrorClick(errMsg));
-
-  // 创建图标元素
-  const retryElement = createIconElement(icon.retry);
-  const warnElement = createIconElement(icon.warn);
+  const errorTip = createActionElement(
+    '错误原因',
+    'fluent-read-reason',
+    icon.warn,
+    handleErrorClick(errMsg),
+    keyboardAccessible,
+  );
 
   // 将所有元素批量添加到 wrapper
-  wrapper.append(retryElement, retryBtn, warnElement, errorTip);
+  wrapper.append(retryBtn, errorTip);
   node.appendChild(wrapper);
   return wrapper;
+}
+
+function isExtensionContextInvalidated(message: string): boolean {
+  return message.toLowerCase().includes('extension context invalidated');
+}
+
+// 失败控件可能位于宿主 <a> 内；任何未命中具体按钮的点击也不能触发链接默认行为。
+function blockHostLinkActivation(event: Event): void {
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function createActionElement(
+  label: string,
+  className: string,
+  iconContent: string,
+  onClick: (event: MouseEvent) => void,
+  keyboardAccessible: boolean,
+): HTMLElement {
+  const action = document.createElement('span');
+  action.classList.add('fluent-read-failure-action', className);
+
+  const actionIcon = createIconElement(iconContent);
+  actionIcon.classList.add('fluent-read-action-icon');
+  const actionLabel = document.createElement('span');
+  actionLabel.classList.add('fluent-read-action-label');
+  actionLabel.textContent = label;
+  action.append(actionIcon, actionLabel);
+  action.addEventListener('click', onClick);
+  if (keyboardAccessible) {
+    action.setAttribute('role', 'button');
+    action.setAttribute('tabindex', '0');
+    action.setAttribute('aria-label', label);
+    action.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      event.preventDefault();
+      event.stopPropagation();
+      action.click();
+    });
+  }
+  return action;
 }
 
 // 处理重试按钮点击事件
@@ -68,6 +140,14 @@ function handleRetryClick(node: HTMLElement, wrapper: HTMLElement, onRetry: () =
   };
 }
 
+function handleInvalidatedRetryClick(errMsg: string) {
+  return (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    showPageNotice(resolveErrorMessage(errMsg), 'error');
+  };
+}
+
 // 处理错误提示按钮点击事件
 function handleErrorClick(errMsg: string) {
   return (event: MouseEvent) => {
@@ -75,7 +155,8 @@ function handleErrorClick(errMsg: string) {
     event.stopPropagation();
 
     const message = resolveErrorMessage(errMsg);
-    sendErrorMessage(message); // 发送错误提示
+    // 用户显式点击必须每次都有反馈；自动批量错误才使用节流通知。
+    showPageNotice(message, 'error');
   };
 }
 

--- a/src/features/page-notice/content/notice.css
+++ b/src/features/page-notice/content/notice.css
@@ -71,6 +71,18 @@
     object-fit: cover;
 }
 
+.notice-mark-fallback {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    background: linear-gradient(135deg, #ed5d87, #d83263);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, .28);
+    font-size: 15px;
+    font-weight: 850;
+    line-height: 1;
+}
+
 .notice-copy {
     display: flex;
     width: 0;

--- a/src/features/page-notice/content/notice.ts
+++ b/src/features/page-notice/content/notice.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/features/page-notice/content/notice.ts
  * 文件职责：在任意宿主页面的隔离 Shadow Root 中显示 FluentRead 成功或错误通知，并把缺少 API 凭据的错误转换为可直接前往设置的提醒。
- * 主要内容：包含凭据文案识别、通知标题与详情生成、宿主抗样式污染、堆栈复用、进入/离场计时和关闭按钮，导出 showPageNotice 与一秒节流的 sendErrorMessage。
+ * 主要内容：包含凭据文案识别、通知标题与详情生成、扩展上下文失效时的本地品牌占位、宿主抗样式污染、堆栈复用、进入/离场计时和关闭按钮，导出 showPageNotice 与一秒节流的 sendErrorMessage。
  * 模块边界：本文件只拥有通知 DOM 和打开设置消息，不记录凭据、不处理翻译重试；外观来自 notice.css，后台 openOptions handler 处理导航，调用方传入的文本一律通过 textContent 展示。
  */
 import {throttle} from '@/src/shared/function/throttle';
@@ -46,6 +46,36 @@ function getNoticeTitle(type: NoticeType, credential: boolean): string {
 function getNoticeDetail(message: string, missingCredential: MissingCredentialNotice | null): string {
     if (!missingCredential) return message;
     return `还差一步：为 ${missingCredential.service} 填写 ${missingCredential.credentialLabel}，就可以开始翻译了。`;
+}
+
+function resolveNoticeIconUrl(): string | null {
+    try {
+        if (typeof browser === 'undefined') return null;
+        const runtime = browser.runtime;
+        if (typeof runtime?.getURL !== 'function') return null;
+        const url = runtime.getURL('/icon/48.png');
+        return typeof url === 'string' && url ? url : null;
+    } catch {
+        // 扩展更新后旧内容脚本仍可能存活；通知必须继续可见，提醒用户刷新页面。
+        return null;
+    }
+}
+
+function createNoticeMark(): HTMLElement {
+    const iconUrl = resolveNoticeIconUrl();
+    if (iconUrl) {
+        const mark = document.createElement('img');
+        mark.className = 'notice-mark';
+        mark.src = iconUrl;
+        mark.alt = '流畅阅读';
+        return mark;
+    }
+
+    const fallback = document.createElement('span');
+    fallback.className = 'notice-mark notice-mark-fallback';
+    fallback.setAttribute('aria-hidden', 'true');
+    fallback.textContent = '流';
+    return fallback;
 }
 
 function applyHostStyles(host: HTMLElement): void {
@@ -142,10 +172,7 @@ export function showPageNotice(message: string, type: NoticeType): HTMLElement {
     notice.setAttribute('role', 'alert');
     notice.setAttribute('aria-atomic', 'true');
 
-    const mark = document.createElement('img');
-    mark.className = 'notice-mark';
-    mark.src = browser.runtime.getURL('/icon/48.png');
-    mark.alt = '流畅阅读';
+    const mark = createNoticeMark();
 
     const copy = document.createElement('span');
     copy.className = 'notice-copy';
@@ -164,9 +191,15 @@ export function showPageNotice(message: string, type: NoticeType): HTMLElement {
         action.type = 'button';
         action.textContent = '去设置';
         action.addEventListener('click', () => {
-            void browser.runtime.sendMessage({type: 'openOptionsPage'}).catch((error: unknown) => {
+            const reportFailure = (error: unknown) => {
                 console.error('[FluentRead] 打开设置页失败', error);
-            });
+            };
+            try {
+                void Promise.resolve(browser.runtime.sendMessage({type: 'openOptionsPage'}))
+                    .catch(reportFailure);
+            } catch (error) {
+                reportFailure(error);
+            }
         });
         body.appendChild(action);
     }

--- a/src/services/translation/errors.ts
+++ b/src/services/translation/errors.ts
@@ -2,7 +2,7 @@
  * @file src/services/translation/errors.ts
  *
  * 文件职责：建立翻译请求跨 runtime 消息边界的结构化错误协议，保留类型、重试性、状态码和安全详情。
- * 主要内容：定义 SerializedTranslationError 与 TranslationRequestError，负责 serialize、类型守卫、响应 unwrap 和 retryable 判定，避免原生 Error 在浏览器消息传递中丢失语义。 可核对的公开符号包括 TranslationErrorKind、TRANSLATION_ERROR_MARKER、SerializedTranslationError、serializeTranslationError、isSerializedTranslationError、TranslationRequestError、unwrapTranslationResponse、isRetryableTranslationError。
+ * 主要内容：定义 SerializedTranslationError 与 TranslationRequestError，负责 serialize、类型守卫、响应 unwrap 和 retryable 判定，并把不可恢复的扩展上下文失效排除出自动重试，避免原生 Error 在浏览器消息传递中丢失语义。 可核对的公开符号包括 TranslationErrorKind、TRANSLATION_ERROR_MARKER、SerializedTranslationError、serializeTranslationError、isSerializedTranslationError、TranslationRequestError、unwrapTranslationResponse、isRetryableTranslationError。
  * 模块边界：本文件位于翻译 application service 层，负责用例编排和端口契约；不挂载页面 UI，且不应把某家供应商的网络细节扩散到 feature，具体 HTTP 协议由 providers/platform 实现。
  */
 
@@ -49,6 +49,9 @@ function optionalString(value: unknown): string | undefined {
 
 function classifyMessage(message: string): Pick<SerializedTranslationError, 'kind' | 'retryable'> {
   const normalized = message.toLowerCase();
+  if (normalized.includes('extension context invalidated')) {
+    return {kind: 'unknown', retryable: false};
+  }
   if (/429|rate.?limit|quota|频率|配额/u.test(normalized)) {
     return {kind: 'rate-limit', retryable: true};
   }
@@ -128,5 +131,9 @@ export function unwrapTranslationResponse<T>(value: unknown): T {
 }
 
 export function isRetryableTranslationError(error: unknown): boolean {
-  return !(error instanceof TranslationRequestError) || error.retryable;
+  if (error instanceof TranslationRequestError) return error.retryable;
+  const message = error instanceof Error
+    ? error.message
+    : typeof error === 'string' ? error : '';
+  return !message.toLowerCase().includes('extension context invalidated');
 }

--- a/tests/fixtures/unified-translation-fixture.html
+++ b/tests/fixtures/unified-translation-fixture.html
@@ -17,6 +17,17 @@
       -webkit-line-clamp: 2;
     }
     .model-description-clamp p { margin: 0; }
+    #translation-error-link {
+      display: block;
+      margin: 18px 0;
+      padding: 12px 14px;
+      border: 1px solid #b8c4d6;
+      border-radius: 10px;
+      color: #8f2f5e;
+      background: #f7f9fc;
+      font: 700 20px/1.35 Georgia, serif;
+      text-decoration: underline wavy currentColor 1px;
+    }
   </style>
 </head>
 <body>
@@ -40,6 +51,12 @@
       <button id="save-button"><span aria-hidden="true">★</span><span>Save changes</span></button>
       <button id="cancel-button">Cancel</button>
     </div>
+    <a
+      id="translation-error-link"
+      href="#translation-error-destination"
+      hidden
+    >This block link fails once so its translation error actions can be verified without leaving the page.</a>
+    <span id="translation-error-destination" hidden></span>
     <section id="dynamic-container"></section>
     <div id="shadow-host"></div>
   </main>
@@ -48,6 +65,10 @@
     const host = document.querySelector('#shadow-host');
     const shadow = host.attachShadow({ mode: 'open' });
     shadow.innerHTML = '<p id="shadow-paragraph">This paragraph lives inside an open shadow root.</p>';
+    window.__fluentReadFailureLinkActivations = 0;
+    document.querySelector('#translation-error-link').addEventListener('click', () => {
+      window.__fluentReadFailureLinkActivations += 1;
+    });
   </script>
 </body>
 </html>

--- a/tests/fullPageTranslationErrorMessage.test.ts
+++ b/tests/fullPageTranslationErrorMessage.test.ts
@@ -29,6 +29,7 @@ describe('全文翻译错误文案', () => {
     ['timeout', '请求超时啦，请稍后再试一次。'],
     ['timed out', '请求超时啦，请稍后再试一次。'],
     ['请求超时', '请求超时啦，请稍后再试一次。'],
+    ['Extension context invalidated.', '扩展已更新或重新加载，请刷新当前页面后再试。'],
     ['provider unavailable', 'provider unavailable'],
     ['', '出现了未知错误，请前往开源社区联系开发者吧~'],
   ])('归类 %s', (message, expected) => {

--- a/tests/fullPageTranslationIndicators.test.ts
+++ b/tests/fullPageTranslationIndicators.test.ts
@@ -3,14 +3,14 @@ import {parseHTML} from 'linkedom';
 
 const mocks = vi.hoisted(() => ({
   config: {animations: true, service: 'deepseek'},
-  sendErrorMessage: vi.fn(),
+  showPageNotice: vi.fn(),
 }));
 
 vi.mock('@/src/services/config/store', () => ({config: mocks.config}));
 vi.mock('@/src/core/config/catalog', () => ({
   options: {services: [{value: 'deepseek', label: 'DeepSeek'}]},
 }));
-vi.mock('@/src/features/page-notice/public', () => ({sendErrorMessage: mocks.sendErrorMessage}));
+vi.mock('@/src/features/page-notice/public', () => ({showPageNotice: mocks.showPageNotice}));
 
 import {
   insertFailedTip,
@@ -20,13 +20,28 @@ import {
 const originalDocument = globalThis.document;
 const originalWindow = globalThis.window;
 
+function dispatchCancelableClick(target: Element): Event {
+  const EventConstructor = (window as unknown as {Event: typeof Event}).Event;
+  const event = new EventConstructor('click', {bubbles: true, cancelable: true});
+  target.dispatchEvent(event);
+  return event;
+}
+
+function dispatchActionKey(target: Element, key: 'Enter' | ' '): Event {
+  const EventConstructor = (window as unknown as {Event: typeof Event}).Event;
+  const event = new EventConstructor('keydown', {bubbles: true, cancelable: true});
+  Object.defineProperty(event, 'key', {value: key});
+  target.dispatchEvent(event);
+  return event;
+}
+
 beforeEach(() => {
   const {document, window} = parseHTML('<html><body><p id="target">Source</p></body></html>');
   Object.defineProperty(globalThis, 'document', {value: document, configurable: true});
   Object.defineProperty(globalThis, 'window', {value: window, configurable: true});
   mocks.config.animations = true;
   mocks.config.service = 'deepseek';
-  mocks.sendErrorMessage.mockReset();
+  mocks.showPageNotice.mockReset();
 });
 
 afterEach(() => {
@@ -45,14 +60,99 @@ describe('全文翻译节点状态指示', () => {
     expect(wrapper.getAttribute('data-fr-translation-owned')).toBe('true');
     expect(wrapper.querySelectorAll('svg')).toHaveLength(2);
     wrapper.querySelector<HTMLElement>('.fluent-read-reason')!.click();
-    expect(mocks.sendErrorMessage).toHaveBeenCalledWith(
+    expect(mocks.showPageNotice).toHaveBeenCalledWith(
       '你的请求频率过高，被【DeepSeek】拒绝了，请稍后再试吧~',
+      'error',
     );
 
     wrapper.querySelector<HTMLElement>('.fluent-read-retry')!.click();
     expect(retry).toHaveBeenCalledOnce();
     expect(wrapper.isConnected).toBe(false);
     expect(target.classList.contains('fluent-read-failure')).toBe(false);
+  });
+
+  it('链接翻译失败时，错误图标和控件空白处只显示提示而不触发原链接', () => {
+    document.body.innerHTML = '<a id="target" href="https://example.com/destination">Source</a>';
+    const target = document.getElementById('target')!;
+    const hostLinkClick = vi.fn();
+    target.addEventListener('click', hostLinkClick);
+
+    const wrapper = insertFailedTip(target, 'quota exceeded', vi.fn());
+    const reason = wrapper.querySelector<HTMLElement>('.fluent-read-reason')!;
+    const reasonIcon = reason.querySelector('svg')!;
+
+    const iconClick = dispatchCancelableClick(reasonIcon);
+    const wrapperClick = dispatchCancelableClick(wrapper);
+
+    expect(reason.getAttribute('role')).toBeNull();
+    expect(reason.getAttribute('tabindex')).toBeNull();
+    expect(iconClick.defaultPrevented).toBe(true);
+    expect(wrapperClick.defaultPrevented).toBe(true);
+    expect(hostLinkClick).not.toHaveBeenCalled();
+    expect(mocks.showPageNotice).toHaveBeenCalledOnce();
+  });
+
+  it('链接翻译失败时，点击重试图标不会触发原链接', () => {
+    document.body.innerHTML = '<a id="target" href="https://example.com/destination">Source</a>';
+    const target = document.getElementById('target')!;
+    const hostLinkClick = vi.fn();
+    const retry = vi.fn();
+    target.addEventListener('click', hostLinkClick);
+
+    const wrapper = insertFailedTip(target, 'provider unavailable', retry);
+    const retryAction = wrapper.querySelector<HTMLElement>('.fluent-read-retry')!;
+    const retryIcon = retryAction.querySelector('svg')!;
+    const iconClick = dispatchCancelableClick(retryIcon);
+
+    expect(retryAction.getAttribute('role')).toBeNull();
+    expect(retryAction.getAttribute('tabindex')).toBeNull();
+    expect(iconClick.defaultPrevented).toBe(true);
+    expect(hostLinkClick).not.toHaveBeenCalled();
+    expect(retry).toHaveBeenCalledOnce();
+    expect(wrapper.isConnected).toBe(false);
+  });
+
+  it('交互宿主内不创建嵌套的可聚焦按钮语义', () => {
+    document.body.innerHTML = '<button id="target" type="button">Source</button>';
+    const target = document.getElementById('target')!;
+    const hostButtonClick = vi.fn();
+    target.addEventListener('click', hostButtonClick);
+
+    const wrapper = insertFailedTip(target, 'provider unavailable', vi.fn());
+    const reason = wrapper.querySelector<HTMLElement>('.fluent-read-reason')!;
+    const click = dispatchCancelableClick(reason);
+
+    expect(reason.getAttribute('role')).toBeNull();
+    expect(reason.getAttribute('tabindex')).toBeNull();
+    expect(click.defaultPrevented).toBe(true);
+    expect(hostButtonClick).not.toHaveBeenCalled();
+    expect(mocks.showPageNotice).toHaveBeenCalledOnce();
+  });
+
+  it('失败操作支持键盘，并让扩展上下文失效的重试保留刷新提示', () => {
+    const target = document.getElementById('target')!;
+    const retry = vi.fn();
+    const wrapper = insertFailedTip(target, 'Extension context invalidated.', retry);
+    const retryAction = wrapper.querySelector<HTMLElement>('.fluent-read-retry')!;
+    const reasonAction = wrapper.querySelector<HTMLElement>('.fluent-read-reason')!;
+
+    expect(retryAction.getAttribute('role')).toBe('button');
+    expect(retryAction.getAttribute('tabindex')).toBe('0');
+    expect(reasonAction.getAttribute('role')).toBe('button');
+    expect(reasonAction.getAttribute('tabindex')).toBe('0');
+
+    const retryKey = dispatchActionKey(retryAction, 'Enter');
+    const reasonKey = dispatchActionKey(reasonAction, ' ');
+
+    expect(retryKey.defaultPrevented).toBe(true);
+    expect(reasonKey.defaultPrevented).toBe(true);
+    expect(retry).not.toHaveBeenCalled();
+    expect(wrapper.isConnected).toBe(true);
+    expect(mocks.showPageNotice).toHaveBeenCalledTimes(2);
+    expect(mocks.showPageNotice).toHaveBeenLastCalledWith(
+      '扩展已更新或重新加载，请刷新当前页面后再试。',
+      'error',
+    );
   });
 
   it('加载指示区分缓存命中，并尊重动画配置', async () => {

--- a/tests/fullPageVisibilityScheduling.test.ts
+++ b/tests/fullPageVisibilityScheduling.test.ts
@@ -1573,6 +1573,38 @@ describe("全文翻译可见性锚点", () => {
         expect(paragraph.textContent).toBe("译:Retry with the latest display mode.");
     });
 
+    it("行内片段首次失败后会从原始候选恢复并完成手动重试", async () => {
+        runtime.config.display = 1;
+        document.body.innerHTML = '<p id="prose">Inline retry source <strong>keeps structure</strong>.</p>';
+        const paragraph = document.querySelector<HTMLElement>("#prose")!;
+        const inlineSource = paragraph.firstChild as Text;
+        runtime.candidates = [{
+            element: paragraph,
+            kind: "content",
+            reason: "generic-inline-run",
+            nodes: [inlineSource],
+        }];
+        runtime.requests.mockRejectedValueOnce(new Error("provider unavailable"));
+
+        handleBilingualTranslation(paragraph, false);
+        await finishScheduledWork();
+
+        const failedSegment = paragraph.querySelector<HTMLElement>('[data-fr-translation-segment="true"]')!;
+        expect(getTranslationState(failedSegment)?.phase).toBe("error");
+        expect(runtime.retryCallbacks).toHaveLength(1);
+
+        runtime.retryCallbacks[0]!();
+        await finishScheduledWork();
+
+        const translatedSegment = paragraph.querySelector<HTMLElement>('[data-fr-translation-segment="true"]')!;
+        expect(runtime.requests).toHaveBeenCalledTimes(2);
+        expect(failedSegment.isConnected).toBe(false);
+        expect(getTranslationState(translatedSegment)?.phase).toBe("translated");
+        expect(translatedSegment.querySelector(".fluent-read-bilingual-content")?.textContent)
+            .toBe("译:Inline retry source ");
+        expect(paragraph.querySelector("strong")?.textContent).toBe("keeps structure");
+    });
+
     it.each(["translate-no", "hidden"] as const)(
         "全文会话登记启动前 hover 状态的祖先索引，新增 %s 会恢复且 stop 后不再响应",
         async (guard) => {

--- a/tests/pageNotice.test.ts
+++ b/tests/pageNotice.test.ts
@@ -64,6 +64,27 @@ describe('page error notice', () => {
         expect(notice.classList.contains('is-visible')).toBe(true);
     });
 
+    it('扩展上下文失效时仍显示错误详情，并使用本地品牌占位', async () => {
+        Object.defineProperty(globalThis, 'browser', {
+            value: {
+                runtime: {
+                    getURL: () => {
+                        throw new Error('Extension context invalidated.');
+                    },
+                    sendMessage,
+                },
+            },
+            configurable: true,
+        });
+
+        expect(() => showPageNotice('扩展已更新，请刷新当前页面后重试。', 'error')).not.toThrow();
+        await Promise.resolve();
+
+        const shadow = document.getElementById('fluent-read-page-notice-host')!.shadowRoot!;
+        expect(shadow.querySelector('.notice-detail')?.textContent).toContain('请刷新当前页面');
+        expect(shadow.querySelector('.notice-mark-fallback')?.textContent).toBe('流');
+    });
+
     it('keeps credential guidance interactive inside the isolated notice', async () => {
         showPageNotice('DeepSeek 需要 API Key（访问令牌），当前尚未配置', 'error');
         await Promise.resolve();

--- a/tests/translateApiPerformance.test.ts
+++ b/tests/translateApiPerformance.test.ts
@@ -340,6 +340,16 @@ describe('translation API request lifecycle performance', () => {
     expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
   });
 
+  it('扩展上下文失效时立即失败，不进入无效的传输重试', async () => {
+    mocks.sendMessage.mockRejectedValue(new Error('Extension context invalidated.'));
+
+    await expect(translateText('Readable source', 'Context', {retryDelay: 100}))
+      .rejects.toThrow('Extension context invalidated.');
+
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('aborts a retry delay without sending another runtime request', async () => {
     mocks.sendMessage.mockRejectedValue(new Error('temporary failure'));
     const controller = new AbortController();

--- a/tests/translationError.test.ts
+++ b/tests/translationError.test.ts
@@ -25,6 +25,7 @@ describe('translation error serialization', () => {
   it.each([
     ['request timed out', 'timeout', true],
     ['NetworkError while fetching', 'network', true],
+    ['Extension context invalidated.', 'unknown', false],
     ['HTTP 400 invalid request', 'bad-request', false],
     ['HTTP 503 service unavailable', 'provider', true],
     ['unexpected provider reply', 'unknown', true],
@@ -115,6 +116,9 @@ describe('translation error serialization', () => {
     }
 
     expect(isRetryableTranslationError(new Error('legacy failure'))).toBe(true);
+    expect(isRetryableTranslationError(new Error('Extension context invalidated.'))).toBe(false);
+    expect(isRetryableTranslationError('Extension context invalidated.')).toBe(false);
+    expect(isRetryableTranslationError(null)).toBe(true);
     expect(isRetryableTranslationError(new TranslationRequestError(
       serializeTranslationError('network error'),
     ))).toBe(true);


### PR DESCRIPTION
## Summary\n\n- make the full Retry and Error reason pills clickable, including their icons, while preventing host links from navigating\n- show explicit error details without notification throttling and keep notices usable after an extension context reload\n- retry the original translation candidate so synthetic inline failures can recover correctly\n- harden failure-action styling against host page CSS and preserve keyboard semantics outside interactive hosts\n- add focused unit, regression, performance, notice, and isolated-browser coverage\n\n## Verification\n\n- pnpm test: 149 files, 2084 tests passed\n- pnpm test:coverage: 109 files, 1517 tests; statements, branches, functions, and lines all 100%\n- pnpm compile\n- pnpm build\n- pnpm build:firefox\n- pnpm test:userscript\n- pnpm verify:extension-manifests\n- git diff --check\n- isolated background Edge production build: error reason displayed an alert, retry succeeded on attempt 2, link activation stayed 0, URL and href stayed unchanged, with no console errors or unexpected network requests\n\nFirefox verification is build-only; the interaction proof uses an isolated deterministic loopback fixture in Edge.