### PR TITLE
docs: add Greasy Fork userscript download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Use focused settings pages for reading preferences, services and models, shortcu
 | Chrome | [Chrome Web Store](https://chromewebstore.google.com/detail/%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB/djnlaiohfaaifbibleebjggkghlmcpcj?hl=en) · [CrxSoso mirror](https://www.crxsoso.com/webstore/detail/djnlaiohfaaifbibleebjggkghlmcpcj) |
 | Edge | [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB/kakgmllfpjldjhcnkghpplmlbnmcoflp) |
 | Firefox | [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB/) |
+| Userscript | [Greasy Fork（Tampermonkey / Violentmonkey / Via）](https://greasyfork.org/zh-CN/scripts/482986-%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB) |
 
 For a local build, install dependencies with pnpm and load the generated `./.output/chrome-mv3` directory as an unpacked extension. See the [official documentation](https://fluent.thinkstu.com/) for setup and configuration details.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,6 +9,7 @@
 - [Chrome Web Store](https://chromewebstore.google.com/detail/%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB/djnlaiohfaaifbibleebjggkghlmcpcj?hl=zh-CN)
 - [Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB/kakgmllfpjldjhcnkghpplmlbnmcoflp?hl=zh-CN)
 - [Firefox Add-ons](https://addons.mozilla.org/zh-CN/firefox/addon/%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB/)
+- [油猴脚本（Tampermonkey / Violentmonkey / Via）](https://greasyfork.org/zh-CN/scripts/482986-%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB)
 
 安装后，建议把 FluentRead 固定到浏览器工具栏，方便随时打开控制面板。
 

--- a/docs/guide/userscript.md
+++ b/docs/guide/userscript.md
@@ -2,6 +2,10 @@
 
 FluentRead 可以从当前 Vue / TypeScript 源码生成一个自包含的 userscript，目标是让 Via、Tampermonkey 和 Violentmonkey 用户获得与浏览器扩展接近的核心网页翻译体验。该方案对应 [Issue #220](https://github.com/FluentRead/FluentRead/issues/220)，目前仍属于实验性构建目标。
 
+## 直接安装
+
+如果你使用 Tampermonkey、Violentmonkey 或 Via，可以直接从 [Greasy Fork 安装流畅阅读油猴脚本](https://greasyfork.org/zh-CN/scripts/482986-%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB)。
+
 ## 本地生成
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,9 @@ hero:
       text: 查看功能
       link: /guide/features
     - theme: alt
+      text: 下载油猴脚本
+      link: https://greasyfork.org/zh-CN/scripts/482986-%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB
+    - theme: alt
       text: GitHub
       link: https://github.com/Bistutu/FluentRead
 

--- a/misc/README_ZH.md
+++ b/misc/README_ZH.md
@@ -70,6 +70,7 @@
 | Chrome | [Chrome 应用商店](https://chromewebstore.google.com/detail/%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB/djnlaiohfaaifbibleebjggkghlmcpcj?hl=zh-CN) · [CrxSoso 国内镜像](https://www.crxsoso.com/webstore/detail/djnlaiohfaaifbibleebjggkghlmcpcj) |
 | Edge | [Microsoft Edge 加载项](https://microsoftedge.microsoft.com/addons/detail/%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB/kakgmllfpjldjhcnkghpplmlbnmcoflp?hl=zh-CN) |
 | Firefox | [Firefox 附加组件](https://addons.mozilla.org/zh-CN/firefox/addon/%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB/) |
+| 油猴脚本 | [Greasy Fork（Tampermonkey / Violentmonkey / Via）](https://greasyfork.org/zh-CN/scripts/482986-%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB) |
 
 如果需要本地构建，请使用 pnpm 安装依赖，然后把生成的 `./.output/chrome-mv3` 目录作为“已解压的扩展程序”加载。详细配置请查看[官方文档](https://fluent.thinkstu.com/)。
 


### PR DESCRIPTION
## Summary
- Add a direct Greasy Fork userscript link to the documentation homepage, installation guide, and userscript guide.
- Add the same download entry to the English and Chinese README installation tables.

## Validation
- `pnpm docs:build`
- `git diff --check`