### PR TITLE
fix: prevent Bilibili comment double-click from freezing the page

### DIFF
--- a/src/core/translation/adapters/bilibili.ts
+++ b/src/core/translation/adapters/bilibili.ts
@@ -1,0 +1,32 @@
+/**
+ * @file src/core/translation/adapters/bilibili.ts
+ *
+ * 文件职责：声明 B 站评论组件的候选保护规则，避免翻译渲染进入由 B 站自定义元素和 Shadow DOM 管理的评论子树。
+ * 主要内容：导出 bilibiliAdapter，裁剪评论根节点及其兼容性后备节点，保留视频页其他普通正文继续使用通用候选发现。
+ * 模块边界：本文件位于 core 的站点规则层，只表达 URL 与 DOM 候选决策；不发送翻译请求、不渲染译文、不监听业务生命周期，通用安全守卫仍由 TranslationCandidateCore 执行。
+ */
+
+import {createDeclarativeAdapter} from './declarative';
+
+/**
+ * B 站评论由多层自定义元素维护自己的 Shadow DOM。向其中插入双语节点会把
+ * FluentRead 的 DOM 事务交给站点渲染器共同管理，双击评论时尤其容易触发页面卡死。
+ * 评论区是交互组件而非文章正文，因此整棵评论子树保持由 B 站自己维护。
+ */
+export const bilibiliAdapter = createDeclarativeAdapter({
+    id: 'bilibili',
+    priority: 380,
+    hosts: [{hostname: 'bilibili.com', includeSubdomains: true}],
+    prune: [
+        {
+            selector: [
+                '#commentapp',
+                'bili-comments',
+                'bili-comment-thread-renderer',
+                'bili-comment-renderer',
+                'bili-rich-text',
+            ],
+            reason: 'bilibili-comment-component',
+        },
+    ],
+});

--- a/src/core/translation/engine.ts
+++ b/src/core/translation/engine.ts
@@ -50,6 +50,12 @@ import {
 } from './internal';
 
 const maxHoverBarrierDiscoverySteps = 256;
+/**
+ * Shadow DOM 的坐标命中 API 属于宿主页面实现，异常组件可能把同一个 host
+ * 再次返回给嵌套 root。坐标解析必须有独立于祖先扫描的深度上限，避免递归耗尽
+ * content script 的调用栈并让页面看起来失去响应。
+ */
+const maxPointResolutionDepth = 64;
 
 interface AdapterDecisionResult {
     decision: AdapterDecision;
@@ -830,19 +836,28 @@ export class TranslationCandidateCore {
     }
 
     resolveAtPoint(root: Document | ShadowRoot, x: number, y: number): TranslationCandidate | null {
-        const pointedNode = findNodeAtPoint(root, x, y);
-        if (pointedNode) {
-            const pointedCandidate = this.resolve(pointedNode);
-            if (pointedCandidate) return pointedCandidate;
-        }
-        for (const element of findElementsAtPoint(root, x, y)) {
-            if (element.shadowRoot) {
-                const shadowCandidate = this.resolveAtPoint(element.shadowRoot, x, y);
-                if (shadowCandidate) return shadowCandidate;
+        const visitedRoots = new Set<Document | ShadowRoot>();
+        const resolveInRoot = (currentRoot: Document | ShadowRoot, depth: number): TranslationCandidate | null => {
+            if (depth > maxPointResolutionDepth || visitedRoots.has(currentRoot)) return null;
+            visitedRoots.add(currentRoot);
+
+            const pointedNode = findNodeAtPoint(currentRoot, x, y);
+            if (pointedNode) {
+                const pointedCandidate = this.resolve(pointedNode);
+                if (pointedCandidate) return pointedCandidate;
             }
-            const candidate = this.resolve(element);
-            if (candidate) return candidate;
-        }
-        return null;
+
+            for (const element of findElementsAtPoint(currentRoot, x, y)) {
+                if (element.shadowRoot) {
+                    const shadowCandidate = resolveInRoot(element.shadowRoot, depth + 1);
+                    if (shadowCandidate) return shadowCandidate;
+                }
+                const candidate = this.resolve(element);
+                if (candidate) return candidate;
+            }
+            return null;
+        };
+
+        return resolveInRoot(root, 0);
     }
 }

--- a/src/core/translation/registry.ts
+++ b/src/core/translation/registry.ts
@@ -2,7 +2,7 @@
  * @file src/core/translation/registry.ts
  *
  * 文件职责：登记并排序 FluentRead 内置站点翻译适配器，为候选核心提供稳定、只读的默认规则集合。
- * 主要内容：汇集 GitHub、GNU、Hacker News、LearnOpenGL、Reddit、X 与 YouTube 适配器，按 priority 和声明顺序生成 defaultTranslationAdapters。 可核对的公开符号包括 defaultTranslationAdapters。
+ * 主要内容：汇集 B 站、GitHub、GNU、Hacker News、LearnOpenGL、Reddit、X 与 YouTube 适配器，按 priority 和声明顺序生成 defaultTranslationAdapters。 可核对的公开符号包括 defaultTranslationAdapters。
  * 模块边界：本文件属于可独立测试的 core 候选领域；可以读取传入 DOM 以计算结果，但不访问配置存储、不调用 provider、不注册页面监听器，也不负责译文渲染或 feature 生命周期。
  */
 
@@ -14,8 +14,10 @@ import {hackerNewsAdapter} from './adapters/hackernews';
 import {youtubeAdapter} from './adapters/youtube';
 import {gnuManualAdapter} from './adapters/gnu';
 import {learnOpenGLAdapter} from './adapters/learnopengl';
+import {bilibiliAdapter} from './adapters/bilibili';
 
 const declaredAdapters = [
+    bilibiliAdapter,
     githubAdapter,
     xAdapter,
     redditAdapter,

--- a/tests/translationCore.test.ts
+++ b/tests/translationCore.test.ts
@@ -50,6 +50,7 @@ import {
     partitionInlineRunAtBarriers,
     readCachedFlagOr,
 } from '@/src/core/translation/internal';
+import {bilibiliAdapter} from '@/src/core/translation/adapters/bilibili';
 
 function page(html: string, url = 'https://example.test/article') {
     const {document} = parseHTML(`<html><head></head><body>${html}</body></html>`);
@@ -884,6 +885,76 @@ describe('translation candidate core', () => {
 
         expect(core.discover(document).map((item) => item.element.id)).toContain('shadow-prose');
         expect(core.resolve(shadowRoot.querySelector('#shadow-prose'))?.element.id).toBe('shadow-prose');
+    });
+
+    it('prunes Bilibili comments across nested Shadow DOM without hiding page prose', () => {
+        const {document, core} = page(`
+            <main>
+                <bili-comments id="comments"></bili-comments>
+                <p id="page-prose">The surrounding video page remains translatable.</p>
+            </main>
+        `, 'https://www.bilibili.com/video/BV1ux4y1e73x/');
+        const comments = document.querySelector('#comments')!;
+        const commentsShadow = comments.attachShadow({mode: 'open'});
+        const thread = document.createElement('bili-comment-thread-renderer');
+        commentsShadow.append(thread);
+        const threadShadow = thread.attachShadow({mode: 'open'});
+        const renderer = document.createElement('bili-comment-renderer');
+        threadShadow.append(renderer);
+        const rendererShadow = renderer.attachShadow({mode: 'open'});
+        const richText = document.createElement('bili-rich-text');
+        rendererShadow.append(richText);
+        const richTextShadow = richText.attachShadow({mode: 'open'});
+        const commentText = document.createElement('p');
+        commentText.id = 'comment-prose';
+        commentText.textContent = 'A Bilibili comment that must remain owned by the site.';
+        richTextShadow.append(commentText);
+
+        expect(bilibiliAdapter.matches(new URL('https://www.bilibili.com/video/BV1ux4y1e73x/'))).toBe(true);
+        expect(bilibiliAdapter.matches(new URL('https://example.test/video'))).toBe(false);
+        expect(core.discover(document).map((candidate) => candidate.element.id)).toContain('page-prose');
+        expect(core.discover(document).some((candidate) => candidate.element === commentText)).toBe(false);
+        expect(core.resolve(commentText.firstChild)).toBeNull();
+
+        Object.defineProperty(document, 'elementFromPoint', {
+            configurable: true,
+            value: () => comments,
+        });
+        Object.defineProperty(commentsShadow, 'elementFromPoint', {
+            configurable: true,
+            value: () => thread,
+        });
+        Object.defineProperty(threadShadow, 'elementFromPoint', {
+            configurable: true,
+            value: () => renderer,
+        });
+        Object.defineProperty(rendererShadow, 'elementFromPoint', {
+            configurable: true,
+            value: () => richText,
+        });
+        Object.defineProperty(richTextShadow, 'elementFromPoint', {
+            configurable: true,
+            value: () => commentText,
+        });
+        expect(core.resolveAtPoint(document, 10, 20)).toBeNull();
+    });
+
+    it('bounds cyclic Shadow DOM coordinate lookup without overflowing the call stack', () => {
+        const {document, core} = page('<main><article-card id="host"></article-card></main>');
+        const host = document.querySelector('#host')!;
+        const shadowRoot = host.attachShadow({mode: 'open'});
+
+        Object.defineProperty(document, 'elementFromPoint', {
+            configurable: true,
+            value: () => host,
+        });
+        Object.defineProperty(shadowRoot, 'elementFromPoint', {
+            configurable: true,
+            value: () => host,
+        });
+
+        expect(() => core.resolveAtPoint(document, 10, 20)).not.toThrow();
+        expect(core.resolveAtPoint(document, 10, 20)).toBeNull();
     });
 
     it('translates GitHub PR titles instead of pruning repository-content', () => {

--- a/vitest.coverage.config.ts
+++ b/vitest.coverage.config.ts
@@ -229,6 +229,7 @@ export default defineConfig({
                 'src/features/video-subtitle/content/youtubeTimedTextMessage.ts',
                 'src/features/video-subtitle/content/serviceProfile.ts',
                 'src/core/translation/adapters/declarative.ts',
+                'src/core/translation/adapters/bilibili.ts',
                 'src/core/translation/adapters/github.ts',
                 'src/core/translation/adapters/gnu.ts',
                 'src/core/translation/adapters/hackernews.ts',


### PR DESCRIPTION
## Summary

Fixes #382.

Bilibili comments are rendered through nested Shadow DOM components. The hover translation coordinate resolver recursively followed shadow roots without cycle/depth protection, so a host returned again by the point-hit API could overflow the content script call stack and make the page unresponsive. The resolver now de-duplicates visited roots and enforces a bounded depth. A Bilibili site adapter also keeps the comment component subtree out of translation DOM mutations while leaving surrounding video-page prose translatable.

## Verification

- pnpm compile
- pnpm test:translation-core (145 tests passed)
- pnpm test:regression:all (audit, strict V8 coverage, architecture/unit/functional/regression groups, Chrome/Firefox builds and manifest verification, userscript verification, docs build)
- Real hidden isolated Edge: playing Bilibili video, scroll to a live comment, trusted double-click with DoubleClick translation enabled; no page errors, no console errors, no translation request or comment DOM mutation, heartbeat max gap 39.2 ms.
