### PR TITLE
chore: release V0.0.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 An open-source browser extension that helps you understand foreign-language webpages without leaving the page.
 
-[![Latest version](https://img.shields.io/badge/version-0.0.31-6d5dfc?style=flat-square)](https://github.com/FluentRead/FluentRead/releases)
+[![Latest version](https://img.shields.io/badge/version-0.0.32-6d5dfc?style=flat-square)](https://github.com/FluentRead/FluentRead/releases)
 [![License: GPL v3](https://img.shields.io/badge/license-GPL--3.0-22a06b?style=flat-square)](./LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/FluentRead/FluentRead?style=flat-square)](https://github.com/FluentRead/FluentRead)
 

--- a/misc/README_ZH.md
+++ b/misc/README_ZH.md
@@ -8,7 +8,7 @@
 
 一款帮助你在当前页面读懂外语内容的开源浏览器翻译插件。
 
-[![版本](https://img.shields.io/badge/version-0.0.31-6d5dfc?style=flat-square)](https://github.com/FluentRead/FluentRead/releases)
+[![版本](https://img.shields.io/badge/version-0.0.32-6d5dfc?style=flat-square)](https://github.com/FluentRead/FluentRead/releases)
 [![许可证：GPL v3](https://img.shields.io/badge/license-GPL--3.0-22a06b?style=flat-square)](../LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/FluentRead/FluentRead?style=flat-square)](https://github.com/FluentRead/FluentRead)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "流畅阅读",
   "description": "一款革命性的浏览器开源翻译插件，让所有人都能够拥有母语般的阅读体验",
   "private": true,
-  "version": "0.0.31",
+  "version": "0.0.32",
   "userscriptVersion": "2.0.0",
   "type": "module",
   "engines": {

--- a/tests/extensionManifestContract.test.ts
+++ b/tests/extensionManifestContract.test.ts
@@ -112,23 +112,23 @@ describe('extension manifest capability contract', () => {
             ): string[];
         };
         const expected = [
-            'fluent-read-0.0.31-firefox.zip',
-            'fluent-read-0.0.31-sources.zip',
+            'fluent-read-0.0.32-firefox.zip',
+            'fluent-read-0.0.32-sources.zip',
         ];
 
         expect(verifier.findUnexpectedCurrentVersionArchives([
             ...expected,
             '-0.0.30-firefox.zip',
-            'legacy-10.0.31-sources.zip',
-        ], '0.0.31', expected)).toEqual([]);
+            'legacy-10.0.32-sources.zip',
+        ], '0.0.32', expected)).toEqual([]);
         expect(verifier.findUnexpectedCurrentVersionArchives([
             ...expected,
-            '-0.0.31-firefox.zip',
-            'legacy-v0.0.31-sources.zip',
+            '-0.0.32-firefox.zip',
+            'legacy-v0.0.32-sources.zip',
             'fluent-read-0.0.30-firefox.zip',
-        ], '0.0.31', expected)).toEqual([
-            '-0.0.31-firefox.zip',
-            'legacy-v0.0.31-sources.zip',
+        ], '0.0.32', expected)).toEqual([
+            '-0.0.32-firefox.zip',
+            'legacy-v0.0.32-sources.zip',
         ]);
     });
 


### PR DESCRIPTION
## Summary
- bump the extension version from 0.0.31 to 0.0.32
- update English and Chinese version badges
- update current-version archive contract fixtures

## Verification
- pnpm exec vitest run tests/extensionManifestContract.test.ts
- pnpm test:audit
- pnpm compile
- pnpm build
- pnpm build:firefox
- pnpm verify:extension-manifests
- generated Chrome MV3 and Firefox MV2 manifests both report 0.0.32