### PR TITLE
fix: keep Reddit navigation and actions untranslated

### DIFF
--- a/src/core/translation/README.md
+++ b/src/core/translation/README.md
@@ -33,6 +33,11 @@ adapter targets and cannot be reopened. Adapters are sorted by priority, while
 registration order is stable for ties. Invalid selectors only invalidate that
 match and never abort the page scan.
 
+An adapter may set `genericCandidatePolicy` to `targets-only` when a site has a
+large application shell and a stable content allowlist. This disables generic
+block and inline-run fallbacks for that matched site while preserving explicit
+`force-target` decisions for both hover and full-page translation.
+
 Every accepted candidate includes a reason and optional adapter id. This keeps
 hover/full equality and adapter precedence directly testable without starting a
 browser. Open Shadow DOM is traversed through the same policy.

--- a/src/core/translation/adapters/declarative.ts
+++ b/src/core/translation/adapters/declarative.ts
@@ -10,6 +10,7 @@ import {safeClosest, safeMatches} from '../dom';
 import type {
     AdapterContext,
     AdapterDecision,
+    TranslationGenericCandidatePolicy,
     TranslationCandidateKind,
     TranslationSiteAdapter,
 } from '../types';
@@ -36,6 +37,7 @@ export interface DeclarativeHostRule {
 export interface DeclarativeSiteAdapterDefinition {
     id: string;
     priority?: number;
+    genericCandidatePolicy?: TranslationGenericCandidatePolicy;
     hosts: readonly (string | DeclarativeHostRule)[];
     pathnames?: readonly RegExp[];
     targets?: readonly DeclarativeTargetRule[];
@@ -124,6 +126,7 @@ export function createDeclarativeAdapter(
     return {
         id: definition.id,
         priority: definition.priority,
+        genericCandidatePolicy: definition.genericCandidatePolicy,
         matches(url: URL): boolean {
             return definition.hosts.some((host) => matchesHost(url, host)) &&
                 matchesPathname(url.pathname, definition.pathnames);

--- a/src/core/translation/adapters/reddit.ts
+++ b/src/core/translation/adapters/reddit.ts
@@ -8,9 +8,52 @@
 
 import {createDeclarativeAdapter} from './declarative';
 
+const redditPostProseSelectors = [
+    'shreddit-post [slot="text-body"] p',
+    'shreddit-post [slot="text-body"] li',
+    'shreddit-post [slot="text-body"] blockquote',
+    'shreddit-post [slot="text-body"] h1',
+    'shreddit-post [slot="text-body"] h2',
+    'shreddit-post [slot="text-body"] h3',
+    'shreddit-post [slot="text-body"] h4',
+    'shreddit-post [slot="text-body"] h5',
+    'shreddit-post [slot="text-body"] h6',
+    '[data-testid="post-content"] p',
+    '[data-testid="post-content"] li',
+    '[data-testid="post-content"] blockquote',
+    '[data-click-id="text"] p',
+    '[data-click-id="text"] li',
+    '[data-click-id="body"] p',
+    '[data-click-id="body"] h1',
+    '[data-click-id="body"] h2',
+    '[data-click-id="body"] h3',
+    '[data-click-id="body"] h4',
+    '[data-click-id="body"] h5',
+    '[data-click-id="body"] h6',
+] as const;
+
+const redditCommentProseSelectors = [
+    'shreddit-comment [slot="comment"] p',
+    'shreddit-comment [slot="comment"] li',
+    'shreddit-comment [slot="comment"] blockquote',
+    'shreddit-comment [id$="-comment-rtjson-content"] p',
+    '[data-testid="comment"] p',
+    '[data-testid="comment"] li',
+    '[data-click-id="comment"] p',
+] as const;
+
+const redditControlSelectors = [
+    'button',
+    '[role="button"]',
+    '[role="menuitem"]',
+] as const;
+
 export const redditAdapter = createDeclarativeAdapter({
     id: 'reddit',
     priority: 390,
+    // Reddit 的页面壳层包含大量由 Web Component 生成的按钮、链接和 aria 文案。
+    // 参照沉浸式翻译的 Reddit 规则，只接收下方显式声明的正文 target。
+    genericCandidatePolicy: 'targets-only',
     hosts: [
         {hostname: 'reddit.com', includeSubdomains: true},
         {hostname: 'redd.it', includeSubdomains: true},
@@ -29,24 +72,21 @@ export const redditAdapter = createDeclarativeAdapter({
             atomic: true,
         },
         {
-            selector: [
-                'shreddit-post [slot="text-body"] p',
-                '[data-testid="post-content"] p',
-                '[data-click-id="text"] p',
-            ],
+            selector: redditPostProseSelectors,
             reason: 'reddit-post-prose',
             match: 'closest',
         },
         {
-            selector: [
-                'shreddit-comment [slot="comment"] p',
-                '[data-testid="comment"] p',
-            ],
+            selector: redditCommentProseSelectors,
             reason: 'reddit-comment-prose',
             match: 'closest',
         },
     ],
     keepOriginal: [
+        {
+            selector: redditControlSelectors,
+            reason: 'reddit-controls',
+        },
         {
             selector: ['faceplate-timeago', '[data-testid="post_timestamp"]', '[data-testid="vote-arrows"]'],
             reason: 'reddit-dynamic-metadata',
@@ -55,6 +95,7 @@ export const redditAdapter = createDeclarativeAdapter({
     mutationExclude: [
         {
             selector: [
+                ...redditControlSelectors,
                 'faceplate-timeago',
                 '[data-testid="post_timestamp"]',
                 '[data-testid="vote-arrows"]',

--- a/src/core/translation/engine.ts
+++ b/src/core/translation/engine.ts
@@ -213,6 +213,14 @@ export class TranslationCandidateCore {
         return result;
     }
 
+    /**
+     * 站点可以选择只翻译自己明确声明的 target。该策略只收紧通用回退，
+     * 不会阻止适配器返回的 force-target，因此全文与悬浮仍共享同一白名单。
+     */
+    private allowsGenericCandidates(): boolean {
+        return !this.adapters.some((adapter) => adapter.genericCandidatePolicy === 'targets-only');
+    }
+
     shouldStayOriginal = (element: Element): boolean => this.adapters.some((adapter) => {
         try {
             return adapter.shouldStayOriginal?.(element, this.context) === true;
@@ -412,6 +420,10 @@ export class TranslationCandidateCore {
             return {candidate};
         }
 
+        if (!this.allowsGenericCandidates()) {
+            return {candidate: null};
+        }
+
         if (evaluationContext &&
             this.hasStructuralAncestorForResolution(element, evaluationContext) &&
             !isSemanticHeadingElement(element)) {
@@ -443,6 +455,7 @@ export class TranslationCandidateCore {
         candidateChildBarriers?: ReadonlySet<Element>,
         evaluationContext?: ResolutionEvaluationContext,
     ): TranslationCandidate[] {
+        if (!this.allowsGenericCandidates()) return [];
         const candidates: TranslationCandidate[] = [];
         const atomicTargetCache = new WeakMap<Element, boolean>();
         const protectionOptions = evaluationContext?.textProtectionOptions;
@@ -495,6 +508,7 @@ export class TranslationCandidateCore {
         insideStructural: boolean,
         textProtectionCache: TranslationTextProtectionCache,
     ): TranslationCandidate | null {
+        if (!this.allowsGenericCandidates()) return null;
         if (insideStructural && !isSemanticHeadingElement(element)) return null;
         const classification = classifyGenericCandidate(
             element,

--- a/src/core/translation/types.ts
+++ b/src/core/translation/types.ts
@@ -8,6 +8,9 @@
 
 export type TranslationCandidateKind = 'content' | 'control';
 
+/** 站点适配器是否允许没有显式 selector 命中的通用候选。 */
+export type TranslationGenericCandidatePolicy = 'allow' | 'targets-only';
+
 export type AdapterDecision =
     | {kind: 'pass'}
     | {kind: 'skip-self'; reason: string}
@@ -27,6 +30,8 @@ export interface AdapterContext {
 export interface TranslationSiteAdapter {
     id: string;
     priority?: number;
+    /** `targets-only` 仍允许 force-target，但禁止通用块和内联 run 回退。 */
+    genericCandidatePolicy?: TranslationGenericCandidatePolicy;
     matches(url: URL): boolean;
     decide(element: Element, context: AdapterContext): AdapterDecision;
     shouldStayOriginal?(element: Element, context: AdapterContext): boolean;

--- a/tests/browser-translation-cases.json
+++ b/tests/browser-translation-cases.json
@@ -314,8 +314,8 @@
     "fullPageHotkey": "Alt+T",
     "service": "freeTranslation"
   },
-  "reddit-chatgpt-thread": {
-    "url": "https://www.reddit.com/r/ChatGPT/comments/1m0fr3u",
+  "reddit-minimax-thread": {
+    "url": "https://www.reddit.com/r/MiniMax_AI/comments/1v73a0r/m31_has_strong_potential_to_be_the_most/",
     "hoverSelector": "shreddit-post [slot=title]",
     "requiredSelectors": [
       "shreddit-post [slot=title]",
@@ -325,12 +325,18 @@
       {"name": "post-title", "selector": "shreddit-post [slot=title]", "kind": "content", "minInitial": 1, "trackDynamic": true},
       {"name": "visible-comments", "selector": "shreddit-comment [id$='-comment-rtjson-content'] p", "kind": "content", "minInitial": 1, "minSeen": 2, "trackDynamic": true}
     ],
-    "forbiddenSelectors": ["faceplate-timeago"],
+    "forbiddenSelectors": [
+      "button",
+      "[role=button]",
+      "[role=menuitem]",
+      "faceplate-timeago",
+      "[data-testid=vote-arrows]"
+    ],
     "dynamicForbiddenSelectors": ["faceplate-timeago"],
     "interactionSelectors": ["shreddit-post a[href]"],
     "modes": ["hover", "full"],
     "tier": "quarantine",
-    "quarantineReason": "Reddit 在当前隔离自动化环境中返回 blocked by network security，保留为动态 Web Component 联网观察样本。",
+    "quarantineReason": "Reddit 在当前隔离自动化环境中返回 blocked by network security，保留为动态 Web Component 联网观察样本；按钮控件必须保持原文。",
     "hoverHotkey": "Control",
     "fullPageHotkey": "Alt+T",
     "service": "freeTranslation"

--- a/tests/siteTranslationHarness.test.ts
+++ b/tests/siteTranslationHarness.test.ts
@@ -1487,7 +1487,7 @@ describe('real-site translation matrix gates', () => {
 
   it('keeps deleted or challenged pages quarantined and replaces them with stable docs', () => {
     expect(cases['hacker-news-8863'].tier).toBe('quarantine');
-    expect(cases['reddit-chatgpt-thread'].tier).toBe('quarantine');
+    expect(cases['reddit-minimax-thread'].tier).toBe('quarantine');
     expect(cases['steam-workshop-discussion-3246316298'].tier).toBe('quarantine');
     expect(cases['w3c-accessibility-introduction'].tier).toBe('quarantine');
     expect(cases['nginx-beginners-guide'].tier).toBe('required');

--- a/tests/translationCore.test.ts
+++ b/tests/translationCore.test.ts
@@ -51,6 +51,7 @@ import {
     readCachedFlagOr,
 } from '@/src/core/translation/internal';
 import {bilibiliAdapter} from '@/src/core/translation/adapters/bilibili';
+import {redditAdapter} from '@/src/core/translation/adapters/reddit';
 
 function page(html: string, url = 'https://example.test/article') {
     const {document} = parseHTML(`<html><head></head><body>${html}</body></html>`);
@@ -937,6 +938,68 @@ describe('translation candidate core', () => {
             value: () => commentText,
         });
         expect(core.resolveAtPoint(document, 10, 20)).toBeNull();
+    });
+
+    it('limits Reddit to explicit post/comment targets and preserves navigation actions', () => {
+        const {document, core} = page(`
+            <header id="reddit-header">
+                <button id="open-menu" aria-label="Open menu">Open menu</button>
+                <a id="reddit-home" href="/">Go to Reddit Home</a>
+                <a id="community" href="/r/MiniMax_AI">r/MiniMax_AI</a>
+                <button id="open-chat">Open chat</button>
+                <button id="create-post">Create</button>
+                <button id="open-inbox">Open inbox</button>
+                <span id="advertise">Advertise on Reddit</span>
+            </header>
+            <main>
+                <shreddit-post id="post">
+                    <h1 id="post-title-t3_fixture">M3.1 has strong potential to be the most cost-efficient large model ahead</h1>
+                    <div slot="text-body">
+                        <p id="post-body">I have gone through the technical specifications and want to share my analysis here.</p>
+                        <ul><li id="post-list-item">The model uses sparse attention.</li></ul>
+                    </div>
+                    <div id="post-actions">
+                        <button id="share">Share</button>
+                        <button id="reply">Reply</button>
+                    </div>
+                </shreddit-post>
+                <shreddit-comment id="comment-host">
+                    <div slot="comment"><p id="comment-body">This is a useful comment.</p></div>
+                    <button id="comment-reply">Reply</button>
+                </shreddit-comment>
+                <p id="unscoped-copy">Open profile menu</p>
+            </main>
+        `, 'https://www.reddit.com/r/MiniMax_AI/comments/1v73a0r/m31_has_strong_potential_to_be_the_most/');
+        const title = document.querySelector('#post-title-t3_fixture')!;
+        const body = document.querySelector('#post-body')!;
+        const listItem = document.querySelector('#post-list-item')!;
+        const comment = document.querySelector('#comment-body')!;
+        const controls = ['open-menu', 'open-chat', 'create-post', 'open-inbox', 'share', 'reply', 'comment-reply']
+            .map((id) => document.querySelector(`#${id}`)!);
+
+        expect(redditAdapter.matches(new URL('https://www.reddit.com/r/MiniMax_AI/comments/1'))).toBe(true);
+        expect(redditAdapter.matches(new URL('https://example.test/article'))).toBe(false);
+
+        const candidates = core.discover(document);
+        expect(candidates.find((candidate) => candidate.element === title))
+            .toMatchObject({adapterId: 'reddit', reason: 'reddit-post-title'});
+        expect(candidates.find((candidate) => candidate.element === body))
+            .toMatchObject({adapterId: 'reddit', reason: 'reddit-post-prose'});
+        expect(candidates.find((candidate) => candidate.element === listItem))
+            .toMatchObject({adapterId: 'reddit', reason: 'reddit-post-prose'});
+        expect(candidates.find((candidate) => candidate.element === comment))
+            .toMatchObject({adapterId: 'reddit', reason: 'reddit-comment-prose'});
+        expect(candidates.some((candidate) => candidate.adapterId !== 'reddit')).toBe(false);
+
+        for (const control of controls) {
+            expect(core.resolve(control.firstChild)).toBeNull();
+            expect(core.shouldStayOriginal(control)).toBe(true);
+            expect(core.shouldIgnoreMutation(control)).toBe(true);
+        }
+        expect(core.resolve(document.querySelector('#reddit-home')?.firstChild)).toBeNull();
+        expect(core.resolve(document.querySelector('#community')?.firstChild)).toBeNull();
+        expect(core.resolve(document.querySelector('#advertise')?.firstChild)).toBeNull();
+        expect(core.resolve(document.querySelector('#unscoped-copy')?.firstChild)).toBeNull();
     });
 
     it('bounds cyclic Shadow DOM coordinate lookup without overflowing the call stack', () => {


### PR DESCRIPTION
## Summary

- Restrict Reddit translation to explicit post title, post prose, and comment prose targets.
- Keep Reddit navigation, menus, Share, Reply, and other controls in the host language.
- Add regression coverage for the requested MiniMax Reddit thread and the targets-only candidate policy.

## Validation

- pnpm test — 160 files, 2310 tests passed
- pnpm compile passed
- pnpm build passed
- git diff --check passed
- Hidden production Edge Reddit-host fixture: hover [1, 0, 1], six content wrappers, zero control wrappers, zero page/console errors.
- The live Reddit URL currently returns Reddit human verification, so it is recorded as a network challenge rather than a product result.