### PR TITLE
fix: stabilize translation-only dynamic text

### DIFF
--- a/src/features/full-page-translation/content/renderer.ts
+++ b/src/features/full-page-translation/content/renderer.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/features/full-page-translation/content/renderer.ts
- * 文件职责：把翻译返回的受限 HTML 或纯文本安全插入原页面，构造 FluentRead 双语译文节点，同时保护链接属性并触发布局截断修复。
- * 主要内容：包含 URL 协议白名单、可复制属性集合、递归节点净化、DocumentFragment 创建，以及 appendBilingualTranslation 对译文样式、显示模式和原文节点的组装。
+ * 文件职责：把翻译返回的受限 HTML 或纯文本安全插入原页面，构造 FluentRead 双语与仅译文节点，同时保护链接属性并触发布局截断修复。
+ * 主要内容：包含 URL 协议白名单、可复制属性集合、递归节点净化、DocumentFragment 创建、双语 wrapper，以及通过 Shadow DOM 保留宿主原文的仅译文文本槽。
  * 模块边界：本文件只负责安全渲染，不发起翻译或管理请求状态；服务调用归 runtime，节点所有权归 state，配置仅用于展示选项，任意脚本、事件属性和危险链接都不得穿过净化边界。
  */
 import { options } from "@/src/core/config/catalog";
@@ -85,6 +85,52 @@ export interface BilingualTranslationRenderOptions {
     targetLanguage?: string;
     /** 全文会话启动时冻结的译文样式。 */
     style?: number;
+}
+
+export interface SingleTranslationSlot {
+    node: Text;
+    text: string;
+}
+
+/**
+ * 仅译文模式不再改写宿主 Text.nodeValue。React、GitHub relative-time
+ * 等动态组件会把被改写的文本立即校正回原文，与 MutationObserver
+ * 重译形成无限往返。这里把原 Text 移入轻 DOM，但只渲染闭合
+ * ShadowRoot 中的译文：宿主仍能读到原 textContent 和原节点身份，
+ * 用户看到的则是可选中、可复制且继承页面样式的译文。
+ */
+export function appendSingleTranslationSlots(
+    owner: HTMLElement,
+    slots: readonly SingleTranslationSlot[],
+    renderOptions: BilingualTranslationRenderOptions = {},
+): HTMLElement[] {
+    if (slots.some(({node}) => !node.parentNode || !owner.contains(node))) return [];
+    const hosts: HTMLElement[] = [];
+    for (const slot of slots) {
+        const parent = slot.node.parentNode!;
+
+        const host = owner.ownerDocument.createElement("span");
+        host.classList.add("fluent-read-single-slot");
+        host.setAttribute("data-fr-translation-owned", "true");
+        host.setAttribute("translate", "no");
+        host.setAttribute("aria-label", slot.text);
+        host.lang = (renderOptions.targetLanguage ?? config.to) || "";
+        host.dir = "auto";
+
+        const shadow = host.attachShadow({mode: "closed"});
+        const translated = owner.ownerDocument.createElement("span");
+        translated.setAttribute("data-fr-translation-owned", "true");
+        translated.setAttribute("translate", "no");
+        translated.lang = host.lang;
+        translated.dir = "auto";
+        translated.textContent = slot.text;
+        shadow.appendChild(translated);
+
+        parent.insertBefore(host, slot.node);
+        host.appendChild(slot.node);
+        hosts.push(host);
+    }
+    return hosts;
 }
 
 export function appendBilingualTranslation(

--- a/src/features/full-page-translation/content/runtime.ts
+++ b/src/features/full-page-translation/content/runtime.ts
@@ -44,6 +44,7 @@ import {
 } from '@/src/features/full-page-translation/progress';
 import {
     appendBilingualTranslation,
+    appendSingleTranslationSlots,
 } from "@/src/features/full-page-translation/content/renderer";
 import {ensureTranslationTruncationLayout} from "@/src/features/full-page-translation/content/layout";
 import {
@@ -59,6 +60,7 @@ import {
     setBilingualContent,
     setRenderedStyleAttribute,
     setRetryWrapper,
+    setSingleTextSlotHosts,
     setSpinner,
     setTextSlotsApplied,
     isTranslationLayoutOverrideMutation,
@@ -107,6 +109,7 @@ interface LiveTextTranslationResult {
     complete: boolean;
     changed: boolean;
     nodes: readonly Text[];
+    slots: readonly {node: Text; text: string}[];
     apply: () => void;
 }
 
@@ -305,6 +308,17 @@ function statefulSourceAndTextSlotsAreCurrent(
     node: HTMLElement,
     state: TranslationState,
 ): boolean {
+    if (state.singleTextSlotHosts) {
+        const previousNodes = state.sourceTextNodes ?? [];
+        if (state.singleTextSlotHosts.length !== previousNodes.length) return false;
+        return state.singleTextSlotHosts.every(({host, source, sourceValue}, index) =>
+            previousNodes[index] === source &&
+            host.parentNode !== null &&
+            node.contains(host) &&
+            host.contains(source) &&
+            (source.nodeValue ?? "") === sourceValue);
+    }
+
     const currentNodes = currentStateTextNodes(node, state);
     const previousNodes = state.translatedTextNodes ?? state.sourceTextNodes ?? [];
     if (currentNodes.length !== previousNodes.length ||
@@ -400,6 +414,7 @@ async function translateLiveText(
         complete: false,
         changed: false,
         nodes: [],
+        slots: [],
         apply: () => undefined,
     };
 
@@ -414,6 +429,10 @@ async function translateLiveText(
         complete: translations.length === origins.length,
         changed,
         nodes: parts.map((part) => part.node),
+        slots: parts.map((part, index) => ({
+            node: part.node,
+            text: `${part.prefix}${translations[index] ?? part.source}${part.suffix}`,
+        })),
         apply: () => {
             translations.forEach((translation, index) => {
                 const part = parts[index];
@@ -552,8 +571,16 @@ async function renderTranslation(
             if (!markTranslationComplete(node, state, generation, false)) {
                 return staleOutcome();
             }
-            liveResult.apply();
-            setTextSlotsApplied(node, liveResult.nodes);
+            if (state.mode === "single" && state.kind === "content") {
+                const hosts = appendSingleTranslationSlots(node, liveResult.slots, {
+                    targetLanguage: snapshot.targetLanguage,
+                });
+                if (hosts.length !== liveResult.slots.length) return staleOutcome();
+                setSingleTextSlotHosts(node, hosts);
+            } else {
+                liveResult.apply();
+                setTextSlotsApplied(node, liveResult.nodes);
+            }
             return {status: "committed"};
         }
 

--- a/src/features/full-page-translation/content/state.ts
+++ b/src/features/full-page-translation/content/state.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/features/full-page-translation/content/state.ts
  * 文件职责：维护每个被翻译 DOM 节点的可恢复状态、请求代次、译文工件和共享布局覆盖所有权，确保重复翻译、宿主变更和移除节点都能安全收敛。
- * 主要内容：包含 WeakMap 状态索引、begin/complete/error/discard 状态机、spinner/译文/retry 节点登记、截断祖先样式快照与观察器引用计数、文本槽回写以及全量恢复。
+ * 主要内容：包含 WeakMap 状态索引、begin/complete/error/discard 状态机、spinner/译文/retry/仅译文槽节点登记、截断祖先样式快照与观察器引用计数、文本槽回写以及全量恢复。
  * 模块边界：该模块不发现候选、不请求翻译也不生成译文 HTML；runtime 负责会话编排，renderer 负责内容创建，本文件仅拥有 DOM 状态与可逆样式资源，避免跨 session 误删新结果。
  */
 import {
@@ -84,6 +84,8 @@ export interface TranslationState {
     translatedTextValues?: WeakMap<Text, string>;
     /** 单译文或控件渲染执行时可见且可翻译的 Text 节点。 */
     translatedTextNodes?: readonly Text[];
+    /** 仅译文 content 的视觉替换槽；每个 host 的轻 DOM 仍保存宿主原 Text。 */
+    singleTextSlotHosts?: Array<{host: HTMLElement; source: Text; sourceValue: string}>;
     controller: AbortController;
     spinner?: HTMLElement;
     bilingualContent?: HTMLElement;
@@ -166,6 +168,7 @@ function refreshOwnershipIndex(owner: HTMLElement, state: TranslationState): voi
         ...(state.spinner ? [state.spinner] : []),
         ...(state.bilingualContent ? [state.bilingualContent] : []),
         ...(state.retryWrapper ? [state.retryWrapper] : []),
+        ...(state.singleTextSlotHosts?.map(({host}) => host) ?? []),
         ...(state.layoutOverrideElements ?? []),
         ...(state.layoutWatchElements ?? []),
     ]);
@@ -782,6 +785,16 @@ function teardownAttempt(
 ): void {
     state.generation += 1;
     state.controller.abort();
+
+    // 仅译文槽的轻 DOM 保存原始 Text 节点，必须在通用扩展产物
+    // 清理之前解包。宿主已移除或移走的槽保持宿主权威，不重新插回。
+    state.singleTextSlotHosts?.forEach(({host}) => {
+        if (!node.contains(host) || !host.parentNode) return;
+        const parent = host.parentNode;
+        while (host.firstChild) parent.insertBefore(host.firstChild, host);
+        parent.removeChild(host);
+    });
+
     removeExtensionNode(state.spinner);
     removeExtensionNode(state.bilingualContent);
     removeRetryArtifacts(node);
@@ -817,6 +830,23 @@ export function setTextSlotsApplied(
             state.originalTextValues.map(({node: textNode}) => [textNode, textNode.nodeValue ?? ""]),
         );
     }
+}
+
+export function setSingleTextSlotHosts(
+    node: HTMLElement,
+    hosts: readonly HTMLElement[],
+): void {
+    const state = states.get(node);
+    if (!state) return;
+    const originalValues = new WeakMap(
+        state.originalTextValues.map(({node: textNode, value}) => [textNode, value]),
+    );
+    state.singleTextSlotHosts = hosts.flatMap((host) => {
+        const source = Array.from(host.childNodes).find((child): child is Text => child.nodeType === 3);
+        if (!source) return [];
+        return [{host, source, sourceValue: originalValues.get(source) ?? source.nodeValue ?? ""}];
+    });
+    refreshOwnershipIndex(node, state);
 }
 
 /**

--- a/tests/fullPageVisibilityScheduling.test.ts
+++ b/tests/fullPageVisibilityScheduling.test.ts
@@ -84,6 +84,24 @@ vi.mock('@/src/features/full-page-translation/ui/translationIndicators', () => (
     },
 }));
 vi.mock("@/src/features/full-page-translation/content/renderer", () => ({
+    appendSingleTranslationSlots: (
+        node: HTMLElement,
+        slots: readonly {node: Text; text: string}[],
+        options: Record<string, unknown> = {},
+    ) => slots.map((slot) => {
+        const host = node.ownerDocument.createElement("span");
+        host.className = "fluent-read-single-slot";
+        host.setAttribute("data-fr-translation-owned", "true");
+        host.setAttribute("aria-label", slot.text);
+        host.lang = typeof options.targetLanguage === "string" ? options.targetLanguage : "";
+        const shadow = host.attachShadow({mode: "open"});
+        const translated = node.ownerDocument.createElement("span");
+        translated.textContent = slot.text;
+        shadow.appendChild(translated);
+        slot.node.parentNode!.insertBefore(host, slot.node);
+        host.appendChild(slot.node);
+        return host;
+    }),
     appendBilingualTranslation: (node: HTMLElement, text: string, options: Record<string, unknown> = {}) => {
         runtime.renderOptions.push(options);
         const wrapper = node.ownerDocument.createElement("span");
@@ -200,6 +218,12 @@ import {
     translateTextSlots,
     type FullPageTranslationConfigSnapshot,
 } from '@/src/features/full-page-translation/content/translationRequest';
+
+function singleTranslationText(owner: HTMLElement): string {
+    return Array.from(owner.querySelectorAll<HTMLElement>('.fluent-read-single-slot'))
+        .map((host) => host.getAttribute('aria-label') ?? '')
+        .join('');
+}
 
 class TestIntersectionObserver {
     static instances: TestIntersectionObserver[] = [];
@@ -960,8 +984,8 @@ describe("全文翻译可见性锚点", () => {
         expect(runtime.requests).toHaveBeenCalledTimes(2);
         expect(runtime.requests).toHaveBeenCalledWith(["Visible paragraph"]);
         expect(runtime.requests).toHaveBeenCalledWith(["Paragraph near the page bottom"]);
-        expect(visible.textContent).toBe("译:Visible paragraph");
-        expect(belowFold.textContent).toBe("译:Paragraph near the page bottom");
+        expect(singleTranslationText(visible)).toBe("译:Visible paragraph");
+        expect(singleTranslationText(belowFold)).toBe("译:Paragraph near the page bottom");
     });
 
     it("立即翻译整页仍只并发三个候选，释放槽位后才启动下一项", async () => {
@@ -995,7 +1019,7 @@ describe("全文翻译可见性锚点", () => {
         requests[2]!.resolve(["译:Three"]);
         requests[3]!.resolve(["译:Four"]);
         await finishScheduledWork();
-        expect(candidates.map((candidate) => candidate.textContent)).toEqual([
+        expect(candidates.map(singleTranslationText)).toEqual([
             "译:One", "译:Two", "译:Three", "译:Four",
         ]);
     });
@@ -1053,7 +1077,7 @@ describe("全文翻译可见性锚点", () => {
 
         expect(TestIntersectionObserver.instances[1]!.observe).not.toHaveBeenCalled();
         expect(runtime.requests).toHaveBeenCalledWith(["Mode changes apply to the next session."]);
-        expect(paragraph.textContent).toBe("译:Mode changes apply to the next session.");
+        expect(singleTranslationText(paragraph)).toBe("译:Mode changes apply to the next session.");
     });
 
     it("全文会话冻结服务、模型、语言、缓存、AI 上下文、显示模式和样式，配置热更新不会混入后续候选", async () => {
@@ -1136,7 +1160,7 @@ describe("全文翻译可见性锚点", () => {
         await finishScheduledWork();
 
         expect(runtime.requests).toHaveBeenCalledWith(["A paragraph appended by infinite scroll"]);
-        expect(paragraph.textContent).toBe("译:A paragraph appended by infinite scroll");
+        expect(singleTranslationText(paragraph)).toBe("译:A paragraph appended by infinite scroll");
         expect(TestIntersectionObserver.instances[0]!.observe).not.toHaveBeenCalled();
     });
 
@@ -1160,7 +1184,7 @@ describe("全文翻译可见性锚点", () => {
         await finishScheduledWork();
 
         expect(runtime.requests).toHaveBeenCalledWith(["Pull request title"]);
-        expect(title.textContent).toBe("译:Pull request title");
+        expect(singleTranslationText(title)).toBe("译:Pull request title");
         expect(observer.unobserve).toHaveBeenCalledWith(label);
     });
 
@@ -1215,7 +1239,7 @@ describe("全文翻译可见性锚点", () => {
 
         request.resolve(["译:Hydrated title"]);
         await finishScheduledWork();
-        expect(title.textContent).toBe("译:Hydrated title");
+        expect(singleTranslationText(title)).toBe("译:Hydrated title");
         expect(runtime.requests).toHaveBeenCalledTimes(1);
     });
 
@@ -1275,7 +1299,7 @@ describe("全文翻译可见性锚点", () => {
         expect(observer.observe).not.toHaveBeenCalled();
         expect(runtime.requests).toHaveBeenCalledTimes(1);
         expect(runtime.requests).toHaveBeenCalledWith(["Text-only heading"]);
-        expect(title.textContent).toBe("译:Text-only heading");
+        expect(singleTranslationText(title)).toBe("译:Text-only heading");
     });
 
     it("inFlightCandidates 是唯一并发计数，并在 settle 后释放下一候选", async () => {
@@ -1312,7 +1336,7 @@ describe("全文翻译可见性锚点", () => {
         requests[2]!.resolve(["译:Three"]);
         requests[3]!.resolve(["译:Four"]);
         await finishScheduledWork();
-        expect(candidates.map((candidate) => candidate.textContent)).toEqual([
+        expect(candidates.map(singleTranslationText)).toEqual([
             "译:One", "译:Two", "译:Three", "译:Four",
         ]);
     });
@@ -1410,7 +1434,7 @@ describe("全文翻译可见性锚点", () => {
             requests[4]!.resolve(["译:Five"]);
             await finishScheduledWork();
 
-            expect(candidates.map((candidate) => candidate.textContent)).toEqual([
+            expect(candidates.map(singleTranslationText)).toEqual([
                 "译:One", "译:Two", "译:Three", "译:Four", "译:Five",
             ]);
             expectCurrentProgress({
@@ -1577,7 +1601,7 @@ describe("全文翻译可见性锚点", () => {
         expect(runtime.requests).toHaveBeenCalledTimes(2);
         expect(getTranslationState(paragraph)).toMatchObject({phase: "translated", mode: "single"});
         expect(paragraph.querySelector(".fluent-read-bilingual-content")).toBeNull();
-        expect(paragraph.textContent).toBe("译:Retry with the latest display mode.");
+        expect(singleTranslationText(paragraph)).toBe("译:Retry with the latest display mode.");
     });
 
     it("行内片段首次失败后会从原始候选恢复并完成手动重试", async () => {
@@ -2131,7 +2155,7 @@ describe("全文翻译可见性锚点", () => {
         expect(runtime.requests).toHaveBeenNthCalledWith(3, [
             "The settled perspective paragraph keeps the inline formula intact.",
         ]);
-        expect(paragraph.textContent).toBe("译:The settled perspective paragraph keeps the inline formula intact.");
+        expect(singleTranslationText(paragraph)).toBe("译:The settled perspective paragraph keeps the inline formula intact.");
 
         await finishScheduledWork();
         expect(runtime.requests).toHaveBeenCalledTimes(3);
@@ -2198,6 +2222,41 @@ describe("全文翻译可见性锚点", () => {
             expect(runtime.requests).toHaveBeenCalledTimes(1);
         },
     );
+
+    it("仅译文保留动态组件的原 Text，宿主一致性校验不再与重译循环争用", async () => {
+        runtime.config.display = 0;
+        runtime.config.fullPageTranslationMode = "all";
+        document.body.innerHTML = '<relative-time id="time">12 hours ago</relative-time>';
+        const time = document.querySelector<HTMLElement>("#time")!;
+        const originalText = time.firstChild as Text;
+        setLayoutBox(time, 120, 24);
+        runtime.candidates = [{element: time, kind: "content", reason: "generic-text-container"}];
+
+        autoTranslateEnglishPage();
+        await finishScheduledWork();
+
+        expect(runtime.requests).toHaveBeenCalledTimes(1);
+        expect(runtime.requests).toHaveBeenCalledWith(["12 hours ago"]);
+        expect(singleTranslationText(time)).toBe("译:12 hours ago");
+        expect(time.textContent).toBe("12 hours ago");
+        expect(time.querySelector('.fluent-read-single-slot')?.firstChild).toBe(originalText);
+
+        // GitHub 这类组件会读取 textContent 并在值偏离时写回。旧实现每轮
+        // 都会看到译文并写回英文；新实现中连续校验不产生任何 mutation。
+        let hostCorrections = 0;
+        for (let index = 0; index < 5; index += 1) {
+            if (time.textContent !== "12 hours ago") {
+                time.textContent = "12 hours ago";
+                hostCorrections += 1;
+            }
+        }
+        expect(hostCorrections).toBe(0);
+        expect(runtime.requests).toHaveBeenCalledTimes(1);
+
+        restoreOriginalContent();
+        expect(time.textContent).toBe("12 hours ago");
+        expect(time.querySelector('.fluent-read-single-slot')).toBeNull();
+    });
 
     it("已译 prose 忽略 MathJax/code 等保护后代 churn，但外层 source mutation 会重启", async () => {
         runtime.config.display = 1;
@@ -2573,6 +2632,6 @@ describe("全文翻译可见性锚点", () => {
         await finishScheduledWork();
 
         expect(runtime.requests).toHaveBeenCalledTimes(4);
-        expect(paragraph.textContent).toBe("译:Late prose became readable after hydration.");
+        expect(singleTranslationText(paragraph)).toBe("译:Late prose became readable after hydration.");
     });
 });

--- a/tests/translationState.test.ts
+++ b/tests/translationState.test.ts
@@ -14,6 +14,7 @@ import {
     setBilingualContent,
     setRenderedStyleAttribute,
     setRetryWrapper,
+    setSingleTextSlotHosts,
     setSpinner,
     setTextSlotsApplied,
     type TranslationState,
@@ -245,6 +246,26 @@ describe("指定节点翻译状态机", () => {
         expect(target.querySelector('a')).toBe(link);
         expect(originalNodes[0]!.nodeValue).toBe('Open ');
         expect(originalNodes[1]!.nodeValue).toBe('Host updated link');
+    });
+
+    it("仅译文视觉槽恢复原 Text 身份，并保留宿主在槽内的实时更新", () => {
+        const {document} = parseHTML('<html><body><relative-time id="time">12 hours ago</relative-time></body></html>');
+        const target = document.querySelector<HTMLElement>('#time')!;
+        const source = target.firstChild as Text;
+        beginTranslation(target, 'single', 'content', false, '12 hours ago', [source]);
+
+        const host = document.createElement('span');
+        host.setAttribute('data-fr-translation-owned', 'true');
+        target.insertBefore(host, source);
+        host.appendChild(source);
+        setSingleTextSlotHosts(target, [host]);
+
+        source.nodeValue = '11 hours ago';
+        expect(restoreTranslation(target)).toBe(true);
+
+        expect(target.firstChild).toBe(source);
+        expect(target.textContent).toBe('11 hours ago');
+        expect(host.isConnected).toBe(false);
     });
 
     it("能在宿主移除双语 wrapper 后找到并清理其 owner", () => {

--- a/tests/translationTruncation.test.ts
+++ b/tests/translationTruncation.test.ts
@@ -24,9 +24,13 @@ import {
     reconcileTranslationLayoutOverrides,
     restoreTranslation,
     setBilingualContent,
+    setSingleTextSlotHosts,
 } from '@/src/features/full-page-translation/content/state';
 import {ensureTranslationTruncationLayout} from '@/src/features/full-page-translation/content/layout';
-import {appendBilingualTranslation} from '@/src/features/full-page-translation/content/renderer';
+import {
+    appendBilingualTranslation,
+    appendSingleTranslationSlots,
+} from '@/src/features/full-page-translation/content/renderer';
 
 function openRouterFixture() {
     const {document} = parseHTML(`
@@ -293,6 +297,62 @@ describe('translation truncation layout', () => {
             } finally {
                 Object.assign(config, previousConfig);
                 options.styles = previousStyles;
+            }
+        });
+    });
+
+    it('仅译文 renderer 在闭合 ShadowRoot 显示译文，不改写宿主 textContent', async () => {
+        const {document} = parseHTML('<html><body><relative-time id="time">12 hours ago</relative-time></body></html>');
+        const owner = document.querySelector<HTMLElement>('#time')!;
+        const source = owner.firstChild as Text;
+
+        await withDocumentRealm(document, async () => {
+            beginTranslation(owner, 'single', 'content', false, '12 hours ago', [source]);
+            const hosts = appendSingleTranslationSlots(owner, [{node: source, text: '12 小时前'}], {
+                targetLanguage: 'zh-Hans',
+            });
+            setSingleTextSlotHosts(owner, hosts);
+
+            expect(hosts).toHaveLength(1);
+            expect(hosts[0]!.firstChild).toBe(source);
+            expect(hosts[0]!.shadowRoot).toBeNull();
+            expect(hosts[0]!.lang).toBe('zh-Hans');
+            expect(hosts[0]!.getAttribute('translate')).toBe('no');
+            expect(hosts[0]!.getAttribute('aria-label')).toBe('12 小时前');
+            expect(owner.textContent).toBe('12 hours ago');
+            expect(source.nodeValue).toBe('12 hours ago');
+
+            expect(restoreTranslation(owner)).toBe(true);
+            expect(owner.firstChild).toBe(source);
+            expect(owner.textContent).toBe('12 hours ago');
+        });
+    });
+
+    it('仅译文 renderer 原子拒绝失效文本槽，并覆盖空语言回退', async () => {
+        const {document} = parseHTML('<html><body><p id="owner">Owner</p><p id="foreign">Foreign</p></body></html>');
+        const owner = document.querySelector<HTMLElement>('#owner')!;
+        const foreign = document.querySelector<HTMLElement>('#foreign')!;
+        const ownerSource = owner.firstChild as Text;
+        const foreignSource = foreign.firstChild as Text;
+        const detached = document.createTextNode('Detached');
+        const previousTo = config.to;
+
+        await withDocumentRealm(document, async () => {
+            expect(appendSingleTranslationSlots(owner, [])).toEqual([]);
+            expect(appendSingleTranslationSlots(owner, [{node: detached, text: '脱离'}])).toEqual([]);
+            expect(appendSingleTranslationSlots(owner, [{node: foreignSource, text: '外部'}])).toEqual([]);
+            expect(owner.textContent).toBe('Owner');
+            expect(foreign.textContent).toBe('Foreign');
+
+            try {
+                config.to = '';
+                beginTranslation(owner, 'single', 'content', false, 'Owner', [ownerSource]);
+                const hosts = appendSingleTranslationSlots(owner, [{node: ownerSource, text: '所有者'}]);
+                setSingleTextSlotHosts(owner, hosts);
+                expect(hosts[0]!.lang).toBe('');
+                expect(restoreTranslation(owner)).toBe(true);
+            } finally {
+                config.to = previousTo;
             }
         });
     });


### PR DESCRIPTION
## 问题

仅译文模式会直接改写宿主页面的文本节点。GitHub 这类动态页面会持续校正相对时间和评审状态（例如 `12 hours ago`、`No reviews`），导致页面脚本与扩展互相覆盖文本，表现为重复翻译和持续抖动。

## 修复

- 保留宿主文本节点、文本值和 `textContent`，避免触发页面框架的反复校正
- 在轻量包装节点的 closed ShadowRoot 中显示译文，并维持仅译文的视觉效果
- 将译文槽纳入全文翻译状态管理，确保恢复、重译和动态文本更新正确清理
- 增加无障碍标签，并覆盖首次翻译、动态更新、恢复和截断等回归场景

## 验证

- `pnpm test`：154 个文件、2242 项测试通过
- 针对性测试：3 个文件、106 项测试通过
- `pnpm test:audit`：154 个文件、1698 项审计用例通过
- `pnpm compile`
- `pnpm build`
- `pnpm build:firefox`
- `pnpm build:userscript`
- `git diff --check`
- 隔离的真实 Edge 生产构建验证：初始 3 次翻译请求后保持稳定；`12 hours ago` 更新为 `11 hours ago` 时仅新增 1 次请求并再次稳定；宿主 `textContent` 未被改写；控制台错误为 0

## 覆盖率说明

`pnpm test:coverage` 的 112 个文件、1642 项测试均通过；全局分支覆盖率为 99.95%，未达到仓库 100% 阈值。缺口位于本分支未修改的 `src/features/selection-translation/core.ts`（来自既有 PR #372），本次修改涉及的 renderer 分支覆盖率为 100%。

Fixes the translation-only rendering loop observed on #372.
