### PR TITLE
fix: restore area translation screenshot permission

### DIFF
--- a/tests/extensionManifestContract.test.ts
+++ b/tests/extensionManifestContract.test.ts
@@ -18,6 +18,16 @@ function permissionsFor(browser: string, manifestVersion: 2 | 3): string[] {
 }
 
 describe('extension manifest capability contract', () => {
+    it('declares the literal all-URLs host permission required by captureVisibleTab', () => {
+        for (const [browser, manifestVersion] of [
+            ['chrome', 3],
+            ['edge', 3],
+        ] as const) {
+            const manifest = createExtensionManifest({browser, manifestVersion} as Parameters<typeof createExtensionManifest>[0]);
+            expect(manifest.host_permissions, `${browser}-mv${manifestVersion}`).toContain('<all_urls>');
+        }
+    });
+
     it('declares Offscreen exactly once only for supported Chrome and Edge MV3 builds', () => {
         for (const [browser, manifestVersion, expected] of [
             ['chrome', 3, 1],

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -69,6 +69,7 @@ export function createExtensionManifest(
             extension_pages: "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';",
         },
         host_permissions: [
+            '<all_urls>',
             'https://translate.google.com/*',
             'https://translate.google.co.uk/*',
             'https://translate.googleapis.com/*',


### PR DESCRIPTION
## Summary\n- add the literal <all_urls> host permission required by tabs.captureVisibleTab for Shift+Z area translation\n- add a manifest contract regression test for Chrome and Edge MV3\n\n## Validation\n- pnpm test:unit (88 files, 1137 tests)\n- pnpm compile\n- pnpm build\n- pnpm build:firefox\n- pnpm verify:extension-manifests\n- real isolated Edge Shift+Z area translation: permission error reproduced before the fix and translated image displayed after the fix\n