### PR TITLE
fix: prevent custom service endpoint overflow

### DIFF
--- a/scripts/testing/run-settings-center-ui-test.cjs
+++ b/scripts/testing/run-settings-center-ui-test.cjs
@@ -1245,6 +1245,33 @@ async function main() {
     if ((await customServiceCount.textContent())?.trim() !== '1 / 20') {
       throw new Error(`创建后的自定义服务计数异常：${await customServiceCount.textContent()}`);
     }
+    const customServiceDescriptionLayout = await customServiceItem.evaluate(item => {
+      const card = item.getBoundingClientRect();
+      const copy = item.querySelector('.service-copy')?.getBoundingClientRect();
+      const description = item.querySelector('.service-copy small');
+      const descriptionRect = description?.getBoundingClientRect();
+      const descriptionStyle = description ? getComputedStyle(description) : null;
+      return {
+        cardRight: card.right,
+        copyRight: copy?.right ?? null,
+        descriptionRight: descriptionRect?.right ?? null,
+        descriptionWidth: descriptionRect?.width ?? null,
+        descriptionScrollWidth: description?.scrollWidth ?? null,
+        overflow: descriptionStyle?.overflow ?? '',
+        textOverflow: descriptionStyle?.textOverflow ?? '',
+        whiteSpace: descriptionStyle?.whiteSpace ?? '',
+      };
+    });
+    if (customServiceDescriptionLayout.descriptionRight === null
+      || customServiceDescriptionLayout.descriptionRight > customServiceDescriptionLayout.cardRight + 1
+      || customServiceDescriptionLayout.descriptionRight > (customServiceDescriptionLayout.copyRight ?? Infinity) + 1
+      || customServiceDescriptionLayout.overflow !== 'hidden'
+      || customServiceDescriptionLayout.textOverflow !== 'ellipsis'
+      || customServiceDescriptionLayout.whiteSpace !== 'nowrap') {
+      throw new Error(`自定义服务接口地址超出卡片边界：${JSON.stringify(customServiceDescriptionLayout)}`);
+    }
+    report.informationArchitecture.serviceCatalogHierarchy.customServiceDescription = customServiceDescriptionLayout;
+    report.assertions.customServiceDescriptionBounded = true;
     if (await customServiceItem.getAttribute('aria-pressed') !== 'true'
       || await serviceCatalog.getAttribute('data-editing-service') !== customServiceId
       || await serviceCatalog.getAttribute('data-default-service') !== defaultServiceMetrics.defaultService) {

--- a/src/features/settings/ui/services/ServiceCatalog.vue
+++ b/src/features/settings/ui/services/ServiceCatalog.vue
@@ -330,7 +330,16 @@ watch(() => props.service, () => {
 .service-item.active { border-color: #f3c4d1; background: #fff0f4; box-shadow: 0 7px 18px rgba(214, 50, 96, .08); }
 .service-copy { display: flex; min-width: 0; flex-direction: column; }
 .service-copy strong { overflow: hidden; font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
-.service-copy small { margin-top: 3px; color: #9097a7; font-size: 10px; }
+.service-copy small {
+  display: block;
+  min-width: 0;
+  margin-top: 3px;
+  overflow: hidden;
+  color: #9097a7;
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .current-dot { width: 7px; height: 7px; border-radius: 50%; background: #ef4776; box-shadow: 0 0 0 4px rgba(239, 71, 118, .12); }
 .service-detail { display: flex; min-width: 0; min-height: 0; margin: 14px; padding: 22px; border: 1px solid #e4e7ef; border-radius: 16px; background: #fff; flex-direction: column; overflow: hidden; }
 .service-detail > .detail-hero,

--- a/tests/settingsUiArchitecture.test.ts
+++ b/tests/settingsUiArchitecture.test.ts
@@ -419,6 +419,7 @@ describe('options UI composition architecture', () => {
   it('keeps the service catalog hierarchy searchable and accessible', () => {
     const catalog = source('src/features/settings/ui/services/ServiceCatalog.vue')
     const viewModel = source('src/ui/view-model/serviceCatalog.ts')
+    const serviceDescriptionStyles = catalog.match(/\.service-copy small \{([^}]*)\}/u)?.[1] || ''
 
     expect(catalog).toContain(':data-service-section-toggle="section.id"')
     expect(catalog).toContain(':aria-expanded="!isSectionCollapsed(section)"')
@@ -433,6 +434,11 @@ describe('options UI composition architecture', () => {
     expect(viewModel).toContain("label: '模型服务商'")
     expect(viewModel).toContain("label: '聚合平台与接口'")
     expect(viewModel).toContain("item.catalogKind === 'platform'")
+    expect(serviceDescriptionStyles).toContain('display: block')
+    expect(serviceDescriptionStyles).toContain('min-width: 0')
+    expect(serviceDescriptionStyles).toContain('overflow: hidden')
+    expect(serviceDescriptionStyles).toContain('text-overflow: ellipsis')
+    expect(serviceDescriptionStyles).toContain('white-space: nowrap')
   })
 
   it('keeps translation interactions together in the requested order', () => {


### PR DESCRIPTION
Keep custom service endpoint descriptions inside service cards with single-line ellipsis, and add source and real Edge regression assertions. Validation: focused 38 tests, test audit, architecture tests, compile, Chrome MV3 build, Firefox MV2 build, production settings-center UI, and production service-catalog UI. The generic full runner remains blocked by its stale 配置管理 selector.