### PR TITLE
feat: add opt-in bilingual sentence highlighting (#351)

### DIFF
--- a/src/app/content/bilingualSentenceHighlight.ts
+++ b/src/app/content/bilingualSentenceHighlight.ts
@@ -1,0 +1,15 @@
+/**
+ * @file src/app/content/bilingualSentenceHighlight.ts
+ * 文件职责：同步网页根节点上的双语逐句高亮开关，供内容应用控制 page.css 的可选视觉状态。
+ * 主要内容：定义高亮配置属性名称和安全的 Document 属性同步函数，不触碰翻译状态或请求流程。
+ * 模块边界：这里只负责页面级视觉开关；双语译文 DOM 由全文翻译 renderer 管理，配置持久化由 config service 管理。
+ */
+
+export const BILINGUAL_SENTENCE_HIGHLIGHT_ATTRIBUTE = 'data-fr-bilingual-sentence-highlight';
+
+export function syncBilingualSentenceHighlight(document: Document, enabled: boolean): void {
+    const root = document.documentElement;
+    if (!root) return;
+    if (enabled) root.setAttribute(BILINGUAL_SENTENCE_HIGHLIGHT_ATTRIBUTE, 'true');
+    else root.removeAttribute(BILINGUAL_SENTENCE_HIGHLIGHT_ATTRIBUTE);
+}

--- a/src/app/content/page.css
+++ b/src/app/content/page.css
@@ -358,6 +358,22 @@
     overflow-wrap: break-word; /* 处理长单词或 URL 的断行，避免溢出 */
 }
 
+/* 双语逐句高亮：原文节点包含译文节点，因此同一个 hover 状态可以同时突出两者。 */
+html[data-fr-bilingual-sentence-highlight="true"] .fluent-read-bilingual:hover,
+html[data-fr-bilingual-sentence-highlight="true"] .fluent-read-bilingual:focus-within {
+    background-color: rgba(239, 71, 118, 0.08) !important;
+    border-radius: 0.35em;
+    box-shadow: 0 0 0 2px rgba(239, 71, 118, 0.14) !important;
+    transition: background-color 120ms ease, box-shadow 120ms ease;
+}
+
+html[data-fr-bilingual-sentence-highlight="true"] .fluent-read-bilingual:hover > .fluent-read-bilingual-content,
+html[data-fr-bilingual-sentence-highlight="true"] .fluent-read-bilingual:focus-within > .fluent-read-bilingual-content {
+    background-color: rgba(239, 71, 118, 0.14) !important;
+    border-radius: 0.35em;
+    box-shadow: inset 3px 0 0 rgba(239, 71, 118, 0.5) !important;
+}
+
 /* 马克笔 */
 .fluent-display-marker {
     background: #ffeb3b;

--- a/src/app/content/runtime.ts
+++ b/src/app/content/runtime.ts
@@ -50,6 +50,7 @@ import {
     shouldAutomaticallyTranslatePage,
     type ContentPageAvailabilityRuntime,
 } from './pageAvailability';
+import {syncBilingualSentenceHighlight} from './bilingualSentenceHighlight';
 function installPageStyles(ctx: ContentScriptContext): () => void {
     const existing = document.getElementById('fluent-read-page-styles');
     if (existing) return () => undefined;
@@ -99,10 +100,8 @@ export async function startContentApp(ctx: ContentScriptContext,
             isDisabled: currentPageSiteDisabled,
         }).catch(() => undefined);
     };
-
     const isPageRuntimeEnabled = (): boolean => !cleanedUp && !currentPageSiteDisabled && config.on !== false;
     let pageAvailability: ContentPageAvailabilityRuntime | null = null;
-
     const disposePageFeatures = (): void => {
         featureController?.abort();
         featureController = null;
@@ -114,12 +113,13 @@ export async function startContentApp(ctx: ContentScriptContext,
         inputTranslationFeature.invalidate();
         removePageStyles?.();
         removePageStyles = null;
+        syncBilingualSentenceHighlight(document, false);
     };
 
     const activatePageFeatures = async (): Promise<void> => {
         if (!isPageRuntimeEnabled() || featureController) return;
-
         removePageStyles = installPageStyles(ctx);
+        syncBilingualSentenceHighlight(document, config.bilingualSentenceHighlightEnabled === true);
         const activationController = new AbortController();
         featureController = activationController;
         const isActivationCurrent = () => !cleanedUp
@@ -240,8 +240,8 @@ export async function startContentApp(ctx: ContentScriptContext,
     }, capabilities);
     browser.runtime.onMessage.addListener(runtimeMessageListener);
     reportSiteDisabledState();
-
     unsubscribeContentConfig = subscribeConfig((nextConfig) => {
+        syncBilingualSentenceHighlight(document, nextConfig.bilingualSentenceHighlightEnabled === true);
         const nextInputBoxConfigKey = inputBoxTranslationConfigKey(nextConfig);
         if (nextInputBoxConfigKey !== previousInputBoxConfigKey) {
             previousInputBoxConfigKey = nextInputBoxConfigKey;

--- a/src/core/config/diff.ts
+++ b/src/core/config/diff.ts
@@ -310,6 +310,7 @@ const FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     style: {group: 'general', label: '译文样式', format: (value) => formatEnum(value, STYLE_LABELS)},
     disableFloatingBall: {group: 'general', label: '全文翻译悬浮球', format: (value) => formatBoolean(value, true)},
     translationProgressPanelEnabled: {group: 'general', label: '翻译进度面板', format: formatBoolean},
+    bilingualSentenceHighlightEnabled: {group: 'general', label: '双语逐句高亮', format: formatBoolean},
 
     service: {group: 'general', label: '默认翻译服务', format: formatService},
     customOpenAIProviders: {group: 'translationServices', label: '自定义 OpenAI 服务', format: formatCustomOpenAIProviders},

--- a/src/core/config/model.ts
+++ b/src/core/config/model.ts
@@ -157,6 +157,7 @@ export class Config {
     useCache: boolean; // 是否使用缓存
     enableAIContext: boolean; // 是否为 AI 翻译附加网页上下文
     enableAIMultiSegment: boolean; // 是否把相邻全文段落合并为一次 AI 翻译请求
+    bilingualSentenceHighlightEnabled: boolean; // 是否在双语翻译中同步高亮原文与译文
     contextMenuEnabled: boolean; // 是否显示右键全文翻译菜单
     fullPageTranslationMode: FullPageTranslationMode; // 全文翻译按视口加载或立即处理整页
     disableFloatingBall: boolean; // 是否禁用悬浮球
@@ -247,6 +248,7 @@ export class Config {
         this.useCache = true; // 默认开启缓存
         this.enableAIContext = false; // 默认关闭 AI 智能上下文，避免意外增加请求体和费用
         this.enableAIMultiSegment = false; // 默认逐段请求，由用户按需开启 AI 多段翻译
+        this.bilingualSentenceHighlightEnabled = false; // 默认关闭双语逐句高亮，避免改变现有网页视觉
         this.contextMenuEnabled = true; // 默认显示右键全文翻译入口
         this.fullPageTranslationMode = 'viewport'; // 默认按阅读进度翻译，避免一次发出过多请求
         this.disableFloatingBall = true; // 默认关闭悬浮球
@@ -576,6 +578,7 @@ export function normalizeConfig(value: unknown): Config {
             ? legacyTranslationStatus
             : false;
     }
+    normalized.bilingualSentenceHighlightEnabled = source.bilingualSentenceHighlightEnabled === true;
     delete (normalized as unknown as Record<string, unknown>).translationStatus;
     // __fluentConfigRevision 只用于 storage 的写入顺序判断，不能进入运行时
     // 配置或历史快照，否则默认配置与同值的页面快照会因内部字段不同而无法去重。

--- a/src/features/settings/model/navigation.ts
+++ b/src/features/settings/model/navigation.ts
@@ -31,7 +31,7 @@ export const navigationGroups: NavigationGroup[] = [
         id: 'settings-general', icon: '⌂', label: '通用设置', description: '服务、显示与网页辅助', group: '基础配置',
         heading: '通用设置', summary: '选择默认翻译服务，并管理译文显示、网页辅助和基础偏好。',
         kicker: '基础配置', title: '通用设置', detail: '选择翻译服务，设置译文显示、网页辅助与界面偏好。',
-        searchDescription: '选择翻译服务、默认服务、译文显示、网页辅助、AI 智能上下文、默认目标语言、主题',
+        searchDescription: '选择翻译服务、默认服务、译文显示、双语逐句高亮、网页辅助、AI 智能上下文、默认目标语言、主题',
       },
       {
         id: 'settings-services', icon: '译', label: '翻译服务', description: '服务与模型', group: '基础配置',

--- a/src/features/settings/ui/SettingsSections.vue
+++ b/src/features/settings/ui/SettingsSections.vue
@@ -328,6 +328,9 @@
             </el-option-group>
           </el-select>
         </SettingsItem>
+        <SettingsItem v-show="config.display === 1" label="双语逐句高亮" description="开启后，鼠标悬停在原文或译文上会同步高亮对应的双语段落；仅双语模式生效。">
+          <el-switch v-model="config.bilingualSentenceHighlightEnabled" class="settings-toggle" aria-label="双语逐句高亮" />
+        </SettingsItem>
         <div v-show="config.display === 1" class="style-preview-card" aria-live="polite">
           <div class="style-preview-example">
             <p class="style-preview-source">Reading should feel calm and effortless.</p>

--- a/tests/architecture/verificationOwnership.test.ts
+++ b/tests/architecture/verificationOwnership.test.ts
@@ -152,6 +152,8 @@ const BUILD_ONLY_SRC_ALLOWLIST = new Set([
     'src/app/background/configMessageHandlers.ts',
     // content composition root 绑定 WXT context、页面生命周期和静态 feature registry；由内容功能测试与隔离浏览器回归验证。
     'src/app/content/runtime.ts',
+    // 双语高亮只同步 page.css 使用的 Document 根属性；由设置契约、构建和隔离浏览器回归验证。
+    'src/app/content/bilingualSentenceHighlight.ts',
     // 页面快捷键 runtime 绑定真实可信 KeyboardEvent、Selection/Range 与 AbortSignal；纯匹配策略已严格覆盖，信任边界由回归测试验证。
     'src/app/content/hotkeyRuntime.ts',
     // 内容消息 runtime 绑定 browser.runtime 与动态 UI 挂载；payload 守卫和行为由内容消息功能测试、双浏览器构建验证。

--- a/tests/configDiff.test.ts
+++ b/tests/configDiff.test.ts
@@ -8,6 +8,19 @@ function group(result: ReturnType<typeof buildConfigDiff>, id: string) {
 }
 
 describe('配置差异预览', () => {
+    it('预览双语逐句高亮开关', () => {
+        const result = buildConfigDiff({bilingualSentenceHighlightEnabled: false}, {
+            bilingualSentenceHighlightEnabled: true,
+        });
+
+        expect(group(result, 'general')?.changes).toEqual(expect.arrayContaining([expect.objectContaining({
+            key: 'bilingualSentenceHighlightEnabled',
+            label: '双语逐句高亮',
+            before: '关闭',
+            after: '开启',
+        })]));
+    });
+
     it('按设置页稳定分组并把常用枚举、开关、数组和数字格式化为可读文本', () => {
         const result = buildConfigDiff({
             on: true,

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -600,6 +600,16 @@ describe('翻译进度面板配置', () => {
     });
 });
 
+describe('双语逐句高亮配置', () => {
+    it('默认关闭，并只接受显式布尔值开启', () => {
+        expect(new Config().bilingualSentenceHighlightEnabled).toBe(false);
+        expect(normalizeConfig({}).bilingualSentenceHighlightEnabled).toBe(false);
+        expect(normalizeConfig({bilingualSentenceHighlightEnabled: true}).bilingualSentenceHighlightEnabled).toBe(true);
+        expect(normalizeConfig({bilingualSentenceHighlightEnabled: false}).bilingualSentenceHighlightEnabled).toBe(false);
+        expect(normalizeConfig({bilingualSentenceHighlightEnabled: 'true'}).bilingualSentenceHighlightEnabled).toBe(false);
+    });
+});
+
 describe('鼠标悬浮翻译延迟配置', () => {
     it('默认保留现有 50ms 行为，并归一化用户设置', () => {
         expect(new Config().mouseHoverTranslationDelay).toBe(DEFAULT_MOUSE_HOVER_TRANSLATION_DELAY);

--- a/tests/settingsUiArchitecture.test.ts
+++ b/tests/settingsUiArchitecture.test.ts
@@ -405,6 +405,8 @@ describe('options UI composition architecture', () => {
     expect(aiContextSwitch).not.toContain(':disabled')
     expect(general).toContain('label="翻译模式"')
     expect(general).toContain('aria-label="译文样式"')
+    expect(general).toContain('v-model="config.bilingualSentenceHighlightEnabled"')
+    expect(general).toContain('aria-label="双语逐句高亮"')
 
     expect(services).toContain('<ServiceCatalog')
     expect(services).not.toContain('data-testid="default-translation-service-card"')
@@ -466,5 +468,12 @@ describe('options UI composition architecture', () => {
     expect(pageStyles.startsWith('@import "../../../ui/styles/tokens.css";')).toBe(true)
     expect(tokens).toContain('--fr-color-brand: #ef4776;')
     expect(tokens).toContain('--surface-soft: var(--fr-color-surface-soft);')
+  })
+
+  it('keeps bilingual sentence highlighting opt-in and scoped to bilingual wrappers', () => {
+    const page = source('src/app/content/page.css')
+
+    expect(page).toContain('html[data-fr-bilingual-sentence-highlight="true"] .fluent-read-bilingual:hover')
+    expect(page).toContain('> .fluent-read-bilingual-content')
   })
 })


### PR DESCRIPTION
Closes #351. Adds an opt-in bilingual sentence highlighting setting under General Settings > Translation Display. When enabled, hovering or focusing either the original or translated content highlights the paired bilingual unit; disabling it restores the existing appearance. Validation: pnpm test (159 files, 2308 tests), pnpm compile, pnpm build, pnpm build:firefox, and extension manifest verification.