### PR TITLE
fix: 保留双语译文中的公式结构和排版

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -6,6 +6,8 @@ FluentRead 的功能都围绕一个目标：让你在当前页面完成理解，
 
 点击“翻译页面”，译文会放在原文附近，形成可以对照阅读的双语页面。原文不会被覆盖，随时可以恢复。
 
+阅读论文时，双语译文会保留原文中的行内公式，包括原生 MathML、KaTeX、MathJax 和 Wikipedia 公式图片。公式沿用网页的渲染结构，周围文字正常翻译；恢复原文和再次翻译不会改写原始公式。
+
 <figure class="doc-figure">
   <img class="doc-screenshot" src="/screenshots/translation.webp" alt="英文网页中原文和中文译文按段落显示" />
   <figcaption>适合新闻、博客、在线文档和长篇资料。</figcaption>

--- a/src/features/full-page-translation/content/bilingualReplay.ts
+++ b/src/features/full-page-translation/content/bilingualReplay.ts
@@ -43,6 +43,7 @@ export function refreshBilingualTranslationSkeleton(
 
     const translatedHTML = applyTranslationsToSnapshot(snapshot, replay.translations);
     refreshBilingualTranslation(node, content, translatedHTML, {
+        sourceSkeleton: snapshot.clone,
         targetLanguage: replay.targetLanguage,
         style: replay.style,
     });

--- a/src/features/full-page-translation/content/renderer.ts
+++ b/src/features/full-page-translation/content/renderer.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/features/full-page-translation/content/renderer.ts
  * 文件职责：把翻译返回的受限 HTML 或纯文本安全插入原页面，构造 FluentRead 双语与仅译文节点，同时保护链接属性并触发布局截断修复。
- * 主要内容：包含 URL 协议白名单、可复制属性集合、递归节点净化、DocumentFragment 创建、不改写宿主 class 的双语 wrapper，以及通过 Shadow DOM 保留宿主原文的仅译文文本槽。
+ * 主要内容：包含 URL 协议白名单、可复制属性集合、递归节点净化、本地公式骨架的受限克隆、DocumentFragment 创建、不改写宿主 class 的双语 wrapper，以及通过 Shadow DOM 保留宿主原文的仅译文文本槽。
  * 模块边界：本文件只负责安全渲染，不发起翻译或管理请求状态；服务调用归 runtime，节点所有权归 state，配置仅用于展示选项，任意脚本、事件属性和危险链接都不得穿过净化边界。
  */
 import { options } from "@/src/core/config/catalog";
@@ -41,7 +41,76 @@ function copySafeAttributes(source: Element, target: HTMLElement): void {
     }
 }
 
-function sanitizeNode(node: Node): Node[] {
+// 公式只能来自本地快照，不能根据 provider 返回的 HTML 升级信任。
+const formulaSelector = 'math, mjx-container, .MathJax, .MathJax_Display, .MathJax_SVG, .MathJax_CHTML, .katex, .mwe-math-element, .ltx_Math';
+const formulaTags = new Set((
+    'span div img math semantics annotation mi mn mo mrow mfrac msqrt mroot mstyle merror ' +
+    'mpadded mphantom mfenced menclose msub msup msubsup munder mover munderover mmultiscripts ' +
+    'mprescripts none mtable mtr mtd mlabeledtr mtext mspace svg g defs path use rect line polyline ' +
+    'polygon circle ellipse'
+).split(' '));
+const formulaAttributes = new Set((
+    'class title role aria-hidden alt width height viewbox preserveaspectratio jax size s texclass d transform x y x1 y1 ' +
+    'x2 y2 cx cy r rx ry points fill stroke stroke-width opacity focusable display mathvariant ' +
+    'mathsize mathcolor mathbackground displaystyle scriptlevel stretchy symmetric largeop movablelimits ' +
+    'accent accentunder fence separator form lspace rspace minsize maxsize linethickness bevelled ' +
+    'rowalign columnalign rowspacing columnspacing columnspan rowspan depth voffset encoding '
+).trim().split(' '));
+let formulaCloneSequence = 0;
+
+/** 保留公式排版所需的惰性节点，丢弃脚本、外部 SVG 引用、事件和可聚焦控件。 */
+function cloneSourceFormula(source: Element): Element | null {
+    const ids = new Map<string, string>();
+    const prefix = `fr-formula-${++formulaCloneSequence}-`;
+    for (const element of [source, ...Array.from(source.querySelectorAll('[id]'))]) {
+        const id = element.getAttribute('id');
+        if (id) ids.set(id, `${prefix}${ids.size}`);
+    }
+    const clone = (element: Element): Element | null => {
+        const tag = element.localName.toLowerCase();
+        // MathJax CHTML 使用无脚本语义的 mjx-* 自定义排版元素。
+        if (!formulaTags.has(tag) && !allowedTags.has(tag) && !/^mjx-[a-z0-9-]+$/u.test(tag)) return null;
+        const target = document.createElementNS(element.namespaceURI, element.localName);
+        for (const {name, value} of Array.from(element.attributes)) {
+            const lower = name.toLowerCase();
+            if (lower === 'id') {
+                target.setAttribute('id', ids.get(value)!);
+            } else if (lower === 'href' || lower === 'xlink:href') {
+                if (tag === 'use' && /^#[\w.:-]+$/u.test(value)) {
+                    target.setAttributeNS(lower === 'xlink:href' ? 'http://www.w3.org/1999/xlink' : null,
+                        name, `#${ids.get(value.slice(1)) ?? value.slice(1)}`);
+                }
+            } else if (lower === 'src' && tag === 'img') {
+                try {
+                    const url = new URL(value, document.baseURI || undefined);
+                    if (['http:', 'https:'].includes(url.protocol)) target.setAttribute('src', url.href);
+                } catch { /* 非法图片地址不能进入克隆。 */ }
+            } else if (lower === 'style') {
+                // 公式布局需要 renderer 的字体、尺寸与相对定位；不接受 URL、转义或执行语法。
+                const safe = value.split(';').filter((declaration) => {
+                    const [property, ...parts] = declaration.split(':');
+                    return /^(?:--[a-z0-9-]+|[a-z-]+)$/iu.test(property.trim()) && parts.length > 0 &&
+                        !/(?:url|expression|behavior|binding|import|javascript|[\\<>@])/iu.test(parts.join(':')) &&
+                        !/^(?:position)\s*:\s*(?:fixed|sticky)/iu.test(declaration.trim());
+                }).join(';');
+                if (safe) target.setAttribute('style', safe);
+            } else if (formulaAttributes.has(lower) || /^data-(?:mjx|mml|c)(?:-|$)/u.test(lower)) {
+                if (!/(?:url\s*\(|javascript:)/iu.test(value)) target.setAttribute(name, value);
+            }
+        }
+        for (const child of Array.from(element.childNodes)) {
+            if (child.nodeType === Node.TEXT_NODE) target.appendChild(document.createTextNode((child as Text).data));
+            else if (child.nodeType === Node.ELEMENT_NODE) {
+                const safe = clone(child as Element);
+                if (safe) target.appendChild(safe);
+            }
+        }
+        return target;
+    };
+    return clone(source);
+}
+
+function sanitizeNode(node: Node, sourceSkeleton = false): Node[] {
     if (node.nodeType === Node.TEXT_NODE) {
         return [document.createTextNode(node.nodeValue ?? "")];
     }
@@ -52,7 +121,11 @@ function sanitizeNode(node: Node): Node[] {
     const tag = source.tagName.toLowerCase();
     if (blockedTags.has(tag)) return [];
 
-    const children = Array.from(source.childNodes).flatMap(sanitizeNode);
+    if (sourceSkeleton && source.matches(formulaSelector)) {
+        const formula = cloneSourceFormula(source);
+        return formula ? [formula] : [];
+    }
+    const children = Array.from(source.childNodes).flatMap((child) => sanitizeNode(child, sourceSkeleton));
 
     // 不在白名单中的结构只展开其安全文本/内联子节点，避免丢失译文内容。
     if (!allowedTags.has(tag)) return children;
@@ -71,7 +144,7 @@ function createSafeTranslationFragment(text: string): DocumentFragment {
     const parsed = new DOMParser().parseFromString(text || "", "text/html");
     const fragment = document.createDocumentFragment();
     Array.from(parsed.body.childNodes)
-        .flatMap(sanitizeNode)
+        .flatMap((node) => sanitizeNode(node))
         .forEach((node) => fragment.appendChild(node));
     return fragment;
 }
@@ -83,6 +156,8 @@ function createSafeTranslationFragment(text: string): DocumentFragment {
 export interface BilingualTranslationRenderOptions {
     /** 全文会话启动时冻结的目标语言；普通悬浮翻译缺省仍读取当前配置。 */
     targetLanguage?: string;
+    /** 仅接受本地 createTranslationSourceSnapshot 的克隆，文本槽已经安全写入。 */
+    sourceSkeleton?: HTMLElement;
     /** 全文会话启动时冻结的译文样式。 */
     style?: number;
 }
@@ -149,10 +224,16 @@ function createBilingualTranslationContent(
     const style = options.styles.find((item) => item.value === styleValue && !item.disabled);
     if (style?.class) content.classList.add(style.class);
 
-    // 译文可能来自机器翻译的 HTML 或大模型的富文本响应。统一经过
-    // DOMParser + 白名单迁移，既保留链接/强调等行内结构，也不把服务响应
-    // 当作可信 HTML 直接写回网页。
-    const fragment = createSafeTranslationFragment(text);
+    // 本地骨架已把 provider 输出写为文本节点，直接做白名单迁移以保留公式命名空间。
+    // 其他调用方传入的 HTML 仍经过 DOMParser，并使用更严格的普通内联白名单。
+    const fragment = renderOptions.sourceSkeleton
+        ? document.createDocumentFragment()
+        : createSafeTranslationFragment(text);
+    if (renderOptions.sourceSkeleton) {
+        Array.from(renderOptions.sourceSkeleton.childNodes)
+            .flatMap((child) => sanitizeNode(child, true))
+            .forEach((child) => fragment.appendChild(child));
+    }
     content.appendChild(fragment);
     return content;
 }

--- a/src/features/full-page-translation/content/runtime.ts
+++ b/src/features/full-page-translation/content/runtime.ts
@@ -558,7 +558,7 @@ async function renderTranslation(
 
         const content = withFullPageViewportAnchor(() =>
             appendBilingualTranslation(node, translatedText, {
-                targetLanguage: snapshot.targetLanguage,
+                sourceSkeleton: freshSnapshot.clone, targetLanguage: snapshot.targetLanguage,
                 style: snapshot.style,
             }), [node]);
         setBilingualContent(node, content, {sources: result.sources, translations: result.translations,

--- a/tests/translationTruncation.test.ts
+++ b/tests/translationTruncation.test.ts
@@ -9,6 +9,8 @@ vi.mock('@/src/core/config/catalog', () => ({
 }));
 
 import {
+    applyTranslationsToSnapshot,
+    createTranslationSourceSnapshot,
     findTranslationTruncationAncestors,
     hasActiveTranslationLineClamp,
     hasActiveTranslationTruncation,
@@ -424,6 +426,64 @@ describe('translation truncation layout', () => {
                 Object.assign(config, previousConfig);
                 options.styles = previousStyles;
             }
+        });
+    });
+
+    it('preserves source MathML, KaTeX, MathJax SVG and image formulas through the actual renderer', async () => {
+        const {document} = parseHTML(`<html><body><p id="owner">The velocity
+            <math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>v</mi><mi>t</mi></msub></math>
+            and <span class="katex"><span class="katex-html" aria-hidden="true" style="height:1em"><span class="mord">x</span></span></span>
+            with <mjx-container class="MathJax" jax="CHTML"><mjx-msub><mjx-mi>x</mjx-mi><mjx-script><mjx-mn size="s">1</mjx-mn></mjx-script></mjx-msub><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><defs><path id="glyph" d="M0 0L10 10"/></defs><use href="#glyph"/></svg></mjx-container>
+            and <span class="mwe-math-element"><img src="https://example.org/math.svg" alt="y"></span> remains stable.
+        </p></body></html>`);
+        const owner = document.querySelector<HTMLElement>('#owner')!;
+        const originalHTML = owner.innerHTML;
+        const originalMath = owner.querySelector('math');
+        await withDocumentRealm(document, async () => {
+            for (let cycle = 0; cycle < 2; cycle += 1) {
+                const snapshot = createTranslationSourceSnapshot(owner);
+                const html = applyTranslationsToSnapshot(snapshot, snapshot.slots.map(() => '译文'));
+                const wrapper = appendBilingualTranslation(owner, html, {sourceSkeleton: snapshot.clone});
+                expect(wrapper.querySelectorAll('math')).toHaveLength(1);
+                expect(wrapper.querySelector('msub')?.textContent).toBe('vt');
+                expect(wrapper.querySelector('.katex .mord')?.textContent).toBe('x');
+                expect(wrapper.querySelector('.katex-html')?.getAttribute('style')).toContain('height');
+                expect(wrapper.querySelector('mjx-container')?.getAttribute('jax')).toBe('CHTML');
+                expect(wrapper.querySelector('mjx-mn')?.getAttribute('size')).toBe('s');
+                expect(wrapper.querySelector('svg use')?.getAttribute('href')).toBe(`#${wrapper.querySelector('svg path')?.id}`);
+                expect(wrapper.querySelector('svg path')?.id).not.toBe('glyph');
+                expect(wrapper.querySelector('.mwe-math-element img')?.getAttribute('src')).toContain('math.svg');
+                wrapper.remove();
+                expect(owner.innerHTML).toBe(originalHTML);
+                expect(owner.querySelector('math')).toBe(originalMath);
+            }
+        });
+    });
+
+    it('rejects active formula content and keeps formula privileges out of provider HTML', async () => {
+        const {document} = parseHTML(`<html><head><base href="https://example.org/paper"></head><body><p id="owner">Prose</p></body></html>`);
+        const owner = document.querySelector<HTMLElement>('#owner')!;
+        await withDocumentRealm(document, async () => {
+            const skeleton = document.createElement('p');
+            skeleton.innerHTML = `<span class="katex" onclick="alert(1)" tabindex="0">
+                <span id="safe" style="height:1em;position:relative;left:0;bad;1bad:value;background:url(https://bad);position:fixed" data-mjx-test="yes">x</span>
+                <span style="background:url(https://bad)" fill="url(https://bad)">y</span>
+                <script>alert(1)</script><iframe src="https://bad"></iframe><button>bad control</button>
+                <a href="javascript:alert(1)">link</a><img src="javascript:alert(1)"><img src="http://[">
+                <svg><use xlink:href="#external-glyph"/><use href="https://bad/glyph"/><foreignObject>bad</foreignObject></svg>
+                <!-- comment -->
+            </span><section class="MathJax">unsupported wrapper</section>`;
+            const wrapper = appendBilingualTranslation(owner, '', {sourceSkeleton: skeleton});
+            expect(wrapper.querySelectorAll('script, iframe, button, foreignObject, section')).toHaveLength(0);
+            expect(wrapper.querySelector('[onclick], [tabindex], [href]')).toBeNull();
+            expect(wrapper.querySelector('use')?.getAttribute('xlink:href')).toBe('#external-glyph');
+            expect([...wrapper.querySelectorAll('img')].every(img => !img.hasAttribute('src'))).toBe(true);
+            expect(wrapper.querySelector('[data-mjx-test]')?.getAttribute('style')).toBe('height:1em;position:relative;left:0');
+            expect(wrapper.querySelector('[fill]')).toBeNull();
+            wrapper.remove();
+            const provider = appendBilingualTranslation(owner, '<span class="katex" style="height:100vh"><math><mi>x</mi></math><img src="https://bad"></span>');
+            expect(provider.querySelector('math, img, .katex, [style]')).toBeNull();
+            expect(provider.textContent).toBe('x');
         });
     });
 


### PR DESCRIPTION
## 问题与修复

双语翻译虽然在文本槽阶段保留了本地公式骨架，最终 HTML 渲染白名单仍会拆掉 MathML、SVG 结构并移除 KaTeX/MathJax 排版属性，造成译文公式消失、变成普通文字或下标错位。

让首次翻译和动态骨架重放直接使用本地源快照，受限克隆公式的结构、字体和尺寸属性，并重写内部 SVG ID 引用。继续过滤脚本、事件属性、危险地址与外部 SVG 引用；provider HTML 仍使用原有普通内联白名单。补充真实渲染器回归测试和功能文档。

参考问题与场景：mengxi-ream/read-frog#2155，以及 https://arxiv.org/html/2512.02012v1 。本实现沿用 FluentRead 的文本槽架构，未复制或修改参考项目，不取代上游 PR。

## 验证

- 严格覆盖率：129 个测试文件、2,144 个用例通过，statements/branches/functions/lines 均为 100%。
- 架构测试：23 个文件、601 个用例通过；test:audit 和 git diff --check 通过。
- TypeScript/Vue 编译、Chrome/Firefox/userscript 构建、userscript verifier、文档构建通过。
- 交付前重跑 translationTruncation、bilingualReplay、translationCore、compile 和 Chrome build。
- 临时隔离 Edge + 实际 freeTranslation 服务：arXiv 摘要悬浮及全文入口公式数均为 3 → 0 → 3，MathJax 为 2 → 0 → 2，Wikipedia 为 1 → 0 → 1；原始公式节点完整，译文无重复；检查截图确认 MathJax 下标排版正常。

全文入口验证范围为 arXiv 摘要目标，并非整篇论文逐段覆盖；KaTeX 和 SVG 引用使用确定性渲染回归测试，未做 KaTeX 真实站点验证。
