### PR TITLE
fix(popup): expand more services by default

### DIFF
--- a/src/app/popup/PopupApp.vue
+++ b/src/app/popup/PopupApp.vue
@@ -609,7 +609,7 @@ const servicePicker = ref<HTMLElement | null>(null);
 const serviceSearchInput = ref<HTMLInputElement | null>(null);
 const serviceSearchQuery = ref('');
 const servicePickerOpen = ref(false);
-const moreServicesOpen = ref(false);
+const moreServicesOpen = ref(true);
 const hydrated = ref(false);
 let lastSerialized = '';
 let applyingExternalConfig = false;
@@ -658,8 +658,6 @@ const popularServiceOptions = computed(() => popularServiceValues
   .map(value => serviceSearchResults.value.find((item: any) => item.value === value))
   .filter((item): item is any => Boolean(item)));
 const moreServiceOptions = computed(() => serviceSearchResults.value.filter((item: any) => !popularServiceValues.includes(item.value)));
-const selectedServiceIsMore = computed(() => serviceOptions.value.some((item: any) =>
-  item.value === config.value.service && !popularServiceValues.includes(item.value)));
 const servicePickerCount = computed(() => serviceSearchActive.value
   ? `${serviceSearchResults.value.length}/${serviceOptions.value.length}`
   : serviceOptions.value.length);
@@ -818,7 +816,7 @@ function toggleServicePicker() {
   if (!config.value.on) return;
   servicePickerOpen.value = !servicePickerOpen.value;
   if (servicePickerOpen.value) {
-    moreServicesOpen.value = selectedServiceIsMore.value;
+    moreServicesOpen.value = true;
     void nextTick(() => serviceSearchInput.value?.focus());
   } else {
     serviceSearchQuery.value = '';

--- a/tests/popupFeatureVisibility.test.ts
+++ b/tests/popupFeatureVisibility.test.ts
@@ -92,8 +92,8 @@ describe('popup feature visibility', () => {
         expect(popup).toContain(':data-matching-models="item.matchingModels.join(\',\') || undefined"');
         expect(popup).toContain('没有找到包含“{{ serviceSearchQuery.trim() }}”的服务或模型');
         expect(popup).toContain('serviceSearchInput.value?.focus()');
-        expect(popup).toContain('const moreServicesOpen = ref(false)');
-        expect(popup).toContain('moreServicesOpen.value = selectedServiceIsMore.value');
+        expect(popup).toContain('const moreServicesOpen = ref(true)');
+        expect(popup).toContain('moreServicesOpen.value = true');
         expect(styles).toContain('.service-picker-results { min-height: 0; overflow-y: auto; scrollbar-width: thin; }');
     });
 });


### PR DESCRIPTION
Summary: make the popup's 更多服务 section expanded by default, reset it to expanded whenever the service picker opens, preserve manual collapse, and update the regression assertion. Validation: pnpm test (160 files, 2309 tests), pnpm exec vitest run tests/popupFeatureVisibility.test.ts, pnpm compile, pnpm build, and hidden isolated Edge popup verification with no console errors.