### PR TITLE
feat: 重组翻译服务目录

### DIFF
--- a/scripts/testing/run-service-catalog-ui-test.cjs
+++ b/scripts/testing/run-service-catalog-ui-test.cjs
@@ -1,0 +1,239 @@
+'use strict';
+
+/**
+ * @file scripts/testing/run-service-catalog-ui-test.cjs
+ * 文件职责：在屏幕外隔离 Edge 中验证翻译服务目录的二级分类、顺序、折叠、搜索与响应式布局。
+ * 主要内容：加载生产扩展，检查模型服务商和聚合平台清单，覆盖机器翻译手动折叠、搜索自动展开、编辑状态与窄屏无横向溢出。
+ * 模块边界：脚本只操作本次创建的临时浏览器 profile，不访问用户日常浏览器，也不修改扩展持久配置或调用翻译服务。
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function argument(name, fallback) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : fallback;
+}
+
+const extensionDir = path.resolve(argument('extension-dir', '.output/chrome-mv3'));
+const playwrightRoot = path.resolve(argument('playwright-root', ''));
+const focusSafeHelper = path.resolve(argument('focus-safe-helper', ''));
+const artifactsDir = path.resolve(argument('artifacts-dir', '/private/tmp/fluentread-service-catalog-ui'));
+const browserPath = argument('browser-path', '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge');
+const timeout = Number(argument('timeout', '30000'));
+
+const expectedProviderServices = [
+  'deepseek', 'tongyi', 'doubao', 'moonshot', 'zhipu', 'huanYuan',
+  'huanYuanTranslation', 'yiyan', 'minimax', 'mimo', 'jieyue', 'openai',
+  'gemini', 'claude', 'grok',
+];
+const expectedPlatformServices = [
+  'siliconCloud', 'newapi', 'infini', 'openrouter', 'groq', 'azureOpenai', 'custom',
+];
+const expectedMachineServices = [
+  'freeTranslation', 'microsoft', 'google', 'deepL', 'deeplx', 'xiaoniu', 'youdao', 'tencent',
+];
+
+if (!fs.existsSync(path.join(extensionDir, 'manifest.json'))) throw new Error(`扩展产物不存在：${extensionDir}`);
+if (!fs.existsSync(focusSafeHelper)) throw new Error(`防抢焦点 helper 不存在：${focusSafeHelper}`);
+fs.mkdirSync(artifactsDir, {recursive: true});
+
+const {chromium} = require(path.join(playwrightRoot, 'playwright'));
+const {
+  launchFocusSafePersistentContext,
+  newPageWithoutForeground,
+} = require(focusSafeHelper);
+
+async function screenshot(page, file, report) {
+  const target = path.join(artifactsDir, file);
+  await page.screenshot({path: target, fullPage: false});
+  report.screenshots.push(target);
+}
+
+function assertSameOrder(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${label}分类或顺序异常：${JSON.stringify(actual)}`);
+  }
+}
+
+async function main() {
+  const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fluentread-service-catalog-profile-'));
+  const consoleErrors = [];
+  const report = {
+    extensionDir,
+    artifactsDir,
+    launchMode: null,
+    focusPolicy: null,
+    windowPlacement: null,
+    manifest: {},
+    serviceGroups: {},
+    collapse: {},
+    responsive: [],
+    consoleErrors,
+    screenshots: [],
+  };
+  let launched;
+
+  try {
+    const manifest = JSON.parse(fs.readFileSync(path.join(extensionDir, 'manifest.json'), 'utf8'));
+    report.manifest = {
+      popup: manifest.action?.default_popup || manifest.browser_action?.default_popup || '',
+      options: manifest.options_ui?.page || manifest.options_page || '',
+    };
+    if (!report.manifest.popup || !report.manifest.options) throw new Error('扩展清单缺少 popup 或 options 入口');
+
+    launched = await launchFocusSafePersistentContext({
+      chromium,
+      profileDir,
+      browserPath,
+      headless: false,
+      background: true,
+      browserArgs: [
+        `--disable-extensions-except=${extensionDir}`,
+        `--load-extension=${extensionDir}`,
+        '--no-first-run',
+        '--no-default-browser-check',
+      ],
+      viewport: {width: 1440, height: 1000},
+      timeout,
+    });
+    report.launchMode = launched.launchMode;
+    report.focusPolicy = launched.focusPolicy;
+    report.windowPlacement = launched.windowPlacement;
+
+    const {context} = launched;
+    let workers = context.serviceWorkers().filter(worker => worker.url().startsWith('chrome-extension://'));
+    if (workers.length === 0) workers = [await context.waitForEvent('serviceworker', {timeout})];
+    const extensionOrigin = `chrome-extension://${new URL(workers[0].url()).host}`;
+    const page = await newPageWithoutForeground(context, timeout);
+    page.on('pageerror', error => consoleErrors.push(`pageerror: ${error.message}`));
+    page.on('console', message => {
+      if (message.type() === 'error') consoleErrors.push(`console: ${message.text()}`);
+    });
+
+    await page.goto(`${extensionOrigin}/options.html#settings-services`, {waitUntil: 'domcontentloaded', timeout});
+    await page.setViewportSize({width: 1440, height: 1000});
+    const catalog = page.locator('.service-catalog');
+    await catalog.waitFor({state: 'visible', timeout});
+
+    const topLevelGroups = (await catalog.locator('.group-heading strong').allTextContents()).map(value => value.trim());
+    assertSameOrder(topLevelGroups, ['机器翻译', 'AI翻译'], '顶层服务');
+    const subgroupLabels = (await catalog.locator('.subgroup-heading strong').allTextContents()).map(value => value.trim());
+    assertSameOrder(subgroupLabels, ['模型服务商', '聚合平台与接口'], 'AI 二级');
+
+    const providerServices = await catalog
+      .locator('[data-service-subgroup="ai-providers"] .service-item')
+      .evaluateAll(items => items.map(item => item.getAttribute('data-service-value')));
+    const platformServices = await catalog
+      .locator('[data-service-subgroup="ai-platforms"] .service-item')
+      .evaluateAll(items => items.map(item => item.getAttribute('data-service-value')));
+    assertSameOrder(providerServices, expectedProviderServices, '模型服务商');
+    assertSameOrder(platformServices, expectedPlatformServices, '聚合平台');
+    const machineGroup = catalog.locator('[data-service-section="machine"]');
+    const serviceItems = catalog.locator('.service-item');
+    const machineServices = await machineGroup.locator('.service-item')
+      .evaluateAll(items => items.map(item => item.getAttribute('data-service-value')));
+    const chromeMachineServices = [...expectedMachineServices, 'chromeTranslator'];
+    if (JSON.stringify(machineServices) !== JSON.stringify(expectedMachineServices)
+      && JSON.stringify(machineServices) !== JSON.stringify(chromeMachineServices)) {
+      throw new Error(`机器翻译分类或顺序异常：${JSON.stringify(machineServices)}`);
+    }
+    if (await serviceItems.count() !== machineServices.length + expectedProviderServices.length + expectedPlatformServices.length) {
+      throw new Error(`服务项数量异常：机器翻译 ${machineServices.length}，全部 ${await serviceItems.count()}`);
+    }
+    report.serviceGroups = {topLevelGroups, subgroupLabels, machineServices, providerServices, platformServices};
+    if (await serviceItems.locator('.service-brand-icon svg').count() !== await serviceItems.count()) {
+      throw new Error('服务列表存在未渲染的本地图标');
+    }
+
+    const defaultService = await catalog.getAttribute('data-default-service');
+    const machineToggle = machineGroup.locator('[data-service-section-toggle="machine"]');
+    if (await machineToggle.getAttribute('aria-expanded') !== 'true') {
+      throw new Error(`默认机器翻译服务没有自动展开：${defaultService}`);
+    }
+    const defaultItem = catalog.locator(`.service-item[data-service-value="${defaultService}"]`);
+    if (await defaultItem.count() !== 1 || !await defaultItem.isVisible()) throw new Error('当前默认服务没有保持可见');
+
+    await machineToggle.click();
+    if (await machineToggle.getAttribute('aria-expanded') !== 'false'
+      || await machineGroup.locator('.service-item').first().isVisible()) {
+      throw new Error('机器翻译分组无法收起');
+    }
+    await screenshot(page, 'service-catalog-machine-collapsed.png', report);
+
+    const serviceSearch = catalog.getByPlaceholder('搜索翻译服务');
+    await serviceSearch.fill('微软翻译');
+    await machineGroup.locator('.service-item[data-service-value="microsoft"]').waitFor({state: 'visible', timeout});
+    if (await machineToggle.getAttribute('aria-expanded') !== 'true') throw new Error('搜索机器翻译时没有自动展开分组');
+    if (!await machineToggle.isDisabled()) throw new Error('搜索期间机器翻译折叠按钮仍可操作');
+    await serviceSearch.fill('');
+    await machineGroup.locator('.service-item').first().waitFor({state: 'hidden', timeout});
+    if (await machineToggle.getAttribute('aria-expanded') !== 'false') throw new Error('清空搜索后没有恢复手动折叠状态');
+    if (await machineToggle.isDisabled()) throw new Error('清空搜索后机器翻译折叠按钮没有恢复可用');
+
+    const deepSeekItem = catalog.locator('.service-item[data-service-value="deepseek"]');
+    await deepSeekItem.click();
+    await page.waitForFunction(() => document.querySelector('.service-catalog')?.getAttribute('data-editing-service') === 'deepseek', null, {timeout});
+    if (await catalog.getAttribute('data-default-service') !== defaultService) throw new Error('切换编辑服务时误改默认服务');
+    if (await machineToggle.getAttribute('aria-expanded') !== 'false') throw new Error('选择 AI 服务后覆盖了用户的机器翻译折叠状态');
+    if (!await catalog.getByText('正在配置', {exact: true}).isVisible()) throw new Error('非默认服务没有显示正在配置状态');
+    await screenshot(page, 'service-catalog-providers.png', report);
+
+    const platformHeading = catalog.locator('[data-service-subgroup="ai-platforms"] .subgroup-heading');
+    await platformHeading.scrollIntoViewIfNeeded();
+    await screenshot(page, 'service-catalog-platforms.png', report);
+
+    await serviceSearch.fill('New API');
+    const visibleSearchItems = catalog.locator('.service-item:visible');
+    if (await visibleSearchItems.count() !== 1
+      || await visibleSearchItems.first().getAttribute('data-service-value') !== 'newapi') {
+      throw new Error('聚合平台搜索结果不唯一或不正确');
+    }
+    await serviceSearch.fill('');
+
+    report.collapse = {
+      defaultService,
+      currentMachineServiceAutoExpanded: true,
+      manualCollapse: true,
+      searchAutoExpanded: true,
+      clearSearchRestoredCollapse: true,
+      aiSelectionPreservedCollapse: true,
+    };
+
+    for (const viewport of [
+      {width: 820, height: 900},
+      {width: 390, height: 844},
+    ]) {
+      await page.setViewportSize(viewport);
+      await page.waitForTimeout(150);
+      const metrics = await page.evaluate(() => ({
+        horizontalOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+        catalogWidth: Math.round(document.querySelector('.service-catalog')?.getBoundingClientRect().width || 0),
+        viewportWidth: window.innerWidth,
+        serviceRailOverflow: (() => {
+          const rail = document.querySelector('.service-rail');
+          return rail ? rail.scrollHeight > rail.clientHeight : false;
+        })(),
+      }));
+      if (metrics.horizontalOverflow || metrics.catalogWidth > metrics.viewportWidth + 1) {
+        throw new Error(`${viewport.width}px 服务目录横向溢出：${JSON.stringify(metrics)}`);
+      }
+      report.responsive.push({...viewport, ...metrics});
+      await screenshot(page, `service-catalog-${viewport.width}.png`, report);
+    }
+
+    if (consoleErrors.length) throw new Error(`浏览器控制台存在错误：${consoleErrors.join(' | ')}`);
+  } finally {
+    fs.writeFileSync(path.join(artifactsDir, 'report.json'), JSON.stringify(report, null, 2));
+    await launched?.close();
+    fs.rmSync(profileDir, {recursive: true, force: true});
+  }
+
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+
+main().catch(error => {
+  process.stderr.write(`${error.stack || error}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/testing/run-settings-center-ui-test.cjs
+++ b/scripts/testing/run-settings-center-ui-test.cjs
@@ -930,6 +930,61 @@ async function main() {
       || serviceOnlyMetrics.defaultService !== defaultServiceMetrics.defaultService) {
       throw new Error(`翻译服务页不是纯服务目录：${JSON.stringify(serviceOnlyMetrics)}`);
     }
+    const expectedProviderServices = [
+      'deepseek', 'tongyi', 'doubao', 'moonshot', 'zhipu', 'huanYuan',
+      'huanYuanTranslation', 'yiyan', 'minimax', 'mimo', 'jieyue', 'openai',
+      'gemini', 'claude', 'grok',
+    ];
+    const expectedPlatformServices = [
+      'siliconCloud', 'newapi', 'infini', 'openrouter', 'groq', 'azureOpenai', 'custom',
+    ];
+    const expectedMachineServices = [
+      'freeTranslation', 'microsoft', 'google', 'deepL', 'deeplx', 'xiaoniu', 'youdao', 'tencent',
+    ];
+    const providerServices = await serviceCatalog
+      .locator('[data-service-subgroup="ai-providers"] .service-item')
+      .evaluateAll(items => items.map(item => item.getAttribute('data-service-value')));
+    const platformServices = await serviceCatalog
+      .locator('[data-service-subgroup="ai-platforms"] .service-item')
+      .evaluateAll(items => items.map(item => item.getAttribute('data-service-value')));
+    if (JSON.stringify(providerServices) !== JSON.stringify(expectedProviderServices)) {
+      throw new Error(`模型服务商分类或顺序异常：${JSON.stringify(providerServices)}`);
+    }
+    if (JSON.stringify(platformServices) !== JSON.stringify(expectedPlatformServices)) {
+      throw new Error(`聚合平台分类或顺序异常：${JSON.stringify(platformServices)}`);
+    }
+
+    const machineGroup = serviceCatalog.locator('[data-service-section="machine"]');
+    const machineServices = await machineGroup.locator('.service-item')
+      .evaluateAll(items => items.map(item => item.getAttribute('data-service-value')));
+    const chromeMachineServices = [...expectedMachineServices, 'chromeTranslator'];
+    if (JSON.stringify(machineServices) !== JSON.stringify(expectedMachineServices)
+      && JSON.stringify(machineServices) !== JSON.stringify(chromeMachineServices)) {
+      throw new Error(`机器翻译分类或顺序异常：${JSON.stringify(machineServices)}`);
+    }
+    const machineToggle = machineGroup.locator('[data-service-section-toggle="machine"]');
+    if (await machineToggle.count() !== 1) throw new Error('机器翻译分组缺少唯一折叠按钮');
+    if (await machineToggle.getAttribute('aria-expanded') === 'true') await machineToggle.click();
+    if (await machineToggle.getAttribute('aria-expanded') !== 'false'
+      || await machineGroup.locator('.service-item').first().isVisible()) {
+      throw new Error('机器翻译分组无法收起');
+    }
+    const serviceSearch = serviceCatalog.getByPlaceholder('搜索翻译服务');
+    await serviceSearch.fill('微软翻译');
+    await machineGroup.locator('.service-item[data-service-value="microsoft"]').waitFor({state: 'visible', timeout});
+    if (await machineToggle.getAttribute('aria-expanded') !== 'true') {
+      throw new Error('搜索机器翻译时没有自动展开命中分组');
+    }
+    if (!await machineToggle.isDisabled()) throw new Error('搜索期间机器翻译折叠按钮仍可操作');
+    await serviceSearch.fill('');
+    if (await machineToggle.getAttribute('aria-expanded') !== 'false') {
+      throw new Error('清空搜索后没有恢复机器翻译折叠状态');
+    }
+    if (await machineToggle.isDisabled()) throw new Error('清空搜索后机器翻译折叠按钮没有恢复可用');
+    report.screenshots.push(await screenshot(page, 'settings-service-catalog-collapsed.png'));
+    await machineToggle.click();
+    if (await machineToggle.getAttribute('aria-expanded') !== 'true') throw new Error('机器翻译分组无法重新展开');
+
     const defaultServiceItem = serviceCatalog.locator(
       `.service-item[data-service-value="${defaultServiceMetrics.defaultService}"]`,
     );
@@ -939,6 +994,13 @@ async function main() {
       throw new Error(`AI 上下文开关用例没有运行在机器默认服务下：${defaultServiceKind}`);
     }
     report.informationArchitecture.services = serviceOnlyMetrics;
+    report.informationArchitecture.serviceCatalogHierarchy = {
+      providerServices,
+      platformServices,
+      machineServices,
+      machineSearchAutoExpanded: true,
+      machineCollapsedStateRestored: true,
+    };
     report.informationArchitecture.machineDefaultAiContext = {
       defaultService: defaultServiceMetrics.defaultService,
       serviceKind: defaultServiceKind,
@@ -947,6 +1009,8 @@ async function main() {
       restored: aiContextRestored,
     };
     report.assertions.servicesCatalogOnly = true;
+    report.assertions.serviceCatalogHierarchy = true;
+    report.assertions.machineServiceGroupCollapsible = true;
     report.assertions.machineDefaultAiContextOperable = true;
 
     await page.locator('button[data-section="settings-translation"]').click();

--- a/src/core/config/catalog.ts
+++ b/src/core/config/catalog.ts
@@ -2,7 +2,7 @@
  * @file src/core/config/catalog.ts
  *
  * 文件职责：维护 FluentRead 翻译服务与模型的领域目录，让设置、校验和运行时能够引用同一组稳定的服务标识与模型元数据。
- * 主要内容：定义 services、servicesType、模型候选、MiniMax 与 MiMo 的计费和地域选项，并提供 resolveConfiguredModel 等解析函数，把“自定义模型”选择归一为可请求的模型编号。 可核对的公开符号包括 services、servicesType、customModelString、minimaxBillingPlans、MiniMaxBillingPlan、minimaxRegions、MiniMaxRegion、mimoBillingPlans。
+ * 主要内容：定义 services、servicesType、服务目录展示分类与排序、模型候选、MiniMax 与 MiMo 的计费和地域选项，并提供 resolveConfiguredModel 等解析函数，把“自定义模型”选择归一为可请求的模型编号。 可核对的公开符号包括 services、servicesType、customModelString、minimaxBillingPlans、MiniMaxBillingPlan、minimaxRegions、MiniMaxRegion、mimoBillingPlans。
  * 模块边界：本文件属于 core 领域层，只定义规则、类型与纯转换；不直接读写浏览器存储、不发起网络请求、不挂载 Vue/WXT 入口，持久化、协议调用和界面编排分别由 services、providers 与 features 承担。
  */
 
@@ -432,28 +432,30 @@ export const options = {
         {value: services.chromeTranslator, label: "Chrome内置AI翻译"},
         // 大模型翻译
         {value: "ai", label: "AI翻译", disabled: true},
-        {value: services.siliconCloud, label: "硅基流动"},
-        {value: services.huanYuan, label: "腾讯混元"},
-        {value: services.newapi, label: "New API"},
-        {value: services.deepseek, label: "DeepSeek"},
-        {value: services.openai, label: "OpenAI"},
-        {value: services.azureOpenai, label: "Azure OpenAI"},
-        {value: services.huanYuanTranslation, label: "腾讯混元翻译"},
-        {value: services.tongyi, label: "千问/Qwen"},
-        {value: services.doubao, label: "字节豆包"},
-        {value: services.grok, label: "Grok (X.AI)"},
-        {value: services.openrouter, label: "OpenRouter"},
-        {value: services.groq, label: "Groq"},
-        {value: services.moonshot, label: "月之暗面/Kimi"},
-        {value: services.zhipu, label: "智谱/GLM"},
-        {value: services.minimax, label: "MiniMax"},
-        {value: services.mimo, label: "小米 MiMo"},
-        {value: services.jieyue, label: "阶跃星辰"},
-        {value: services.infini, label: "无问芯穹"},
-        {value: services.claude, label: "Claude"},
-        {value: services.gemini, label: "Gemini"},
-        {value: services.yiyan, label: "文心一言"},
-        {value: services.custom, label: "自定义接口"},
+        // 大模型服务商：中国常用厂商优先，其次为常用海外厂商。
+        {value: services.deepseek, label: "DeepSeek", catalogKind: "provider"},
+        {value: services.tongyi, label: "千问/Qwen", catalogKind: "provider"},
+        {value: services.doubao, label: "字节豆包", catalogKind: "provider"},
+        {value: services.moonshot, label: "月之暗面/Kimi", catalogKind: "provider"},
+        {value: services.zhipu, label: "智谱/GLM", catalogKind: "provider"},
+        {value: services.huanYuan, label: "腾讯混元", catalogKind: "provider"},
+        {value: services.huanYuanTranslation, label: "腾讯混元翻译", catalogKind: "provider"},
+        {value: services.yiyan, label: "文心一言", catalogKind: "provider"},
+        {value: services.minimax, label: "MiniMax", catalogKind: "provider"},
+        {value: services.mimo, label: "小米 MiMo", catalogKind: "provider"},
+        {value: services.jieyue, label: "阶跃星辰", catalogKind: "provider"},
+        {value: services.openai, label: "OpenAI", catalogKind: "provider"},
+        {value: services.gemini, label: "Gemini", catalogKind: "provider"},
+        {value: services.claude, label: "Claude", catalogKind: "provider"},
+        {value: services.grok, label: "Grok (X.AI)", catalogKind: "provider"},
+        // 聚合平台、托管平台与 OpenAI 兼容接口。
+        {value: services.siliconCloud, label: "硅基流动", catalogKind: "platform"},
+        {value: services.newapi, label: "New API", catalogKind: "platform"},
+        {value: services.infini, label: "无问芯穹", catalogKind: "platform"},
+        {value: services.openrouter, label: "OpenRouter", catalogKind: "platform"},
+        {value: services.groq, label: "Groq", catalogKind: "platform"},
+        {value: services.azureOpenai, label: "Azure OpenAI", catalogKind: "platform"},
+        {value: services.custom, label: "自定义接口", catalogKind: "platform"},
     ],
     display: [
         {value: 0, label: "仅译文模式"},

--- a/src/features/settings/model/navigation.ts
+++ b/src/features/settings/model/navigation.ts
@@ -35,9 +35,9 @@ export const navigationGroups: NavigationGroup[] = [
       },
       {
         id: 'settings-services', icon: '译', label: '翻译服务', description: '服务与模型', group: '基础配置',
-        heading: '配置翻译服务与模型', summary: '按机器翻译和 AI 翻译分类，配置各服务的模型、连接参数与凭据。',
+        heading: '配置翻译服务与模型', summary: '按机器翻译、模型服务商和聚合平台分类，配置各服务的模型、连接参数与凭据。',
         kicker: '基础配置', title: '翻译服务', detail: '配置可用的翻译服务、模型、连接和凭据。',
-        searchDescription: '微软翻译、OpenAI、DeepSeek、Gemini、模型与令牌',
+        searchDescription: '机器翻译、模型服务商、聚合平台、OpenAI、DeepSeek、硅基流动、OpenRouter、模型与令牌',
       },
       {
         id: 'settings-translation', icon: '译', label: '翻译设置', description: '悬浮、划词、输入框与全文', group: '基础配置',

--- a/src/features/settings/ui/services/ServiceCatalog.vue
+++ b/src/features/settings/ui/services/ServiceCatalog.vue
@@ -1,7 +1,7 @@
 <!--
  * @file src/features/settings/ui/services/ServiceCatalog.vue
- * 文件职责：实现翻译服务目录与筛选选择界面，把内置、AI 和自定义服务按分组、搜索条件与浏览器能力呈现为可切换的卡片列表。
- * 主要内容：组件接收当前服务和配置，使用 ServiceIcon、catalog 元数据及能力过滤计算可见选项，支持关键词搜索、分组计数、选择事件和自定义模型入口。
+ * 文件职责：实现翻译服务目录与筛选选择界面，把机器翻译、模型服务商和聚合平台按分层目录、搜索条件与浏览器能力呈现为可切换的卡片列表。
+ * 主要内容：组件接收当前服务和配置，使用 ServiceIcon、catalog 元数据及能力过滤计算可见选项，支持机器翻译折叠、AI 二级分类、关键词搜索、分组计数、选择事件和自定义模型入口。
  * 模块边界：目录只决定“选择哪个服务”，不编辑凭据、不测试连接也不保存配置；详细表单归 ServiceConfiguration.vue，服务定义来自 core/config，外层 SettingsSections 处理持久化。
  -->
 <template>
@@ -18,33 +18,75 @@
           <input v-model.trim="serviceQuery" type="search" placeholder="搜索翻译服务" />
         </label>
 
-        <div v-if="filteredGroups.length" class="service-groups">
-          <section v-for="group in filteredGroups" :key="group.id" class="service-group">
-            <div class="group-heading">
-              <strong>{{ group.label }}</strong>
-              <span>{{ group.items.length }} 项</span>
-            </div>
+        <div v-if="filteredSections.length" class="service-groups">
+          <section
+            v-for="section in filteredSections"
+            :key="section.id"
+            class="service-group"
+            :data-service-section="section.id"
+          >
             <button
-              v-for="item in group.items"
-              :key="item.value"
+              v-if="section.collapsible"
               type="button"
-              class="service-item"
-              :data-service-value="item.value"
-              :class="{ active: service === item.value }"
-              :aria-pressed="service === item.value"
-              @click="$emit('update:service', item.value)"
+              class="group-heading group-heading-toggle"
+              :data-service-section-toggle="section.id"
+              :aria-expanded="!isSectionCollapsed(section)"
+              :aria-controls="`service-section-${section.id}`"
+              :disabled="Boolean(serviceQuery)"
+              @click="toggleSection(section.id)"
             >
-              <ServiceIcon :service="item.value" :label="item.label" />
-              <span class="service-copy">
-                <strong>{{ item.label }}</strong>
-                <small>{{ group.id === 'machine' ? '机器翻译' : 'AI 翻译' }}</small>
+              <span class="group-heading-copy">
+                <strong>{{ section.label }}</strong>
+                <small>{{ sectionItemCount(section) }} 项</small>
               </span>
-              <span
-                v-if="defaultService === item.value"
-                class="current-dot"
-                title="默认翻译服务"
-              ></span>
+              <span class="group-toggle-copy">
+                {{ serviceQuery ? '搜索中' : isSectionCollapsed(section) ? '展开' : '收起' }}
+                <i aria-hidden="true">⌄</i>
+              </span>
             </button>
+            <div v-else class="group-heading">
+              <strong>{{ section.label }}</strong>
+              <span>{{ sectionItemCount(section) }} 项</span>
+            </div>
+
+            <div
+              v-show="!isSectionCollapsed(section)"
+              :id="`service-section-${section.id}`"
+              class="service-section-body"
+            >
+              <section
+                v-for="group in section.groups"
+                :key="group.id"
+                class="service-subgroup"
+                :data-service-subgroup="group.id"
+              >
+                <div v-if="group.label" class="subgroup-heading">
+                  <strong>{{ group.label }}</strong>
+                  <span>{{ group.items.length }} 项</span>
+                </div>
+                <button
+                  v-for="item in group.items"
+                  :key="item.value"
+                  type="button"
+                  class="service-item"
+                  :data-service-value="item.value"
+                  :class="{ active: service === item.value }"
+                  :aria-pressed="service === item.value"
+                  @click="$emit('update:service', item.value)"
+                >
+                  <ServiceIcon :service="item.value" :label="item.label" />
+                  <span class="service-copy">
+                    <strong>{{ item.label }}</strong>
+                    <small>{{ group.itemKind }}</small>
+                  </span>
+                  <span
+                    v-if="defaultService === item.value"
+                    class="current-dot"
+                    title="默认翻译服务"
+                  ></span>
+                </button>
+              </section>
+            </div>
           </section>
         </div>
         <p v-else class="catalog-empty">没有匹配的翻译服务</p>
@@ -142,12 +184,13 @@ import { computed, ref, watch } from 'vue'
 import ServiceIcon from '@/src/ui/components/ServiceIcon.vue'
 import { customModelString } from '@/src/core/config/catalog'
 import {
-  buildServiceGroups,
+  buildServiceSections,
   filterModels,
-  filterServiceGroups,
+  filterServiceSections,
   getSelectedModelLabel,
   splitModelOptions,
   type ServiceOption,
+  type ServiceSection,
 } from '@/src/ui/view-model/serviceCatalog'
 
 const props = defineProps<{
@@ -171,8 +214,10 @@ const moreModelsOpen = ref(false)
 const commonModelCount = 4
 const customModelLabel = customModelString
 
-const groups = computed(() => buildServiceGroups(props.services))
-const filteredGroups = computed(() => filterServiceGroups(groups.value, serviceQuery.value))
+const sections = computed(() => buildServiceSections(props.services))
+const filteredSections = computed(() => filterServiceSections(sections.value, serviceQuery.value))
+const collapsedSectionIds = ref(new Set(['machine']))
+const manuallyCollapsedSectionIds = ref(new Set<string>())
 const filteredModels = computed(() => filterModels(props.modelOptions, modelQuery.value))
 const modelGroups = computed(() => splitModelOptions(props.modelOptions, props.selectedModel, commonModelCount))
 const moreModels = computed(() => modelGroups.value.more)
@@ -184,7 +229,60 @@ const selectedModelLabel = computed(() => getSelectedModelLabel(
 const displayedModels = computed(() => modelQuery.value
   ? filteredModels.value
   : moreModelsOpen.value ? [...modelGroups.value.common, ...moreModels.value] : modelGroups.value.common)
-const selectedService = computed(() => groups.value.flatMap((group) => group.items).find((item) => item.value === props.service))
+const selectedService = computed(() => sections.value
+  .flatMap((section) => section.groups)
+  .flatMap((group) => group.items)
+  .find((item) => item.value === props.service))
+
+function sectionItemCount(section: ServiceSection) {
+  return section.groups.reduce((count, group) => count + group.items.length, 0)
+}
+
+function sectionContainsService(section: ServiceSection, service: string) {
+  return section.groups.some((group) => group.items.some((item) => item.value === service))
+}
+
+function isSectionCollapsed(section: ServiceSection) {
+  return section.collapsible
+    && !serviceQuery.value
+    && collapsedSectionIds.value.has(section.id)
+}
+
+function toggleSection(sectionId: string) {
+  const next = new Set(collapsedSectionIds.value)
+  const nextManual = new Set(manuallyCollapsedSectionIds.value)
+  if (next.has(sectionId)) {
+    next.delete(sectionId)
+    nextManual.delete(sectionId)
+  } else {
+    next.add(sectionId)
+    nextManual.add(sectionId)
+  }
+  collapsedSectionIds.value = next
+  manuallyCollapsedSectionIds.value = nextManual
+}
+
+watch(
+  [sections, () => props.service, () => props.defaultService],
+  ([currentSections, editingService, defaultService]) => {
+    const next = new Set(collapsedSectionIds.value)
+    const nextManual = new Set(manuallyCollapsedSectionIds.value)
+    currentSections.filter((section) => section.collapsible).forEach((section) => {
+      if (sectionContainsService(section, editingService)) {
+        next.delete(section.id)
+        nextManual.delete(section.id)
+      } else if (
+        sectionContainsService(section, defaultService)
+        && !nextManual.has(section.id)
+      ) {
+        next.delete(section.id)
+      }
+    })
+    collapsedSectionIds.value = next
+    manuallyCollapsedSectionIds.value = nextManual
+  },
+  { immediate: true },
+)
 
 watch(() => props.service, () => {
   modelQuery.value = ''
@@ -204,11 +302,24 @@ watch(modelQuery, () => {
 .catalog-search, .model-search { display: flex; align-items: center; gap: 8px; height: 38px; padding: 0 11px; border: 1px solid #dfe3eb; border-radius: 11px; background: #fff; }
 .catalog-search span, .model-search span { color: #8991a2; font-size: 16px; }
 .catalog-search input, .model-search input { width: 100%; min-width: 0; border: 0; outline: 0; color: #172033; background: transparent; font-size: 13px; }
-.service-groups { display: grid; gap: 18px; margin-top: 17px; }
-.group-heading { display: flex; align-items: center; justify-content: space-between; margin-bottom: 3px; padding: 8px 9px; border-bottom: 1px solid #e5e8ef; color: #667187; background: #f3f5f9; }
+.service-groups { display: grid; gap: 14px; margin-top: 17px; }
+.group-heading { display: flex; align-items: center; justify-content: space-between; width: 100%; margin: 0 0 5px; padding: 8px 9px; border: 0; border-bottom: 1px solid #e5e8ef; color: #667187; background: #f3f5f9; text-align: left; }
 .group-heading strong { color: #46526a; font-size: 12px; letter-spacing: .05em; }
 .group-heading span { font-size: 10px; }
 .service-group { min-width: 0; }
+.group-heading-toggle { cursor: pointer; }
+.group-heading-toggle:not(:disabled):hover { background: #eef1f6; }
+.group-heading-toggle:disabled { cursor: default; }
+.group-heading-copy { display: flex; align-items: baseline; gap: 7px; }
+.group-heading-copy small { color: #8a93a5; font-size: 10px; }
+.group-toggle-copy { display: flex; align-items: center; gap: 3px; color: #c72a56; font-weight: 750; }
+.group-toggle-copy i { display: inline-block; font-style: normal; transition: transform 150ms ease; }
+.group-heading-toggle[aria-expanded="true"] .group-toggle-copy i { transform: rotate(180deg); }
+.service-section-body { display: grid; gap: 14px; }
+.service-subgroup { min-width: 0; }
+.subgroup-heading { display: flex; align-items: center; justify-content: space-between; margin: 2px 9px 4px; color: #8a93a5; }
+.subgroup-heading strong { color: #657086; font-size: 10px; font-weight: 800; letter-spacing: .04em; }
+.subgroup-heading span { font-size: 9px; }
 .service-item { display: grid; grid-template-columns: 40px minmax(0, 1fr) 8px; align-items: center; gap: 10px; width: 100%; padding: 10px; border: 1px solid transparent; border-radius: 12px; color: #172033; background: transparent; text-align: left; cursor: pointer; transition: 150ms ease; }
 .service-item:hover { border-color: #e2e5ec; background: #fff; transform: translateX(2px); }
 .service-item.active { border-color: #f3c4d1; background: #fff0f4; box-shadow: 0 7px 18px rgba(214, 50, 96, .08); }
@@ -272,6 +383,7 @@ watch(modelQuery, () => {
 :global(:root.dark) .catalog-search input,
 :global(:root.dark) .model-search input,
 :global(:root.dark) .group-heading strong,
+:global(:root.dark) .subgroup-heading strong,
 :global(:root.dark) .detail-title-row h4,
 :global(:root.dark) .model-heading strong,
 :global(:root.dark) .model-item,
@@ -282,9 +394,12 @@ watch(modelQuery, () => {
 :global(:root.dark) .model-list-heading,
 :global(:root.dark) .model-item small,
 :global(:root.dark) .more-models-toggle small { color: var(--muted); }
+:global(:root.dark) .subgroup-heading { color: var(--muted); }
+:global(:root.dark) .group-toggle-copy { color: var(--brand-strong); }
 :global(:root.dark) .detail-hero,
 :global(:root.dark) .service-configuration-slot { border-color: var(--line); }
 :global(:root.dark) .service-item:hover { border-color: var(--line); background: var(--surface); }
+:global(:root.dark) .group-heading-toggle:not(:disabled):hover { background: var(--brand-soft); }
 :global(:root.dark) .service-item.active,
 :global(:root.dark) .model-item.active { border-color: rgba(255, 138, 171, .48); background: var(--brand-soft); }
 :global(:root.dark) .more-models-toggle:hover { border-color: rgba(255, 138, 171, .48); background: var(--brand-soft); }
@@ -299,7 +414,7 @@ watch(modelQuery, () => {
   .service-catalog { height: auto; min-height: 0; }
   .catalog-layout { display: block; flex: 0 0 auto; }
   .service-rail { border-right: 0; border-bottom: 1px solid #eceef3; }
-  .service-groups { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .service-groups { grid-template-columns: 1fr; }
   .service-detail { padding: 18px; }
   .model-heading { align-items: stretch; flex-direction: column; }
   .model-search { width: 100%; }

--- a/src/ui/view-model/serviceCatalog.ts
+++ b/src/ui/view-model/serviceCatalog.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/ui/view-model/serviceCatalog.ts
- * 文件职责：为服务与模型选择界面提供无框架的视图模型转换，把扁平配置选项整理成可搜索、可分组和可稳定展示的数据。
- * 主要内容：定义 ServiceOption/ServiceGroup，清理标签星标，按 disabled 分隔项构建服务组，按服务或模型关键词筛选并返回命中模型，解析当前模型标签，并把常用、选中和自定义模型稳定拆分。
+ * 文件职责：为服务与模型选择界面提供无框架的视图模型转换，把扁平配置选项整理成可搜索、可分层和可稳定展示的数据。
+ * 主要内容：定义服务目录的顶层分组与 AI 二级分类，清理标签星标，按服务或模型关键词筛选并返回命中模型，解析当前模型标签，并把常用、选中和自定义模型稳定拆分。
  * 模块边界：这些函数不读取 Vue 状态、不修改 Config，也不判断平台能力或发起连接测试；原始目录由 core/config 提供，Popup/Options 等调用方负责交互与渲染。
  */
 import { customModelString, resolveConfiguredModel, servicesType } from '@/src/core/config/catalog'
@@ -11,12 +11,24 @@ export interface ServiceOption {
   label: string
   description?: string
   disabled?: boolean
+  catalogKind?: string
 }
 
 export interface ServiceGroup {
   id: string
   label: string
   items: ServiceOption[]
+}
+
+export interface ServiceSubgroup extends ServiceGroup {
+  itemKind: string
+}
+
+export interface ServiceSection {
+  id: string
+  label: string
+  collapsible: boolean
+  groups: ServiceSubgroup[]
 }
 
 export interface ServiceSearchOption extends ServiceOption {
@@ -48,6 +60,36 @@ export function buildServiceGroups(options: ServiceOption[]): ServiceGroup[] {
   return groups
 }
 
+export function buildServiceSections(options: ServiceOption[]): ServiceSection[] {
+  return buildServiceGroups(options).map((group) => {
+    if (group.id === 'ai') {
+      const providers = group.items.filter((item) => item.catalogKind !== 'platform')
+      const platforms = group.items.filter((item) => item.catalogKind === 'platform')
+      return {
+        id: group.id,
+        label: group.label,
+        collapsible: false,
+        groups: [
+          { id: 'ai-providers', label: '模型服务商', itemKind: '模型服务商', items: providers },
+          { id: 'ai-platforms', label: '聚合平台与接口', itemKind: '聚合平台', items: platforms },
+        ].filter((subgroup) => subgroup.items.length > 0),
+      }
+    }
+
+    return {
+      id: group.id,
+      label: group.label,
+      collapsible: group.id === 'machine',
+      groups: [{
+        id: `${group.id}-services`,
+        label: '',
+        itemKind: group.id === 'machine' ? '机器翻译' : group.label,
+        items: group.items,
+      }],
+    }
+  })
+}
+
 export function filterServiceGroups(groups: ServiceGroup[], query: string) {
   const keyword = query.trim().toLocaleLowerCase()
   if (!keyword) return groups
@@ -60,6 +102,25 @@ export function filterServiceGroups(groups: ServiceGroup[], query: string) {
       ),
     }))
     .filter((group) => group.items.length > 0)
+}
+
+export function filterServiceSections(sections: ServiceSection[], query: string) {
+  const keyword = query.trim().toLocaleLowerCase()
+  if (!keyword) return sections
+
+  return sections
+    .map((section) => ({
+      ...section,
+      groups: section.groups
+        .map((group) => ({
+          ...group,
+          items: group.items.filter((item) =>
+            `${item.label}${item.value}${item.description || ''}`.toLocaleLowerCase().includes(keyword),
+          ),
+        }))
+        .filter((group) => group.items.length > 0),
+    }))
+    .filter((section) => section.groups.length > 0)
 }
 
 export function filterModels(modelOptions: string[], query: string) {

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -95,6 +95,43 @@ describe('AI 模型编号列表', () => {
         expect(options.services.some(option => option.value === services.lingyi)).toBe(false);
         expect(options.services.find(option => option.value === services.infini)?.label).toBe('无问芯穹');
         expect(options.services.every(option => !/[🌟⭐★]/u.test(option.label))).toBe(true);
+        const aiServices = options.services.slice(
+            options.services.findIndex(option => option.value === 'ai') + 1,
+        );
+        expect(aiServices.map(option => option.value)).toEqual([
+            services.deepseek,
+            services.tongyi,
+            services.doubao,
+            services.moonshot,
+            services.zhipu,
+            services.huanYuan,
+            services.huanYuanTranslation,
+            services.yiyan,
+            services.minimax,
+            services.mimo,
+            services.jieyue,
+            services.openai,
+            services.gemini,
+            services.claude,
+            services.grok,
+            services.siliconCloud,
+            services.newapi,
+            services.infini,
+            services.openrouter,
+            services.groq,
+            services.azureOpenai,
+            services.custom,
+        ]);
+        expect(aiServices.filter(option => option.catalogKind === 'platform').map(option => option.value)).toEqual([
+            services.siliconCloud,
+            services.newapi,
+            services.infini,
+            services.openrouter,
+            services.groq,
+            services.azureOpenai,
+            services.custom,
+        ]);
+        expect(aiServices.filter(option => option.catalogKind === 'provider')).toHaveLength(15);
         expect(servicesType.isMachine(services.freeTranslation)).toBe(true);
         expect(defaultOption.service).toBe(services.freeTranslation);
     });

--- a/tests/optionsNavigation.test.ts
+++ b/tests/optionsNavigation.test.ts
@@ -89,6 +89,9 @@ describe('options navigation view-model', () => {
     expect(filterNavigationItems('AI 多段翻译')).toEqual([
       expect.objectContaining({ id: 'settings-translation' }),
     ])
+    expect(filterNavigationItems('聚合平台')).toEqual([
+      expect.objectContaining({ id: 'settings-services' }),
+    ])
     expect(filterNavigationItems(' KIMI ')).toEqual([
       expect.objectContaining({ id: 'settings-model-usage' }),
     ])

--- a/tests/serviceCatalog.test.ts
+++ b/tests/serviceCatalog.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildServiceGroups,
+  buildServiceSections,
   cleanServiceLabel,
   filterModels,
   filterServiceGroups,
+  filterServiceSections,
   getSelectedModelLabel,
   searchServiceOptions,
   splitModelOptions,
@@ -16,8 +18,9 @@ const options = [
   { value: 'microsoft', label: '微软翻译' },
   { value: 'chromeTranslator', label: 'Chrome内置AI翻译⭐' },
   { value: 'ai', label: 'AI翻译', disabled: true },
-  { value: 'openai', label: 'OpenAI' },
-  { value: 'deepseek', label: 'DeepSeek️' },
+  { value: 'deepseek', label: 'DeepSeek️', catalogKind: 'provider' },
+  { value: 'openai', label: 'OpenAI', catalogKind: 'provider' },
+  { value: 'newapi', label: 'New API', catalogKind: 'platform' },
 ]
 
 describe('service catalog helpers', () => {
@@ -35,9 +38,76 @@ describe('service catalog helpers', () => {
         id: 'ai',
         label: 'AI翻译',
         items: [
-          { value: 'openai', label: 'OpenAI' },
-          { value: 'deepseek', label: 'DeepSeek' },
+          { value: 'deepseek', label: 'DeepSeek', catalogKind: 'provider' },
+          { value: 'openai', label: 'OpenAI', catalogKind: 'provider' },
+          { value: 'newapi', label: 'New API', catalogKind: 'platform' },
         ],
+      },
+    ])
+  })
+
+  it('nests AI services into ordered provider and platform groups', () => {
+    expect(buildServiceSections(options)).toEqual([
+      {
+        id: 'machine',
+        label: '机器翻译',
+        collapsible: true,
+        groups: [{
+          id: 'machine-services',
+          label: '',
+          itemKind: '机器翻译',
+          items: [
+            { value: 'microsoft', label: '微软翻译' },
+            { value: 'chromeTranslator', label: 'Chrome内置AI翻译' },
+          ],
+        }],
+      },
+      {
+        id: 'ai',
+        label: 'AI翻译',
+        collapsible: false,
+        groups: [
+          {
+            id: 'ai-providers',
+            label: '模型服务商',
+            itemKind: '模型服务商',
+            items: [
+              { value: 'deepseek', label: 'DeepSeek', catalogKind: 'provider' },
+              { value: 'openai', label: 'OpenAI', catalogKind: 'provider' },
+            ],
+          },
+          {
+            id: 'ai-platforms',
+            label: '聚合平台与接口',
+            itemKind: '聚合平台',
+            items: [{ value: 'newapi', label: 'New API', catalogKind: 'platform' }],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('keeps unclassified AI services visible as model providers', () => {
+    const sections = buildServiceSections([
+      { value: 'ai', label: 'AI翻译', disabled: true },
+      { value: 'future-provider', label: '未来模型' },
+    ])
+
+    expect(sections[0]?.groups[0]?.items.map((item) => item.value)).toEqual(['future-provider'])
+  })
+
+  it('keeps services before the first divider in a non-collapsible fallback section', () => {
+    expect(buildServiceSections([{ value: 'standalone', label: '独立服务' }])).toEqual([
+      {
+        id: 'other',
+        label: '其他服务',
+        collapsible: false,
+        groups: [{
+          id: 'other-services',
+          label: '',
+          itemKind: '其他服务',
+          items: [{ value: 'standalone', label: '独立服务' }],
+        }],
       },
     ])
   })
@@ -46,11 +116,29 @@ describe('service catalog helpers', () => {
     const groups = buildServiceGroups(options)
     expect(filterServiceGroups(groups, '   ')).toBe(groups)
     expect(filterServiceGroups(groups, 'open')).toEqual([
-      { id: 'ai', label: 'AI翻译', items: [{ value: 'openai', label: 'OpenAI' }] },
+      { id: 'ai', label: 'AI翻译', items: [{ value: 'openai', label: 'OpenAI', catalogKind: 'provider' }] },
     ])
     expect(filterServiceGroups([
       { id: 'ai', label: 'AI翻译', items: [{ value: 'openai', label: 'OpenAI', description: '通用服务' }] },
     ], '通用')).toHaveLength(1)
+  })
+
+  it('filters nested service sections without losing their parent or subgroup', () => {
+    const sections = buildServiceSections(options)
+    expect(filterServiceSections(sections, '   ')).toBe(sections)
+    expect(filterServiceSections(sections, 'new api')).toEqual([
+      {
+        id: 'ai',
+        label: 'AI翻译',
+        collapsible: false,
+        groups: [{
+          id: 'ai-platforms',
+          label: '聚合平台与接口',
+          itemKind: '聚合平台',
+          items: [{ value: 'newapi', label: 'New API', catalogKind: 'platform' }],
+        }],
+      },
+    ])
   })
 
   it('filters model identifiers case-insensitively', () => {

--- a/tests/settingsUiArchitecture.test.ts
+++ b/tests/settingsUiArchitecture.test.ts
@@ -290,6 +290,25 @@ describe('options UI composition architecture', () => {
     expect(styles).not.toContain('box-shadow: inset 4px 0 0 var(--brand);')
   })
 
+  it('keeps the service catalog hierarchy searchable and accessible', () => {
+    const catalog = source('src/features/settings/ui/services/ServiceCatalog.vue')
+    const viewModel = source('src/ui/view-model/serviceCatalog.ts')
+
+    expect(catalog).toContain(':data-service-section-toggle="section.id"')
+    expect(catalog).toContain(':aria-expanded="!isSectionCollapsed(section)"')
+    expect(catalog).toContain(':aria-controls="`service-section-${section.id}`"')
+    expect(catalog).toContain(':disabled="Boolean(serviceQuery)"')
+    expect(catalog).toContain("serviceQuery ? '搜索中'")
+    expect(catalog).toContain(':global(:root.dark) .group-toggle-copy { color: var(--brand-strong); }')
+    expect(catalog).toContain("const collapsedSectionIds = ref(new Set(['machine']))")
+    expect(catalog).toContain('&& !serviceQuery.value')
+    expect(catalog).toContain('sectionContainsService(section, editingService)')
+    expect(catalog).toContain('sectionContainsService(section, defaultService)')
+    expect(viewModel).toContain("label: '模型服务商'")
+    expect(viewModel).toContain("label: '聚合平台与接口'")
+    expect(viewModel).toContain("item.catalogKind === 'platform'")
+  })
+
   it('keeps translation interactions together in the requested order', () => {
     const settings = source('src/features/settings/ui/SettingsSections.vue')
     const translation = activeSectionSource(settings, 'settings-translation')


### PR DESCRIPTION
## 变更摘要

- 将 AI 翻译服务拆分为“模型服务商”和“聚合平台与接口”
- 中国及常用模型服务商优先，硅基流动、New API、无问芯穹、OpenRouter、Groq 等归入聚合平台
- 机器翻译分类支持折叠，并在当前服务、编辑或搜索需要时自动展开
- 保留现有服务 ID 与运行时契约，补充精确目录顺序、可访问性和真实浏览器回归覆盖

## 验证

- pnpm test:regression:all
- 100% statements / branches / functions / lines coverage
- Chrome MV3、Firefox MV2、Userscript 与文档构建
- Chrome/Firefox manifest capability verifier
- 隐藏生产 Edge 专项 UI 验证：桌面、820px、390px，无横向溢出，零控制台错误
- git diff --check

## 已知基线

全设置中心旧 UI 脚本会在进入本次目标页面前等待旧名称“配置管理”，而当前入口已改为“备份与恢复”；本 PR 使用新的翻译服务目录专项生产浏览器脚本覆盖本次交互。