### PR TITLE
fix: prevent GitHub single-translation mutation loop

### DIFF
--- a/src/features/full-page-translation/content/runtime.ts
+++ b/src/features/full-page-translation/content/runtime.ts
@@ -353,6 +353,23 @@ function mutationTouchesCurrentTranslationArtifact(
             (isElementNode(node) && node.contains(artifact))));
 }
 
+function isOwnSingleTextSlotMove(
+    mutation: MutationRecord,
+    target: HTMLElement,
+    state: TranslationState,
+): boolean {
+    if (mutation.type !== "childList" || !state.singleTextSlotHosts?.length) return false;
+    const mutationElement = mutationTargetElement(mutation.target);
+    if (!mutationElement) return false;
+
+    const changedNodes = [...Array.from(mutation.addedNodes), ...Array.from(mutation.removedNodes)];
+    if (changedNodes.length === 0) return false;
+
+    const slot = state.singleTextSlotHosts.find(({host}) => host === mutationElement);
+    return Boolean(slot && changedNodes.every((node) => node === slot.source) &&
+        statefulSourceAndTextSlotsAreCurrent(target, state));
+}
+
 function isTranslationArtifact(node: Node): boolean {
     const element = isElementNode(node) ? node : node.parentElement;
     return Boolean(element &&
@@ -1572,6 +1589,7 @@ function isOwnMutation(
         return false;
     }
     if (state.phase !== "translated") return false;
+    if (isOwnSingleTextSlotMove(mutation, target, state)) return true;
     if ((state.kind === "control" || state.mode === "single") && mutation.type === "characterData") {
         const textNode = mutation.target as Text;
         return state.textSlotsApplied === true &&

--- a/tests/fullPageVisibilityScheduling.test.ts
+++ b/tests/fullPageVisibilityScheduling.test.ts
@@ -2258,6 +2258,45 @@ describe("全文翻译可见性锚点", () => {
         expect(time.querySelector('.fluent-read-single-slot')).toBeNull();
     });
 
+    it("仅译文 slot 内部的 childList mutation 不应触发 GitHub 侧边栏翻译恢复循环", async () => {
+        runtime.config.display = 0;
+        runtime.config.fullPageTranslationMode = "all";
+        document.body.innerHTML = '<relative-time id="sidebar-time">12 hours ago</relative-time>';
+        const time = document.querySelector<HTMLElement>("#sidebar-time")!;
+        setLayoutBox(time, 120, 24);
+        runtime.candidates = [{element: time, kind: "content", reason: "generic-text-container"}];
+
+        autoTranslateEnglishPage();
+        await finishScheduledWork();
+
+        expect(runtime.requests).toHaveBeenCalledTimes(1);
+        const slot = time.querySelector<HTMLElement>(".fluent-read-single-slot")!;
+        const source = slot.firstChild!;
+        TestMutationObserver.instances.at(-1)!.emit([{
+            type: "childList",
+            target: slot,
+            addedNodes: [source] as unknown as NodeList,
+            removedNodes: [] as unknown as NodeList,
+        } as unknown as MutationRecord]);
+        await finishScheduledWork();
+
+        expect(runtime.requests).toHaveBeenCalledTimes(1);
+        expect(getTranslationState(time)?.phase).toBe("translated");
+        expect(singleTranslationText(time)).toBe("译:12 hours ago");
+
+        source.nodeValue = "13 hours ago";
+        TestMutationObserver.instances.at(-1)!.emit([{
+            type: "characterData",
+            target: source,
+            addedNodes: [] as unknown as NodeList,
+            removedNodes: [] as unknown as NodeList,
+        } as unknown as MutationRecord]);
+        await finishScheduledWork();
+
+        expect(runtime.requests).toHaveBeenCalledTimes(2);
+        expect(runtime.requests).toHaveBeenLastCalledWith(["13 hours ago"]);
+    });
+
     it("已译 prose 忽略 MathJax/code 等保护后代 churn，但外层 source mutation 会重启", async () => {
         runtime.config.display = 1;
         document.body.innerHTML = `


### PR DESCRIPTION
## Summary

- Ignore only the extension-owned Text move inside a single-translation slot.
- Keep real host text changes eligible for retranslation.
- Add a regression covering GitHub-style dynamic sidebar content.

## Validation

- pnpm test — 155 files, 2260 tests passed
- pnpm compile
- pnpm build
- git diff --check

## Context

This PR is independent of PR #309, which remains untouched and covers X video Whisper subtitles.