### PR TITLE
fix: sync full-page shortcut with page controls (#400)

### DIFF
--- a/src/app/content/hotkeyRuntime.ts
+++ b/src/app/content/hotkeyRuntime.ts
@@ -14,7 +14,6 @@ import {
     normalizeSelectionText,
     restoreOriginalContent,
     shouldIgnoreSelection,
-    toggleFloatingBallTranslation,
 } from './features';
 
 const SPECIAL_KEYS: Readonly<Record<string, string>> = {
@@ -97,7 +96,8 @@ export function createContentHotkeyRuntime(isSiteDisabled: () => boolean): Conte
     };
 
     const toggleFullPageTranslation = (): void => {
-        if (toggleFloatingBallTranslation()) return;
+        // 快捷键必须读取全文会话真值，不能把悬浮球组件的局部状态当成另一份真源。
+        // 否则快捷键触发后，右键菜单和 Popup 仍可能认为页面未翻译并再次启动会话。
         if (isFullPageTranslationActive()) restoreOriginalContent();
         else autoTranslateEnglishPage();
     };

--- a/tests/contentHotkeyRuntime.test.ts
+++ b/tests/contentHotkeyRuntime.test.ts
@@ -1,0 +1,124 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    config: {
+        on: true,
+        floatingBallHotkey: 'Alt+T',
+        customFloatingBallHotkey: '',
+        selectionTranslatorTrigger: 'direct',
+        selectionTranslatorMode: 'bilingual',
+        disableSelectionTranslator: false,
+        customSelectionTranslatorHotkey: '',
+        to: 'zh',
+    },
+    autoTranslateEnglishPage: vi.fn(),
+    isFullPageTranslationActive: vi.fn(),
+    restoreOriginalContent: vi.fn(),
+    toggleFloatingBallTranslation: vi.fn(),
+    matchesConfiguredHotkey: vi.fn(() => false),
+    shouldClaimConfiguredHotkey: vi.fn(() => false),
+}));
+
+vi.mock('@/src/services/config/store', () => ({config: mocks.config}));
+vi.mock('@/src/core/language/detect', () => ({detectlang: vi.fn(() => 'en')}));
+vi.mock('@/src/core/hotkey', () => ({
+    matchesConfiguredHotkey: mocks.matchesConfiguredHotkey,
+    shouldClaimConfiguredHotkey: mocks.shouldClaimConfiguredHotkey,
+}));
+vi.mock('@/src/app/content/features', () => ({
+    autoTranslateEnglishPage: mocks.autoTranslateEnglishPage,
+    isFullPageTranslationActive: mocks.isFullPageTranslationActive,
+    isSameLanguage: vi.fn(() => false),
+    normalizeSelectionText: vi.fn((value: string) => value),
+    restoreOriginalContent: mocks.restoreOriginalContent,
+    shouldIgnoreSelection: vi.fn(() => false),
+    toggleFloatingBallTranslation: mocks.toggleFloatingBallTranslation,
+}));
+
+type Listener = (event: Record<string, unknown>) => void;
+
+function createDocumentStub() {
+    const listeners = new Map<string, Listener[]>();
+    return {
+        document: {
+            addEventListener: vi.fn((type: string, listener: Listener) => {
+                const current = listeners.get(type) ?? [];
+                current.push(listener);
+                listeners.set(type, current);
+            }),
+            getElementById: vi.fn(() => null),
+        },
+        listeners,
+    };
+}
+
+function keyboardEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        isTrusted: true,
+        repeat: false,
+        key: 't',
+        code: 'KeyT',
+        ctrlKey: false,
+        altKey: true,
+        shiftKey: false,
+        metaKey: false,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    Object.assign(mocks.config, {
+        on: true,
+        floatingBallHotkey: 'Alt+T',
+        customFloatingBallHotkey: '',
+        selectionTranslatorTrigger: 'direct',
+        selectionTranslatorMode: 'bilingual',
+        disableSelectionTranslator: false,
+        customSelectionTranslatorHotkey: '',
+        to: 'zh',
+    });
+    mocks.isFullPageTranslationActive.mockReturnValue(false);
+    mocks.toggleFloatingBallTranslation.mockReturnValue(true);
+
+    const {document, listeners} = createDocumentStub();
+    vi.stubGlobal('document', document);
+    vi.stubGlobal('window', {
+        getSelection: vi.fn(() => null),
+        addEventListener: vi.fn(),
+    });
+    vi.stubGlobal('navigator', {platform: 'MacIntel'});
+    vi.stubGlobal('process', {env: {NODE_ENV: 'test'}});
+    Object.defineProperty(document, '__listeners', {value: listeners});
+});
+
+describe('全文翻译快捷键状态联动', () => {
+    it('悬浮球存在时仍以全文会话真值切换，而不是驱动悬浮球局部状态', async () => {
+        const {createContentHotkeyRuntime} = await import('@/src/app/content/hotkeyRuntime');
+        const runtime = createContentHotkeyRuntime(() => false);
+        runtime.installFloatingBallHotkey(new AbortController().signal);
+
+        const listeners = (document as typeof document & {__listeners: Map<string, Listener[]>}).__listeners;
+        const keydown = listeners.get('keydown')?.[0];
+        const keyup = listeners.get('keyup')?.[0];
+        expect(keydown).toBeTypeOf('function');
+        expect(keyup).toBeTypeOf('function');
+
+        keydown!(keyboardEvent({key: 'Alt', code: 'AltLeft'}));
+        keydown!(keyboardEvent());
+        expect(mocks.autoTranslateEnglishPage).toHaveBeenCalledOnce();
+        expect(mocks.toggleFloatingBallTranslation).not.toHaveBeenCalled();
+
+        keyup!(keyboardEvent({key: 't', code: 'KeyT', altKey: false}));
+        keyup!(keyboardEvent({key: 'Alt', code: 'AltLeft', altKey: false}));
+        mocks.isFullPageTranslationActive.mockReturnValue(true);
+
+        keydown!(keyboardEvent({key: 'Alt', code: 'AltLeft'}));
+        keydown!(keyboardEvent());
+        expect(mocks.restoreOriginalContent).toHaveBeenCalledOnce();
+        expect(mocks.toggleFloatingBallTranslation).not.toHaveBeenCalled();
+    });
+});

--- a/tests/contentTrustBoundary.test.ts
+++ b/tests/contentTrustBoundary.test.ts
@@ -17,12 +17,14 @@ describe('host-page trust boundary', () => {
       source('src/features/input-translation/content/index.ts'),
     ].join('\n');
     const floatingBall = source('src/features/floating-ball/ui/FloatingBall.vue');
+    const hotkeyRuntime = source('src/app/content/hotkeyRuntime.ts');
 
     expect(existsSync(resolve(process.cwd(), 'entrypoints/utils/newApi.ts'))).toBe(false);
     expect(content).not.toContain('fluent:prefill');
     expect(content).not.toContain('fluentread-toggle-translation');
     expect(floatingBall).not.toContain('fluentread-toggle-translation');
-    expect(content).toContain('toggleFloatingBallTranslation()');
+    expect(hotkeyRuntime).not.toContain('toggleFloatingBallTranslation()');
+    expect(hotkeyRuntime).toContain('if (isFullPageTranslationActive()) restoreOriginalContent();');
   });
 
   it('rejects synthetic input before network and screenshot side effects', () => {

--- a/tests/test-matrix.json
+++ b/tests/test-matrix.json
@@ -59,6 +59,7 @@
       "tests/fullPageTranslationErrorMessage.test.ts",
       "tests/hoverTranslationContentFeature.test.ts",
       "tests/hotkey.test.ts",
+      "tests/contentHotkeyRuntime.test.ts",
       "tests/inputTranslationContentFeature.test.ts",
       "tests/mainWorldBridgeLifecycle.test.ts",
       "tests/customService.test.ts",


### PR DESCRIPTION
Fixes #400

## Summary
- route the full-page shortcut through the authoritative translation-session state
- keep the shortcut, floating entry, popup, and context-menu actions aligned
- add regression coverage for the floating-ball-present path

## Validation
- `pnpm test` — 160 files, 2305 tests passed
- `pnpm test:coverage` — 100% statements, branches, functions, and lines
- `pnpm test:architecture` and `pnpm test:regression` passed
- `pnpm compile`, `pnpm build`, `pnpm build:firefox`, and manifest verification passed
- isolated background Edge with real `Alt+T` verified translate → restore → retranslate, with zero console errors

Known baseline: `pnpm test:audit` currently reports three existing tests missing from `tests/test-matrix.json`.