### PR TITLE
fix: preserve GitHub issue labels and metadata

### DIFF
--- a/src/core/translation/adapters/github.ts
+++ b/src/core/translation/adapters/github.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/core/translation/adapters/github.ts
  *
- * 文件职责：声明 GitHub 页面翻译适配规则，使 Markdown 正文、议题和评论成为候选，同时避开代码、导航及交互控件。
+ * 文件职责：声明 GitHub 页面翻译适配规则，使 Markdown 正文、议题和评论成为候选，同时避开代码、导航、标签和议题元数据。
  * 主要内容：通过 createDeclarativeAdapter 配置 githubAdapter，集中列出 Markdown prose 等 GitHub 特有选择器，并将站点差异转换为通用 pass、skip 或 target 决策。 可核对的公开符号包括 githubAdapter。
  * 模块边界：本文件位于 core 的站点规则层，只表达 URL 与 DOM 候选决策；不发送翻译请求、不渲染译文、不监听业务生命周期，通用安全守卫仍由 TranslationCandidateCore 执行。
  */
@@ -24,6 +24,31 @@ const markdownProseSelectors = [
     '.markdown-body dd',
     '.markdown-body th',
     '.markdown-body td',
+] as const;
+
+/** GitHub label 是可点击的受控标记，不应被翻译成另一种 label 名称。 */
+const githubIssueLabelSelectors = [
+    '[data-testid="issue-labels"]',
+    'span[class*="IssueLabel"]',
+] as const;
+
+/**
+ * Issue/PR 列表与详情头部中的编号、仓库、作者、状态和日期属于 GitHub 元数据。
+ * 优先使用 data-testid，同时保留当前 CSS module 的稳定语义前缀以覆盖 pinned issue
+ * 和活动头部等没有 data-testid 的布局。
+ */
+const githubIssueMetadataSelectors = [
+    '[data-testid="list-row-repo-name-and-number"]',
+    '[data-testid="created-at"]',
+    '[class*="IssueItem-module__defaultNumberDescription"]',
+    '[class*="PinnedIssue-module__metadataContainer"]',
+    '[class*="PinnedIssue-module__issueMetadata"]',
+    '[class*="IssueBodyHeader-module__IssueBodyHeaderContainer"]',
+] as const;
+
+const githubNonTranslatableSelectors = [
+    ...githubIssueLabelSelectors,
+    ...githubIssueMetadataSelectors,
 ] as const;
 
 export const githubAdapter = createDeclarativeAdapter({
@@ -50,6 +75,14 @@ export const githubAdapter = createDeclarativeAdapter({
                 'input[data-target="qbsearch-input.inputButton"]',
             ],
             reason: 'github-quick-search',
+        },
+        {
+            selector: githubIssueLabelSelectors,
+            reason: 'github-issue-label',
+        },
+        {
+            selector: githubIssueMetadataSelectors,
+            reason: 'github-issue-metadata',
         },
     ],
     targets: [
@@ -92,6 +125,7 @@ export const githubAdapter = createDeclarativeAdapter({
     keepOriginal: [
         {
             selector: [
+                ...githubNonTranslatableSelectors,
                 '[aria-live]',
                 '[role="status"]',
                 '[role="alert"]',
@@ -107,6 +141,7 @@ export const githubAdapter = createDeclarativeAdapter({
     mutationExclude: [
         {
             selector: [
+                ...githubNonTranslatableSelectors,
                 'dialog',
                 '[role="dialog"]',
                 'form[role="search"]',

--- a/tests/browser-translation-cases.json
+++ b/tests/browser-translation-cases.json
@@ -46,6 +46,39 @@
     "fullPageHotkey": "Alt+T",
     "service": "freeTranslation"
   },
+  "github-eugeny-issue-list": {
+    "url": "https://github.com/Eugeny/tabby/issues?q=is%3Aissue%20state%3Aopen%20in%3Atitle%20%22right%20click%20not%20working%22",
+    "hoverSelector": "[data-testid='issue-pr-title-link']",
+    "requiredSelectors": ["[data-testid='issue-pr-title-link']"],
+    "coverageRules": [
+      {
+        "name": "issue-list-titles",
+        "selector": "[data-testid='issue-pr-title-link']",
+        "kind": "content",
+        "minInitial": 1,
+        "trackDynamic": true,
+        "sourceIncludes": ["right click not working"]
+      }
+    ],
+    "forbiddenSelectors": [
+      "span[class*='IssueLabel']",
+      "[data-testid='list-row-repo-name-and-number']",
+      "[data-testid='created-at']"
+    ],
+    "forbiddenMustExistSelectors": [
+      "span[class*='IssueLabel']",
+      "[data-testid='list-row-repo-name-and-number']",
+      "[data-testid='created-at']"
+    ],
+    "dynamicForbiddenSelectors": ["span[class*='IssueLabel']"],
+    "interactionSelectors": ["main a[href]"],
+    "modes": ["hover", "full"],
+    "tier": "required",
+    "notes": "GitHub Issue 列表回归页：标题可翻译，但 label、Issue 编号/仓库、作者和日期元数据必须保持原文。",
+    "hoverHotkey": "Control",
+    "fullPageHotkey": "Alt+T",
+    "service": "freeTranslation"
+  },
   "github-immersive-pulls": {
     "url": "https://github.com/immersive-translate/immersive-translate/pulls",
     "hoverSelector": ".markdown-title",

--- a/tests/translationCore.test.ts
+++ b/tests/translationCore.test.ts
@@ -974,6 +974,109 @@ describe('translation candidate core', () => {
         expect(core.resolve(title)?.element).toBe(title);
     });
 
+    it('keeps GitHub issue-list labels and metadata original while translating titles', () => {
+        const {document, core} = page(`
+            <main>
+                <div class="IssueRow-module__row__fixture">
+                    <li id="issue-row" role="listitem">
+                        <div data-listview-item-title-container="true">
+                            <h3>
+                                <a id="issue-title" data-testid="issue-pr-title-link" href="/Eugeny/tabby/issues/10084">
+                                    right click not working
+                                </a>
+                            </h3>
+                            <span>
+                                <div data-listview-component="trailing-badge">
+                                    <a href="/Eugeny/tabby/issues?q=label%3A%22T%3A%20Bug%22">
+                                        <span class="prc-Token-TokenBase-te5-F prc-Token-IssueLabel-2IazM">
+                                            <span>T: Bug</span>
+                                        </span>
+                                    </a>
+                                </div>
+                            </span>
+                        </div>
+                        <div data-testid="list-row-repo-name-and-number">
+                            <span>#10084 <span class="sr-only">In Eugeny/tabby;</span></span>
+                        </div>
+                        <div data-testid="created-at">
+                            <span>· </span>
+                            <a href="/kikyoulg">kikyoulg</a>
+                            <span> opened </span>
+                            <relative-time>on Dec 6, 2024</relative-time>
+                        </div>
+                    </li>
+                </div>
+            </main>
+        `, 'https://github.com/Eugeny/tabby/issues?q=is%3Aissue%20state%3Aopen%20macos27');
+        const title = document.querySelector('#issue-title')!;
+        const label = document.querySelector('.prc-Token-IssueLabel-2IazM')!;
+        const repoMetadata = document.querySelector('[data-testid="list-row-repo-name-and-number"]')!;
+        const createdAt = document.querySelector('[data-testid="created-at"]')!;
+        const candidates = core.discover(document);
+
+        expect(candidates.find((candidate) => candidate.element === title))
+            .toMatchObject({adapterId: 'github', reason: 'github-issue-or-pr-title'});
+        expect(core.resolve(label.querySelector('span')?.firstChild)).toBeNull();
+        expect(core.resolve(repoMetadata.querySelector('span')?.firstChild)).toBeNull();
+        expect(core.resolve(createdAt.querySelector('a')?.firstChild)).toBeNull();
+        expect(core.shouldStayOriginal(label)).toBe(true);
+        expect(core.shouldStayOriginal(repoMetadata)).toBe(true);
+        expect(core.shouldStayOriginal(createdAt)).toBe(true);
+        expect(core.shouldIgnoreMutation(label)).toBe(true);
+        expect(core.shouldIgnoreMutation(repoMetadata)).toBe(true);
+        expect(core.shouldIgnoreMutation(createdAt)).toBe(true);
+    });
+
+    it('keeps GitHub issue-detail labels and activity metadata original while translating body prose', () => {
+        const {document, core} = page(`
+            <main>
+                <h1>
+                    <bdi id="detail-title" class="markdown-title" data-testid="issue-title">right click not working</bdi>
+                </h1>
+                <div data-testid="issue-body">
+                    <div class="IssueBodyHeader-module__IssueBodyHeaderContainer__fixture">
+                        <a data-testid="issue-body-header-author" href="/kikyoulg">kikyoulg</a>
+                        <span>opened </span>
+                        <a data-testid="issue-body-header-link" href="#issue-10084">
+                            <relative-time>on Dec 6, 2024</relative-time>
+                        </a>
+                    </div>
+                    <div data-testid="issue-body-viewer">
+                        <div class="markdown-body" data-testid="markdown-body">
+                            <p id="issue-body-copy">Paste or menu both not working.</p>
+                        </div>
+                    </div>
+                </div>
+                <div data-testid="sidebar-labels-section">
+                    <h3>Labels</h3>
+                    <div data-testid="issue-labels">
+                        <a href="/Eugeny/tabby/issues?q=label%3A%22T%3A%20Bug%22">
+                            <span class="prc-Token-TokenBase-te5-F prc-Token-IssueLabel-2IazM">
+                                <span>T: Bug</span>
+                            </span>
+                        </a>
+                    </div>
+                </div>
+            </main>
+        `, 'https://github.com/Eugeny/tabby/issues/10084');
+        const title = document.querySelector('#detail-title')!;
+        const body = document.querySelector('#issue-body-copy')!;
+        const activityHeader = document.querySelector('[class*="IssueBodyHeader-module__IssueBodyHeaderContainer"]')!;
+        const labels = document.querySelector('[data-testid="issue-labels"]')!;
+        const candidates = core.discover(document);
+
+        expect(candidates.find((candidate) => candidate.element === title))
+            .toMatchObject({adapterId: 'github'});
+        expect(candidates.find((candidate) => candidate.element === body))
+            .toMatchObject({adapterId: 'github', reason: 'github-markdown-prose'});
+        expect(core.resolve(activityHeader.querySelector('a')?.firstChild)).toBeNull();
+        expect(core.resolve(labels.querySelector('span')?.firstChild)).toBeNull();
+        expect(core.shouldStayOriginal(activityHeader)).toBe(true);
+        expect(core.shouldStayOriginal(labels)).toBe(true);
+        expect(core.shouldIgnoreMutation(activityHeader)).toBe(true);
+        expect(core.shouldIgnoreMutation(labels)).toBe(true);
+    });
+
     it('keeps X usernames out of full and hover translation candidates', () => {
         const {document, core} = page(`
             <main>


### PR DESCRIPTION
Keep GitHub Issue/PR labels and issue metadata in original form while preserving translation for titles and Markdown prose. Added unit coverage, a real-site regression contract, and validated with 110 tests, compile, build, and isolated Edge hover/full translation checks.