### PR TITLE
fix: allow explicit translation through app shells

### DIFF
--- a/src/core/translation/dom.ts
+++ b/src/core/translation/dom.ts
@@ -2,7 +2,7 @@
  * @file src/core/translation/dom.ts
  *
  * 文件职责：封装翻译候选发现使用的 composed tree 遍历与不可覆盖安全守卫，识别扩展 DOM、脚本、表单及禁止翻译区域。
- * 主要内容：提供 Shadow DOM 父级与祖先遍历、硬裁剪标签、受保护文本元素、隐藏/可编辑/no-translate 判断，并限制祖先深度以避免异常页面结构拖垮扫描。 可核对的公开符号包括 maxComposedAncestorDepth、getComposedParent、isDocumentSurface、isExtensionElement、isExtensionElementSelf、isHardPruneTag、isProtectedTextElement、hasNoTranslateMarker。
+ * 主要内容：提供 Shadow DOM 父级与祖先遍历、硬裁剪标签、受保护文本元素、隐藏/可编辑/no-translate 判断，并限制祖先深度以避免异常页面结构拖垮扫描。 可核对的公开符号包括 maxComposedAncestorDepth、getComposedParent、isDocumentSurface、isExtensionElement、isExtensionElementSelf、isHardPruneTag、isProtectedTextElement、hasNoTranslateMarker、isTopLevelApplicationShell。
  * 模块边界：本文件属于可独立测试的 core 候选领域；可以读取传入 DOM 以计算结果，但不访问配置存储、不调用 provider、不注册页面监听器，也不负责译文渲染或 feature 生命周期。
  */
 
@@ -77,6 +77,26 @@ export function hasNoTranslateMarker(element: Element): boolean {
         element.getAttribute('data-notranslate') === 'true';
 }
 
+/**
+ * 显式翻译可有限穿过应用级 no-translate 外壳，但不能把这个例外扩大到局部区域。
+ * 直接挂在 body 下是刻意保守的边界：嵌套 no-translate 容器仍代表页面作者明确保护的内容。
+ */
+export function isTopLevelApplicationShell(element: Element): boolean {
+    const body = element.ownerDocument?.body;
+    return Boolean(
+        body &&
+        element.parentElement === body &&
+        hasNoTranslateMarker(element),
+    );
+}
+
+export interface TranslationTextProtectionOptions {
+    /** 仅显式选中/悬浮翻译允许穿过 body 直接子级的应用外壳。 */
+    allowTopLevelApplicationShell?: boolean;
+    /** 显式命中的元素自身仍是保护边界，不能因为它的 marker 被放行。 */
+    protectedElement?: Element;
+}
+
 export function hasHiddenMarker(element: Element): boolean {
     const htmlElement = element as HTMLElement;
     if (htmlElement.hidden || htmlElement.inert || element.hasAttribute('inert')) return true;
@@ -119,11 +139,15 @@ export function isMathRendererElement(element: Element): boolean {
 export function isProtectedDescendantElement(
     element: Element,
     ignoreExtensionSelf = false,
+    options?: TranslationTextProtectionOptions,
 ): boolean {
     return (!ignoreExtensionSelf && isExtensionElementSelf(element)) ||
         isProtectedTextElement(element) ||
         isMathRendererElement(element) ||
-        hasNoTranslateMarker(element) ||
+        (hasNoTranslateMarker(element) &&
+            !(options?.allowTopLevelApplicationShell === true &&
+                element !== options.protectedElement &&
+                isTopLevelApplicationShell(element))) ||
         hasContentEditableMarker(element) ||
         hasHiddenMarker(element);
 }

--- a/src/core/translation/engine.ts
+++ b/src/core/translation/engine.ts
@@ -15,9 +15,11 @@ import {
     getComposedParent,
     isDocumentSurface,
     isExtensionElementSelf,
+    isTopLevelApplicationShell,
     maxComposedAncestorDepth,
 } from './dom';
 import type {HardGuardResult} from './dom';
+import type {TranslationTextProtectionOptions} from './dom';
 import {
     classifyGenericCandidate,
     getDirectInlineRuns,
@@ -62,6 +64,8 @@ interface AdapterPrunedAncestor {
 /** 仅在一次同步悬浮或检查调用内有效的缓存集合。 */
 interface ResolutionEvaluationContext {
     textProtectionCache: TranslationTextProtectionCache;
+    textProtectionOptions?: TranslationTextProtectionOptions;
+    topLevelApplicationShellBypassed: boolean;
     hardGuards: WeakMap<Element, HardGuardResult>;
     adapterDecisions: WeakMap<Element, AdapterDecisionResult>;
     adapterPrunedAncestors: WeakMap<Element, AdapterPrunedAncestor | null>;
@@ -70,9 +74,13 @@ interface ResolutionEvaluationContext {
     structuralAncestors: WeakMap<Element, boolean>;
 }
 
-function createResolutionEvaluationContext(): ResolutionEvaluationContext {
+function createResolutionEvaluationContext(
+    textProtectionOptions?: TranslationTextProtectionOptions,
+): ResolutionEvaluationContext {
     return {
         textProtectionCache: createTranslationTextProtectionCache(),
+        textProtectionOptions,
+        topLevelApplicationShellBypassed: false,
         hardGuards: new WeakMap(),
         adapterDecisions: new WeakMap(),
         adapterPrunedAncestors: new WeakMap(),
@@ -167,6 +175,14 @@ export class TranslationCandidateCore {
         this.context = {url: this.url};
     }
 
+    private candidateResolutionMetadata(
+        evaluationContext?: ResolutionEvaluationContext,
+    ): Pick<TranslationCandidate, 'allowTopLevelApplicationShell'> {
+        return evaluationContext?.topLevelApplicationShellBypassed === true
+            ? {allowTopLevelApplicationShell: true}
+            : {};
+    }
+
     private adapterDecision(
         element: Element,
         evaluationContext?: ResolutionEvaluationContext,
@@ -228,6 +244,22 @@ export class TranslationCandidateCore {
         return null;
     }
 
+    private evaluateResolutionElementHardGuard(
+        element: Element,
+        evaluationContext: ResolutionEvaluationContext,
+    ): HardGuardResult {
+        const guard = evaluateElementHardGuard(element);
+        const protectionOptions = evaluationContext.textProtectionOptions;
+        if (guard.reason === 'inherited-no-translate' &&
+            protectionOptions?.allowTopLevelApplicationShell === true &&
+            element !== protectionOptions.protectedElement &&
+            isTopLevelApplicationShell(element)) {
+            evaluationContext.topLevelApplicationShellBypassed = true;
+            return {prune: false};
+        }
+        return guard;
+    }
+
     private primeResolutionAncestry(
         element: Element,
         evaluationContext: ResolutionEvaluationContext,
@@ -245,7 +277,8 @@ export class TranslationCandidateCore {
         // 祖先链过深时继续使用既有的有界回退，不评估或缓存不完整的链前缀。
         if (current) return;
 
-        const ownGuards = chain.map((item) => evaluateElementHardGuard(item));
+        const ownGuards = chain.map((item) =>
+            this.evaluateResolutionElementHardGuard(item, evaluationContext));
         let inheritedGuard: HardGuardResult = {prune: false};
         for (let index = chain.length - 1; index >= 0; index -= 1) {
             const item = chain[index]!;
@@ -268,7 +301,8 @@ export class TranslationCandidateCore {
     ): HardGuardResult {
         if (!evaluationContext) return evaluateHardGuard(element);
         this.primeResolutionAncestry(element, evaluationContext);
-        return evaluationContext.hardGuards.get(element) ?? evaluateHardGuard(element);
+        return evaluationContext.hardGuards.get(element) ??
+            this.evaluateResolutionElementHardGuard(element, evaluationContext);
     }
 
     private isExtensionElementForResolution(
@@ -350,6 +384,7 @@ export class TranslationCandidateCore {
                 [target],
                 this.shouldStayOriginal,
                 textProtectionCache,
+                evaluationContext?.textProtectionOptions,
             ) ||
                 this.hardGuard(target, evaluationContext).prune) {
                 return {candidate: null};
@@ -359,6 +394,7 @@ export class TranslationCandidateCore {
                 kind: decision.candidateKind ?? (isTranslationControlElement(target) ? 'control' : 'content'),
                 reason: decision.reason,
                 adapterId,
+                ...this.candidateResolutionMetadata(evaluationContext),
             };
             return {candidate};
         }
@@ -373,6 +409,7 @@ export class TranslationCandidateCore {
             this.shouldStayOriginal,
             evaluationContext !== undefined,
             textProtectionCache,
+            evaluationContext?.textProtectionOptions,
         );
         if (!classification) {
             return {candidate: null};
@@ -381,6 +418,7 @@ export class TranslationCandidateCore {
             element: element as HTMLElement,
             kind: classification.kind,
             reason: classification.reason,
+            ...this.candidateResolutionMetadata(evaluationContext),
         };
         return {candidate};
     }
@@ -394,6 +432,7 @@ export class TranslationCandidateCore {
     ): TranslationCandidate[] {
         const candidates: TranslationCandidate[] = [];
         const atomicTargetCache = new WeakMap<Element, boolean>();
+        const protectionOptions = evaluationContext?.textProtectionOptions;
         const isAtomicAdapterTarget = (candidate: Element): boolean => {
             const cached = atomicTargetCache.get(candidate);
             if (cached !== undefined) return cached;
@@ -412,6 +451,7 @@ export class TranslationCandidateCore {
             skipStructuralAncestorCheck,
             isDirectRunBarrier,
             textProtectionCache,
+            protectionOptions,
         )) {
             const partitions = partitionInlineRunAtBarriers(
                 run,
@@ -422,12 +462,14 @@ export class TranslationCandidateCore {
                     nodes,
                     this.shouldStayOriginal,
                     textProtectionCache,
+                    protectionOptions,
                 )) {
                     candidates.push({
                         element: element as HTMLElement,
                         nodes,
                         kind: 'content',
                         reason: 'generic-inline-run',
+                        ...this.candidateResolutionMetadata(evaluationContext),
                     });
                 }
             }
@@ -533,15 +575,24 @@ export class TranslationCandidateCore {
     resolve(start: Node | null | undefined): TranslationCandidate | null {
         if (!start) return null;
         const hit = start;
-        const evaluationContext = createResolutionEvaluationContext();
-        const textProtectionCache = evaluationContext.textProtectionCache;
         let current: Element | null = start.nodeType === 3
             ? (start as Text).parentElement
             : isElementNode(start) ? start : null;
+        if (!current) return null;
+        const evaluationContext = createResolutionEvaluationContext({
+            allowTopLevelApplicationShell: true,
+            protectedElement: current,
+        });
+        const textProtectionCache = evaluationContext.textProtectionCache;
 
         while (current && !isDocumentSurface(current)) {
             if (current.matches('[data-fr-translation-segment="true"]')) {
-                return {element: current as HTMLElement, kind: 'content', reason: 'owned-inline-run'};
+                return {
+                    element: current as HTMLElement,
+                    kind: 'content',
+                    reason: 'owned-inline-run',
+                    ...this.candidateResolutionMetadata(evaluationContext),
+                };
             }
             // 命中扩展的双语 wrapper 时，继续映射回宿主页源节点。
             if (current.matches('.fluent-read-bilingual-content')) {
@@ -554,6 +605,13 @@ export class TranslationCandidateCore {
             }
             // 继承硬守卫适用于每个可能的祖先候选；遇到极深树时立即停止，避免反复上溯。
             if (this.hardGuard(current, evaluationContext).reason === 'ancestor-depth-limit') return null;
+            // 外壳本身不是显式目标；避免在缺少更细粒度块边界的 SPA 中把整个应用根
+            // 当作候选，同时允许继续向其上方寻找正常的页面结构。
+            if (isTopLevelApplicationShell(current) &&
+                current !== evaluationContext.textProtectionOptions?.protectedElement) {
+                current = getComposedParent(current);
+                continue;
+            }
             // 全文发现会在遍历子节点前裁剪适配器拥有的受控子树；悬浮解析也必须先应用
             // 相同的继承裁剪，再尝试通用内联 run。否则命中 GitHub Quick Search 等区域时，
             // 可能解析出本应被 discover() 排除的对话框祖先。

--- a/src/core/translation/layout.ts
+++ b/src/core/translation/layout.ts
@@ -16,6 +16,7 @@ import {
     hasMeaningfulTranslationTextInNodes,
 } from './text';
 import type {TranslationTextProtectionCache} from './text';
+import type {TranslationTextProtectionOptions} from './dom';
 
 // 这些上限把同步布局分类限制为有界工作；超限时按保守边界处理，避免大型页面阻塞主线程。
 const maxDirectRunNodes = 2048;
@@ -159,22 +160,34 @@ export function hasDirectReadableText(
     element: Element,
     shouldStayOriginal?: (element: Element) => boolean,
     protectionCache?: TranslationTextProtectionCache,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): boolean {
     if (element.childNodes.length > maxDirectRunNodes) return false;
     const inlineNodes = Array.from(element.childNodes).filter((child) =>
         child.nodeType === 3 || (child.nodeType === 1 && !isBlockBoundary(child as Element)));
-    return hasMeaningfulTranslationTextInNodes(inlineNodes, shouldStayOriginal, protectionCache);
+    return hasMeaningfulTranslationTextInNodes(
+        inlineNodes,
+        shouldStayOriginal,
+        protectionCache,
+        protectionOptions,
+    );
 }
 
 export function hasReadableBlockChild(
     element: Element,
     shouldStayOriginal?: (element: Element) => boolean,
     protectionCache?: TranslationTextProtectionCache,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): boolean {
     if (element.children.length > maxBlockChildrenToProbe) return true;
     return Array.from(element.children).some((child) => {
         if (!isBlockBoundary(child)) return false;
-        return hasMeaningfulTranslationTextInNodes([child], shouldStayOriginal, protectionCache);
+        return hasMeaningfulTranslationTextInNodes(
+            [child],
+            shouldStayOriginal,
+            protectionCache,
+            protectionOptions,
+        );
     });
 }
 
@@ -188,13 +201,14 @@ export function getDirectInlineRuns(
     skipStructuralAncestorCheck = false,
     isAdditionalBarrier?: (element: Element) => boolean,
     protectionCache?: TranslationTextProtectionCache,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): ChildNode[][] {
     if (isDocumentSurface(element) || isStructuralContainer(element) ||
         (!skipStructuralAncestorCheck && hasStructuralAncestor(element))) return [];
     if (shouldStayOriginal?.(element) || isProtectedTextElement(element) || !isBlockBoundary(element)) return [];
     if (element.childNodes.length > maxDirectRunNodes) return [];
-    if (!hasDirectReadableText(element, shouldStayOriginal, protectionCache)) return [];
-    const hasBlockBarrier = hasReadableBlockChild(element, shouldStayOriginal, protectionCache);
+    if (!hasDirectReadableText(element, shouldStayOriginal, protectionCache, protectionOptions)) return [];
+    const hasBlockBarrier = hasReadableBlockChild(element, shouldStayOriginal, protectionCache, protectionOptions);
     const hasAdditionalBarrier = !hasBlockBarrier && isAdditionalBarrier &&
         Array.from(element.children).some((child) => isAdditionalBarrier(child));
     if (!hasBlockBarrier && !hasAdditionalBarrier) return [];
@@ -203,7 +217,12 @@ export function getDirectInlineRuns(
     let current: ChildNode[] = [];
     const flush = () => {
         if (current.length > 0 &&
-            hasMeaningfulTranslationTextInNodes(current, shouldStayOriginal, protectionCache)) {
+            hasMeaningfulTranslationTextInNodes(
+                current,
+                shouldStayOriginal,
+                protectionCache,
+                protectionOptions,
+            )) {
             runs.push(current);
         }
         current = [];
@@ -234,6 +253,7 @@ export function classifyGenericCandidate(
     shouldStayOriginal?: (element: Element) => boolean,
     skipStructuralAncestorCheck = false,
     protectionCache?: TranslationTextProtectionCache,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): GenericClassification | null {
     const semanticHeading = isSemanticHeadingElement(element);
     if (isDocumentSurface(element) || isStructuralContainer(element) ||
@@ -243,14 +263,24 @@ export function classifyGenericCandidate(
     if (shouldStayOriginal?.(element) || isProtectedTextElement(element)) return null;
 
     if (isTranslationControlElement(element)) {
-        if (!hasMeaningfulTranslationTextInNodes([element], shouldStayOriginal, protectionCache)) return null;
+        if (!hasMeaningfulTranslationTextInNodes(
+            [element],
+            shouldStayOriginal,
+            protectionCache,
+            protectionOptions,
+        )) return null;
         return {kind: 'control', reason: 'generic-control'};
     }
 
     if (!isBlockBoundary(element)) return null;
-    if (!hasMeaningfulTranslationTextInNodes([element], shouldStayOriginal, protectionCache)) return null;
+    if (!hasMeaningfulTranslationTextInNodes(
+        [element],
+        shouldStayOriginal,
+        protectionCache,
+        protectionOptions,
+    )) return null;
     // 含可读块级子节点的容器是结构边界，不是回退目标。若悬浮时选中它，实际命中位于
     // header/aside 子节点时可能误翻译整个应用外壳。
-    if (hasReadableBlockChild(element, shouldStayOriginal, protectionCache)) return null;
+    if (hasReadableBlockChild(element, shouldStayOriginal, protectionCache, protectionOptions)) return null;
     return {kind: 'content', reason: 'generic-readable-block'};
 }

--- a/src/core/translation/public.ts
+++ b/src/core/translation/public.ts
@@ -28,7 +28,9 @@ export {
     getComposedParent,
     getOpenShadowRoots,
     isProtectedDescendantElement,
+    isTopLevelApplicationShell,
 } from './dom';
+export type {TranslationTextProtectionOptions} from './dom';
 export {
     extractTranslationText,
     extractTranslationTextFromNodes,

--- a/src/core/translation/serialization.ts
+++ b/src/core/translation/serialization.ts
@@ -7,6 +7,7 @@
  */
 
 import {isTranslationTextNodeProtected} from './text';
+import type {TranslationTextProtectionOptions} from './dom';
 
 const translationArtifactSelector = [
     '.fluent-read-bilingual-content',
@@ -128,10 +129,16 @@ function translationTextSlotParts(
     node: Text,
     shouldStayOriginal?: (element: Element) => boolean,
     ignoredExtensionElement?: Element,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): TranslationTextSlotParts | null {
     const value = node.nodeValue ?? '';
     const match = value.match(/^(\s*)([\s\S]*?\S)(\s*)$/u);
-    if (!match || isTranslationTextNodeProtected(node, shouldStayOriginal, ignoredExtensionElement)) return null;
+    if (!match || isTranslationTextNodeProtected(
+        node,
+        shouldStayOriginal,
+        ignoredExtensionElement,
+        protectionOptions,
+    )) return null;
     return {prefix: match[1], source: match[2], suffix: match[3]};
 }
 
@@ -139,6 +146,7 @@ function collectSlots(
     root: HTMLElement,
     shouldStayOriginal?: (element: Element) => boolean,
     ignoredExtensionElement?: Element,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): TranslationTextSlot[] {
     const slots: TranslationTextSlot[] = [];
     const document = root.ownerDocument;
@@ -147,7 +155,12 @@ function collectSlots(
     let current = walker.nextNode();
     while (current) {
         const node = current as Text;
-        const parts = translationTextSlotParts(node, shouldStayOriginal, ignoredExtensionElement);
+        const parts = translationTextSlotParts(
+            node,
+            shouldStayOriginal,
+            ignoredExtensionElement,
+            protectionOptions,
+        );
         if (parts) slots.push({node, ...parts});
         current = walker.nextNode();
     }
@@ -159,6 +172,7 @@ function collectSnapshotSlots(
     cloneRoot: HTMLElement,
     shouldStayOriginal?: (element: Element) => boolean,
     ignoredExtensionElement?: Element,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): TranslationTextSlot[] {
     const document = liveRoot.ownerDocument;
     if (!document?.createTreeWalker) return [];
@@ -175,6 +189,7 @@ function collectSnapshotSlots(
             liveNode as Text,
             shouldStayOriginal,
             ignoredExtensionElement,
+            protectionOptions,
         );
         if (parts) slots.push({node: cloneNode as Text, ...parts});
         liveNode = liveWalker.nextNode();
@@ -191,11 +206,18 @@ export function createTranslationSourceSnapshot(
     node: HTMLElement,
     shouldStayOriginal?: (element: Element) => boolean,
     ignoredExtensionElement?: Element,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): TranslationSourceSnapshot {
     const clone = node.cloneNode(true) as HTMLElement;
     // 每个槽都依据实时 composed tree 判断。脱离文档的克隆已失去站点选择器、继承
     // contenteditable 和 CSS 可见性规则所需的外部祖先，只能作为映射后的输出骨架。
-    const slots = collectSnapshotSlots(node, clone, shouldStayOriginal, ignoredExtensionElement);
+    const slots = collectSnapshotSlots(
+        node,
+        clone,
+        shouldStayOriginal,
+        ignoredExtensionElement,
+        protectionOptions,
+    );
     clone.querySelectorAll(translationArtifactSelector).forEach((child) => child.remove());
     return {clone, slots};
 }
@@ -204,8 +226,14 @@ export function collectLiveTranslationTextSlots(
     node: HTMLElement,
     shouldStayOriginal?: (element: Element) => boolean,
     ignoredExtensionElement?: Element,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): TranslationTextSlot[] {
-    return collectSlots(node, shouldStayOriginal, ignoredExtensionElement);
+    return collectSlots(
+        node,
+        shouldStayOriginal,
+        ignoredExtensionElement,
+        protectionOptions,
+    );
 }
 
 /** 只修改脱离文档的快照文本节点；没有对应译文的槽位保持原文。 */

--- a/src/core/translation/text.ts
+++ b/src/core/translation/text.ts
@@ -12,6 +12,7 @@ import {
     isProtectedDescendantElement,
     maxComposedAncestorDepth,
 } from './dom';
+import type {TranslationTextProtectionOptions} from './dom';
 
 const identifierPatterns = [
     /^https?:\/\/\S+$/iu,
@@ -44,6 +45,7 @@ export function isTranslationTextNodeProtected(
     node: Text,
     shouldStayOriginal?: (element: Element) => boolean,
     ignoredExtensionElement?: Element,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): boolean {
     const parent = node.parentElement;
     if (!parent) return true;
@@ -51,7 +53,11 @@ export function isTranslationTextNodeProtected(
     for (const ancestor of composedAncestors(parent)) {
         depth += 1;
         if (depth > maxComposedAncestorDepth) return true;
-        if (isProtectedDescendantElement(ancestor, ancestor === ignoredExtensionElement)) return true;
+        if (isProtectedDescendantElement(
+            ancestor,
+            ancestor === ignoredExtensionElement,
+            protectionOptions,
+        )) return true;
         if (shouldStayOriginal?.(ancestor)) return true;
     }
     return false;
@@ -61,12 +67,18 @@ function collectReadableText(
     roots: readonly Node[],
     shouldStayOriginal?: (element: Element) => boolean,
     ignoredExtensionElement?: Element,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): string {
     const parts: string[] = [];
     for (const root of roots) {
         if (root.nodeType === 3) {
             const textNode = root as Text;
-            if (!isTranslationTextNodeProtected(textNode, shouldStayOriginal, ignoredExtensionElement)) {
+            if (!isTranslationTextNodeProtected(
+                textNode,
+                shouldStayOriginal,
+                ignoredExtensionElement,
+                protectionOptions,
+            )) {
                 const value = normalizeTranslationText(textNode.nodeValue ?? '');
                 if (value) parts.push(value);
             }
@@ -80,7 +92,12 @@ function collectReadableText(
         let current = walker.nextNode();
         while (current) {
             const textNode = current as Text;
-            if (!isTranslationTextNodeProtected(textNode, shouldStayOriginal, ignoredExtensionElement)) {
+            if (!isTranslationTextNodeProtected(
+                textNode,
+                shouldStayOriginal,
+                ignoredExtensionElement,
+                protectionOptions,
+            )) {
                 const value = normalizeTranslationText(textNode.nodeValue ?? '');
                 if (value) parts.push(value);
             }
@@ -114,6 +131,7 @@ export function isTranslationTextElementProtected(
     element: Element,
     shouldStayOriginal: ((element: Element) => boolean) | undefined,
     protectionCache: TranslationTextProtectionCache,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): boolean {
     const cached = protectionCache.get(element);
     if (cached) return cached.protected;
@@ -140,7 +158,7 @@ export function isTranslationTextElementProtected(
         depth += 1;
         protectedByAncestor = protectedByAncestor ||
             depth > maxComposedAncestorDepth ||
-            isProtectedDescendantElement(item) ||
+            isProtectedDescendantElement(item, false, protectionOptions) ||
             shouldStayOriginal?.(item) === true;
         protectionCache.set(item, {depth, protected: protectedByAncestor});
     }
@@ -155,6 +173,7 @@ export function hasMeaningfulTranslationTextInNodes(
     roots: readonly Node[],
     shouldStayOriginal?: (element: Element) => boolean,
     protectionCache = createTranslationTextProtectionCache(),
+    protectionOptions?: TranslationTextProtectionOptions,
 ): boolean {
     const stack: Array<{node: Node; nextChildIndex: number; entered: boolean}> = [];
     const parts: string[] = [];
@@ -164,7 +183,12 @@ export function hasMeaningfulTranslationTextInNodes(
     let rootIndex = 0;
 
     const elementIsProtected = (element: Element): boolean =>
-        isTranslationTextElementProtected(element, shouldStayOriginal, protectionCache);
+        isTranslationTextElementProtected(
+            element,
+            shouldStayOriginal,
+            protectionCache,
+            protectionOptions,
+        );
 
     while (textNodes < discoveryTextNodeBudget && characters < discoveryCharacterBudget) {
         if (stack.length === 0) {
@@ -224,8 +248,14 @@ export function extractTranslationTextFromNodes(
     nodes: readonly Node[],
     shouldStayOriginal?: (element: Element) => boolean,
     ignoredExtensionElement?: Element,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): string {
-    return collectReadableText(nodes, shouldStayOriginal, ignoredExtensionElement);
+    return collectReadableText(
+        nodes,
+        shouldStayOriginal,
+        ignoredExtensionElement,
+        protectionOptions,
+    );
 }
 
 /** 无需克隆候选子树，直接提取宿主页中的可读文本。 */
@@ -233,8 +263,14 @@ export function extractTranslationText(
     element: Element,
     shouldStayOriginal?: (element: Element) => boolean,
     ignoredExtensionElement?: Element,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): string {
-    return collectReadableText([element], shouldStayOriginal, ignoredExtensionElement);
+    return collectReadableText(
+        [element],
+        shouldStayOriginal,
+        ignoredExtensionElement,
+        protectionOptions,
+    );
 }
 
 const hanPattern = /\p{Script=Han}/gu;

--- a/src/core/translation/types.ts
+++ b/src/core/translation/types.ts
@@ -41,6 +41,8 @@ export interface TranslationCandidate {
     kind: TranslationCandidateKind;
     reason: string;
     adapterId?: string;
+    /** 显式选中/悬浮解析允许穿过 body 直接子级的应用级 no-translate 外壳。 */
+    allowTopLevelApplicationShell?: boolean;
 }
 
 export interface TranslationCoreOptions {

--- a/src/features/full-page-translation/content/runtime.ts
+++ b/src/features/full-page-translation/content/runtime.ts
@@ -24,7 +24,11 @@ import {
     resolveTranslationCandidateAtPoint,
     selectPreferredTranslationCandidate,
 } from "@/src/core/translation/public";
-import type {TranslationCandidate, TranslationDiscoveryStep} from "@/src/core/translation/public";
+import type {
+    TranslationCandidate,
+    TranslationDiscoveryStep,
+    TranslationTextProtectionOptions,
+} from "@/src/core/translation/public";
 import { detectlang } from "@/src/core/language/detect";
 import { config } from "@/src/services/config/store";
 import type { FullPageTranslationMode } from "@/src/core/config/model";
@@ -261,11 +265,30 @@ function stateProtectionBoundary(
     return state.syntheticSegment ? node : undefined;
 }
 
+function textProtectionOptions(
+    allowTopLevelApplicationShell: boolean | undefined,
+    protectedElement: Element,
+): TranslationTextProtectionOptions | undefined {
+    return allowTopLevelApplicationShell === true
+        ? {allowTopLevelApplicationShell: true, protectedElement}
+        : undefined;
+}
+
+function candidateTextProtectionOptions(
+    candidate: TranslationCandidate,
+): TranslationTextProtectionOptions | undefined {
+    return textProtectionOptions(
+        candidate.allowTopLevelApplicationShell,
+        candidate.element,
+    );
+}
+
 function currentStateSourceText(node: HTMLElement, state: TranslationState): string {
     return extractTranslationText(
         node,
         getCurrentTranslationCore().shouldStayOriginal,
         stateProtectionBoundary(node, state),
+        textProtectionOptions(state.allowTopLevelApplicationShell, node),
     );
 }
 
@@ -274,6 +297,7 @@ function currentStateTextNodes(node: HTMLElement, state: TranslationState): Text
         node,
         getCurrentTranslationCore().shouldStayOriginal,
         stateProtectionBoundary(node, state),
+        textProtectionOptions(state.allowTopLevelApplicationShell, node),
     ).map((slot) => slot.node);
 }
 
@@ -342,9 +366,10 @@ async function translateElementHTML(
     signal?: AbortSignal,
     queueSession?: TranslationQueueSession,
     fullPageSession?: FullPageSession,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): Promise<SnapshotTranslationResult> {
     const core = getCurrentTranslationCore();
-    const slots = collectLiveTranslationTextSlots(node, core.shouldStayOriginal);
+    const slots = collectLiveTranslationTextSlots(node, core.shouldStayOriginal, undefined, protectionOptions);
     if (slots.length === 0) return {kind: "snapshot", sources: [], translations: []};
 
     const origins = slots.map((part) => part.source);
@@ -362,8 +387,14 @@ async function translateLiveText(
     signal?: AbortSignal,
     queueSession?: TranslationQueueSession,
     fullPageSession?: FullPageSession,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): Promise<LiveTextTranslationResult> {
-    const parts = collectLiveTranslationTextSlots(node, getCurrentTranslationCore().shouldStayOriginal);
+    const parts = collectLiveTranslationTextSlots(
+        node,
+        getCurrentTranslationCore().shouldStayOriginal,
+        undefined,
+        protectionOptions,
+    );
     if (parts.length === 0) return {
         kind: "live-text",
         complete: false,
@@ -402,11 +433,26 @@ async function createTranslationRequest(
     signal?: AbortSignal,
     queueSession?: TranslationQueueSession,
     fullPageSession?: FullPageSession,
+    protectionOptions?: TranslationTextProtectionOptions,
 ): Promise<TranslationResult> {
     if (kind === "control" || mode === "single") {
-        return translateLiveText(node, snapshot, signal, queueSession, fullPageSession);
+        return translateLiveText(
+            node,
+            snapshot,
+            signal,
+            queueSession,
+            fullPageSession,
+            protectionOptions,
+        );
     }
-    return translateElementHTML(node, snapshot, signal, queueSession, fullPageSession);
+    return translateElementHTML(
+        node,
+        snapshot,
+        signal,
+        queueSession,
+        fullPageSession,
+        protectionOptions,
+    );
 }
 
 function attemptSourceIsCurrent(node: HTMLElement, state: TranslationState): boolean {
@@ -528,6 +574,7 @@ async function renderTranslation(
             node,
             core.shouldStayOriginal,
             stateProtectionBoundary(node, state),
+            textProtectionOptions(state.allowTopLevelApplicationShell, node),
         );
         const freshSources = freshSnapshot.slots.map((slot) => slot.source);
         if (freshSources.length !== result.sources.length ||
@@ -559,10 +606,17 @@ function candidateIsCurrent(candidate: TranslationCandidate): boolean {
         const fresh = core.resolve(getTranslationCandidateKey(candidate));
         return Boolean(fresh && fresh.element === candidate.element &&
             fresh.kind === candidate.kind &&
+            fresh.allowTopLevelApplicationShell === candidate.allowTopLevelApplicationShell &&
             getTranslationCandidateKey(fresh) === getTranslationCandidateKey(candidate));
     }
-    const fresh = core.inspect(candidate.element).candidate;
-    return fresh?.element === candidate.element && fresh.kind === candidate.kind;
+    const fresh = candidate.allowTopLevelApplicationShell === true
+        ? core.resolve(candidate.element)
+        : core.inspect(candidate.element).candidate;
+    return Boolean(
+        fresh?.element === candidate.element &&
+        fresh.kind === candidate.kind &&
+        fresh.allowTopLevelApplicationShell === candidate.allowTopLevelApplicationShell,
+    );
 }
 
 function materializeCandidate(candidate: TranslationCandidate): {node: HTMLElement; synthetic: boolean} | null {
@@ -851,9 +905,20 @@ async function translateTarget(
     }
 
     const core = getCurrentTranslationCore();
+    const candidateProtectionOptions = candidateTextProtectionOptions(candidate);
     const sourceText = candidate.nodes?.length
-        ? extractTranslationTextFromNodes(candidate.nodes, core.shouldStayOriginal)
-        : extractTranslationText(candidate.element, core.shouldStayOriginal);
+        ? extractTranslationTextFromNodes(
+            candidate.nodes,
+            core.shouldStayOriginal,
+            undefined,
+            candidateProtectionOptions,
+        )
+        : extractTranslationText(
+            candidate.element,
+            core.shouldStayOriginal,
+            undefined,
+            candidateProtectionOptions,
+        );
     if (!normalizeComparableText(sourceText)) {
         return {
             status: "empty",
@@ -892,6 +957,7 @@ async function translateTarget(
         node,
         core.shouldStayOriginal,
         synthetic ? node : undefined,
+        textProtectionOptions(candidate.allowTopLevelApplicationShell, node),
     ).map((slot) => slot.node);
     const attempt = beginTranslation(
         node,
@@ -900,6 +966,7 @@ async function translateTarget(
         synthetic,
         sourceText,
         sourceTextNodes,
+        candidate.allowTopLevelApplicationShell === true,
     );
     if (!attempt) {
         if (synthetic) node.replaceWith(...Array.from(node.childNodes));
@@ -919,6 +986,7 @@ async function translateTarget(
         signal,
         queueSession,
         owner?.active ? owner : undefined,
+        textProtectionOptions(candidate.allowTopLevelApplicationShell, node),
     )
         .finally(() => signal.removeEventListener('abort', cancelQueuedRequest));
     if (synthetic) node.setAttribute('data-fr-translation-segment', 'true');
@@ -943,9 +1011,20 @@ async function translateTarget(
 function candidateLifecycleSource(candidate: TranslationCandidate): string {
     try {
         const core = getCurrentTranslationCore();
+        const protectionOptions = candidateTextProtectionOptions(candidate);
         return normalizeComparableText(candidate.nodes?.length
-            ? extractTranslationTextFromNodes(candidate.nodes, core.shouldStayOriginal)
-            : extractTranslationText(candidate.element, core.shouldStayOriginal));
+            ? extractTranslationTextFromNodes(
+                candidate.nodes,
+                core.shouldStayOriginal,
+                undefined,
+                protectionOptions,
+            )
+            : extractTranslationText(
+                candidate.element,
+                core.shouldStayOriginal,
+                undefined,
+                protectionOptions,
+            ));
     } catch {
         return normalizeComparableText(candidate.element.textContent ?? "");
     }

--- a/src/features/full-page-translation/content/state.ts
+++ b/src/features/full-page-translation/content/state.ts
@@ -64,6 +64,8 @@ export interface TranslationState {
     sourceHTML: string;
     /** runtime 为直接内联 run 创建的临时 wrapper；所有退出路径都会移除。 */
     syntheticSegment: boolean;
+    /** 显式翻译候选可穿过 body 直接子级的应用级 no-translate 外壳。 */
+    allowTopLevelApplicationShell?: boolean;
     /** 添加加载指示器之前捕获的精确直接子节点。 */
     syntheticSourceNodes?: readonly ChildNode[];
     /** 翻译开始前的内联 style 属性，用于可条件恢复。 */
@@ -195,6 +197,7 @@ export function beginTranslation(
     syntheticSegment = false,
     sourceText = node.textContent ?? "",
     sourceTextNodes?: readonly Text[],
+    allowTopLevelApplicationShell = false,
 ): TranslationAttempt | null {
     const previous = states.get(node);
     if (previous?.phase === "loading") return null;
@@ -220,6 +223,7 @@ export function beginTranslation(
         sourceTextNodes: sourceTextNodes ? [...sourceTextNodes] : undefined,
         sourceHTML: node.innerHTML,
         syntheticSegment,
+        allowTopLevelApplicationShell: allowTopLevelApplicationShell || undefined,
         syntheticSourceNodes: syntheticSegment ? Array.from(node.childNodes) : undefined,
         originalStyleAttribute: node.getAttribute("style"),
         originalClassAttribute: node.getAttribute("class"),

--- a/src/features/selection-translation/core.ts
+++ b/src/features/selection-translation/core.ts
@@ -4,6 +4,8 @@
  * 主要内容：定义 SelectionRequestTokenGate、Presentation 状态机、选区/视口类型，处理同语种判断、文本清理、敏感或可编辑区域排除、多矩形选择及边界内弹窗定位。
  * 模块边界：本模块不监听 document selection、不发消息、不渲染 Vue 或播放音频；组件负责连接 DOM，词典和 TTS 由 services/background 提供，函数保持确定性以供单元测试。
  */
+import {isTopLevelApplicationShell} from '@/src/core/translation/public';
+
 export interface SelectionRect {
     top: number;
     right: number;
@@ -266,7 +268,11 @@ function isSelectionExcludedElement(element: Element | null): boolean {
     const role = element.getAttribute('role')?.trim().toLowerCase();
     if (role && selectionExcludedRoles.has(role)) return true;
     if (isEditableSelectionElement(element)) return true;
-    return Boolean(element.closest(selectionExcludedSelector));
+    const excluded = element.closest(selectionExcludedSelector);
+    if (!excluded) return false;
+    // A broad marker on a body-level SPA shell should not suppress a direct user
+    // selection, while the boundary element itself and nested protected regions remain excluded.
+    return excluded === element || !isTopLevelApplicationShell(excluded);
 }
 
 function elementFromSelectionNode(node: Node | null): Element | null {

--- a/tests/selectionTranslatorCore.test.ts
+++ b/tests/selectionTranslatorCore.test.ts
@@ -1,3 +1,4 @@
+import {parseHTML} from 'linkedom';
 import { describe, expect, it, vi } from 'vitest';
 import {
     canUseBundledDictionaryFallback,
@@ -251,6 +252,45 @@ describe('selection translator text and speech language normalization', () => {
             new MockElement({closestMatch: true}) as unknown as Node,
             false,
         ))).toBe(true);
+    });
+
+    it('allows selection inside a body-level application shell but keeps local opt-outs protected', () => {
+        const {document} = parseHTML(`
+            <html><body>
+                <div id="app" class="notranslate">
+                    <main><p id="content">Readable application content.</p></main>
+                </div>
+            </body></html>
+        `);
+        const text = document.querySelector('#content')?.firstChild;
+        if (!text) throw new Error('selection fixture text is missing');
+
+        const range = {
+            startContainer: text,
+            endContainer: text,
+            cloneContents: () => ({querySelector: () => null}),
+        } as unknown as Range;
+        expect(shouldIgnoreSelection(range)).toBe(false);
+
+        const protectedText = document.createTextNode('Protected local content.');
+        const protectedRegion = document.createElement('span');
+        protectedRegion.className = 'notranslate';
+        protectedRegion.append(protectedText);
+        document.querySelector('#content')?.append(' ', protectedRegion);
+        const protectedRange = {
+            startContainer: protectedText,
+            endContainer: protectedText,
+            cloneContents: () => ({querySelector: () => null}),
+        } as unknown as Range;
+        expect(shouldIgnoreSelection(protectedRange)).toBe(true);
+
+        const shell = document.querySelector('#app');
+        const shellRange = {
+            startContainer: shell,
+            endContainer: shell,
+            cloneContents: () => ({querySelector: () => null}),
+        } as unknown as Range;
+        expect(shouldIgnoreSelection(shellRange)).toBe(true);
     });
 
     it('在 fragment 检查失败时 fail-open，避免破坏普通文本选择', () => {

--- a/tests/translationCore.test.ts
+++ b/tests/translationCore.test.ts
@@ -563,6 +563,53 @@ describe('translation candidate core', () => {
         expect(ids).toEqual(['allowed']);
     });
 
+    it('keeps full-page discovery strict while allowing explicit translation through a body-level app shell', () => {
+        const {document, core} = page(`
+            <div id="app" class="notranslate">
+                <main><article><p id="content">Readable application content.</p>
+                    <div class="notranslate"><p id="protected">Protected local content.</p></div>
+                </article></main>
+            </div>
+        `);
+        const content = document.querySelector('#content') as HTMLElement;
+        const source = content.firstChild;
+        if (!source) throw new Error('hover fixture text is missing');
+
+        expect(core.discover(document)).toEqual([]);
+        expect(core.inspect(content).candidate).toBeNull();
+        expect(core.resolve(document.querySelector('#app'))).toBeNull();
+        expect(core.resolve(source)).toMatchObject({
+            element: content,
+            kind: 'content',
+            allowTopLevelApplicationShell: true,
+        });
+        expect(extractTranslationText(
+            content,
+            core.shouldStayOriginal,
+            undefined,
+            {allowTopLevelApplicationShell: true, protectedElement: content},
+        )).toBe('Readable application content.');
+
+        Object.defineProperty(document, 'elementFromPoint', {
+            configurable: true,
+            value: () => content,
+        });
+        expect(core.resolveAtPoint(document, 1, 2)).toMatchObject({
+            element: content,
+            allowTopLevelApplicationShell: true,
+        });
+
+        const local = document.querySelector('#protected') as HTMLElement;
+        expect(core.resolve(local.firstChild)).toBeNull();
+
+        const {document: nestedDocument, core: nestedCore} = page(`
+            <div id="outer">
+                <div class="notranslate"><p id="nested">Nested protected content.</p></div>
+            </div>
+        `);
+        expect(nestedCore.resolve(nestedDocument.querySelector('#nested')?.firstChild)).toBeNull();
+    });
+
     it('preserves inline code/no-translate text without rejecting the outer prose', () => {
         const {document, core} = page(`
             <main><p id="issue-127">Set <code class="notranslate">xxx</code> to enable the feature safely.</p></main>


### PR DESCRIPTION
Fixes #361\n\n## Summary\n\n- Allow explicit selection and hover translation to cross only a no-translate element that is a direct child of body and acts as an application shell.\n- Keep automatic/full-page discovery strict.\n- Keep the selected boundary itself and nested/local no-translate regions protected.\n- Carry the explicit policy through text extraction and the full-page translation lifecycle.\n\n## Verification\n\n- pnpm test: 150 files, 2145 tests passed\n- pnpm compile passed\n- pnpm build passed\n- Hidden isolated Edge fixture: target/neighbor/local protected counts 1/0/0; restore and retranslate passed; URL unchanged\n- Real-site matrix: 32/40 required jobs passed; the 8 failures were stale site selectors or long-page/harness waits, not translation-core assertions.