### PR TITLE
perf: 精简加密依赖、重复资源和未使用函数

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "postinstall": "wxt prepare",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "analyze:bundle": "node scripts/testing/analyze-bundle-size.mjs"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.116",

--- a/scripts/testing/analyze-bundle-size.mjs
+++ b/scripts/testing/analyze-bundle-size.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// 分析已有构建目录的实际字节数和重复文件；不构建、不修改产物。
+// 用法：pnpm analyze:bundle [构建目录] [基线目录]
+import {createHash} from 'node:crypto';
+import {readdir, readFile} from 'node:fs/promises';
+import path from 'node:path';
+
+async function measure(directory) {
+  const files = [];
+  async function walk(current) {
+    for (const entry of await readdir(current, {withFileTypes: true})) {
+      const absolute = path.join(current, entry.name);
+      if (entry.isDirectory()) await walk(absolute);
+      else if (entry.isFile()) {
+        const data = await readFile(absolute);
+        files.push({path: path.relative(directory, absolute), bytes: data.length,
+          hash: createHash('sha256').update(data).digest('hex')});
+      }
+    }
+  }
+  await walk(directory);
+  if (!files.some(file => file.path === 'manifest.json')) {
+    throw new Error(`不是扩展构建目录（缺少 manifest.json）：${directory}`);
+  }
+  return files.sort((a, b) => b.bytes - a.bytes || a.path.localeCompare(b.path));
+}
+
+const directory = path.resolve(process.argv[2] || '.output/chrome-mv3');
+const files = await measure(directory);
+const total = files.reduce((sum, file) => sum + file.bytes, 0);
+const groups = new Map();
+for (const file of files) {
+  if (!groups.has(file.hash)) groups.set(file.hash, []);
+  groups.get(file.hash).push(file);
+}
+const duplicates = [...groups.values()].filter(group => group.length > 1).map(group => ({
+  paths: group.map(file => file.path), bytesEach: group[0].bytes,
+  duplicateBytes: group[0].bytes * (group.length - 1),
+}));
+const result = {directory, files: files.length, totalBytes: total,
+  largestFiles: files.slice(0, 15).map(({path, bytes}) => ({path, bytes})), duplicates};
+if (process.argv[3]) {
+  const baseline = await measure(path.resolve(process.argv[3]));
+  const baselineBytes = baseline.reduce((sum, file) => sum + file.bytes, 0);
+  result.comparison = {baselineBytes, savedBytes: baselineBytes - total,
+    savedPercent: Number(((baselineBytes - total) / baselineBytes * 100).toFixed(3))};
+}
+console.log(JSON.stringify(result, null, 2));

--- a/src/app/popup/PopupApp.vue
+++ b/src/app/popup/PopupApp.vue
@@ -63,7 +63,7 @@
           <h2 id="donation-title">如果你喜欢这款软件，</h2>
           <p class="donation-description">可以扫描微信赞赏码支持作者，感谢鼓励。</p>
           <div class="donation-qr-frame">
-            <img src="/misc/approve.jpg" alt="流畅阅读赞赏码" />
+            <img :src="'/misc/approve.jpg'" alt="流畅阅读赞赏码" />
           </div>
         </section>
       </div>

--- a/src/providers/translation/youdao.ts
+++ b/src/providers/translation/youdao.ts
@@ -9,7 +9,7 @@
 import {normalizeChineseLanguageCode} from '@/src/core/language/chinese';
 import { method } from "@/src/core/config/constants";
 import { config } from "@/src/services/config/store";
-import CryptoJS from 'crypto-js';
+import sha256 from 'crypto-js/sha256';
 import {getTranslationLanguages} from '@/src/services/translation/languages';
 import {createHttpStatusError, readJsonResponse} from '@/src/platform/http/errors';
 import {runtimeFetch} from '@/src/platform/http/runtime';
@@ -42,7 +42,7 @@ async function youdao(message: TranslationProviderRequest<string>): Promise<stri
   // 生成签名
   function generateSign(appKey: string, query: string, salt: string, curtime: string, appSecret: string): string {
     let str1 = appKey + truncate(query) + salt + curtime + appSecret;
-    return CryptoJS.SHA256(str1).toString(CryptoJS.enc.Hex);
+    return sha256(str1).toString();
   }
 
   // 截取函数（用于签名计算）

--- a/src/providers/translation/zhipu.ts
+++ b/src/providers/translation/zhipu.ts
@@ -9,7 +9,8 @@
 import {method, urls} from "@/src/core/config/constants";
 import {resolveConfiguredModel, services} from "@/src/core/config/catalog";
 import {commonMsgTemplate} from '@/src/services/translation/templates';
-import CryptoJS from 'crypto-js';
+import hmacSha256 from 'crypto-js/hmac-sha256';
+import base64 from 'crypto-js/enc-base64';
 import {config} from "@/src/services/config/store";
 import {isApiKeyRequired} from "@/src/core/config/validation";
 import {createHttpStatusError, readJsonResponse} from '@/src/platform/http/errors';
@@ -113,7 +114,7 @@ function generateJWT(secret: string, header: any, payload: any) {
     const encodedHeader = base64UrlSafe(btoa(JSON.stringify(header)));
     const encodedPayload = base64UrlSafe(btoa(JSON.stringify(payload)));
     // 生成 jwt 签名
-    let hmacsha256 = base64UrlSafe(CryptoJS.HmacSHA256(encodedHeader + "." + encodedPayload, secret).toString(CryptoJS.enc.Base64))
+    let hmacsha256 = base64UrlSafe(hmacSha256(encodedHeader + "." + encodedPayload, secret).toString(base64))
     return `${encodedHeader}.${encodedPayload}.${hmacsha256}`;
 }
 

--- a/src/services/harness/modelGateway.ts
+++ b/src/services/harness/modelGateway.ts
@@ -10,7 +10,8 @@ import {createOpenAICompatible} from '@ai-sdk/openai-compatible';
 import {createAnthropic} from '@ai-sdk/anthropic';
 import {createGoogleGenerativeAI} from '@ai-sdk/google';
 import type {LanguageModel} from 'ai';
-import CryptoJS from 'crypto-js';
+import hmacSha256 from 'crypto-js/hmac-sha256';
+import base64 from 'crypto-js/enc-base64';
 import type {Config} from '@/src/core/config/model';
 import {currentModelIds, services} from '@/src/core/config/catalog';
 import {tongyiTokenPlanUrl, urls} from '@/src/core/config/constants';
@@ -30,7 +31,7 @@ function zhipuBearer(apiKey: string): string {
   const encode = (value: string) => btoa(value).replace(/\+/gu, '-').replace(/\//gu, '_').replace(/=+$/gu, '');
   const header = encode(JSON.stringify({alg: 'HS256', sign_type: 'SIGN', typ: 'JWT'}));
   const payload = encode(JSON.stringify({api_key: key, exp: Math.floor(Date.now() / 1000) + 86_400, timestamp: Math.floor(Date.now() / 1000)}));
-  const signature = CryptoJS.HmacSHA256(`${header}.${payload}`, secret).toString(CryptoJS.enc.Base64)
+  const signature = hmacSha256(`${header}.${payload}`, secret).toString(base64)
     .replace(/\+/gu, '-').replace(/\//gu, '_').replace(/=+$/gu, '');
   return `${header}.${payload}.${signature}`;
 }

--- a/src/services/translation/cache.ts
+++ b/src/services/translation/cache.ts
@@ -6,7 +6,7 @@
  * 模块边界：本文件位于翻译 application service 层，负责用例编排和端口契约；不挂载页面 UI，且不应把某家供应商的网络细节扩散到 feature，具体 HTTP 协议由 providers/platform 实现。
  */
 
-import CryptoJS from 'crypto-js';
+import sha256 from 'crypto-js/sha256';
 import Dexie, { type Table } from 'dexie';
 import {
   DEFAULT_TRANSLATION_CACHE_MAX_BYTES,
@@ -73,7 +73,7 @@ export function buildTranslationCacheKey(identity: TranslationCacheIdentity): st
     version: TRANSLATION_CACHE_VERSION,
     ...identity,
   });
-  const digest = CryptoJS.SHA256(payload).toString(CryptoJS.enc.Hex);
+  const digest = sha256(payload).toString();
   return `v${TRANSLATION_CACHE_VERSION}:${digest}`;
 }
 

--- a/src/ui/view-model/serviceCatalog.ts
+++ b/src/ui/view-model/serviceCatalog.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/ui/view-model/serviceCatalog.ts
  * 文件职责：为服务与模型选择界面提供无框架的视图模型转换，把扁平配置选项整理成可搜索、可分层和可稳定展示的数据。
- * 主要内容：定义服务目录分组与官方网站入口，安全派生自定义服务站点，按服务或模型关键词筛选，解析当前模型标签，并把常用、选中和自定义模型稳定拆分。
+ * 主要内容：定义服务目录分组与官方网站入口，安全派生自定义服务站点，按服务与模型关键词搜索、筛选分层目录，并解析当前模型标签。
  * 模块边界：这些函数不读取 Vue 状态、不修改 Config，也不判断平台能力或发起连接测试；原始目录由 core/config 提供，Popup/Options 等调用方负责交互与渲染。
  */
 import { customModelString, resolveConfiguredModel, services, servicesType } from '@/src/core/config/catalog'
@@ -168,20 +168,6 @@ export function buildServiceSections(options: ServiceOption[]): ServiceSection[]
   })
 }
 
-export function filterServiceGroups(groups: ServiceGroup[], query: string) {
-  const keyword = query.trim().toLocaleLowerCase()
-  if (!keyword) return groups
-
-  return groups
-    .map((group) => ({
-      ...group,
-      items: group.items.filter((item) =>
-        `${item.label}${item.value}${item.description || ''}${item.searchTerms?.join('') || ''}`.toLocaleLowerCase().includes(keyword),
-      ),
-    }))
-    .filter((group) => group.items.length > 0)
-}
-
 export function filterServiceSections(sections: ServiceSection[], query: string) {
   const keyword = query.trim().toLocaleLowerCase()
   if (!keyword) return sections
@@ -199,12 +185,6 @@ export function filterServiceSections(sections: ServiceSection[], query: string)
         .filter((group) => group.items.length > 0),
     }))
     .filter((section) => section.groups.length > 0)
-}
-
-export function filterModels(modelOptions: string[], query: string) {
-  const keyword = query.trim().toLocaleLowerCase()
-  if (!keyword) return modelOptions
-  return modelOptions.filter((model) => model.toLocaleLowerCase().includes(keyword))
 }
 
 function searchTextMatches(value: string, rawKeyword: string, compactKeyword: string) {
@@ -256,27 +236,4 @@ export function getSelectedModelLabel(
   const selectedModel = selectedModels[service]
   const configuredModel = resolveConfiguredModel(selectedModel, activeCustomModels[service])
   return configuredModel || (selectedModel === customModelString ? customModelString : '未选择模型')
-}
-
-export function splitModelOptions(modelOptions: string[], selectedModel = '', visibleCount = 4) {
-  // 自定义模型是一个输入入口，不应因为当前选中而被提到常用模型区。
-  // 即使调用方传入的列表顺序不稳定，也要保证它在完整列表的最后。
-  const regularModels = modelOptions.filter((model) => model !== customModelString)
-  const customModels = modelOptions.filter((model) => model === customModelString)
-  const orderedModels = [...regularModels, ...customModels]
-  const common = orderedModels.slice(0, visibleCount)
-
-  if (
-    selectedModel
-    && selectedModel !== customModelString
-    && orderedModels.includes(selectedModel)
-    && !common.includes(selectedModel)
-  ) {
-    common.splice(Math.max(visibleCount - 1, 0), 1, selectedModel)
-  }
-
-  return {
-    common,
-    more: orderedModels.filter((model) => !common.includes(model)),
-  }
 }

--- a/tests/serviceCatalog.test.ts
+++ b/tests/serviceCatalog.test.ts
@@ -3,13 +3,10 @@ import {
   buildServiceGroups,
   buildServiceSections,
   cleanServiceLabel,
-  filterModels,
-  filterServiceGroups,
   filterServiceSections,
   getSelectedModelLabel,
   getServiceWebsite,
   searchServiceOptions,
-  splitModelOptions,
 } from '@/src/ui/view-model/serviceCatalog'
 import { customModelString, defaultModels, models, services, servicesType } from '@/src/core/config/catalog'
 import { Config, normalizeConfig } from '@/src/core/config/model'
@@ -169,29 +166,6 @@ describe('service catalog helpers', () => {
     ])
   })
 
-  it('filters services without losing their category', () => {
-    const groups = buildServiceGroups(options)
-    expect(filterServiceGroups(groups, '   ')).toBe(groups)
-    expect(filterServiceGroups(groups, 'open')).toEqual([
-      { id: 'ai', label: 'AI翻译', items: [{ value: 'openai', label: 'OpenAI', catalogKind: 'provider' }] },
-    ])
-    expect(filterServiceGroups([
-      { id: 'ai', label: 'AI翻译', items: [{ value: 'openai', label: 'OpenAI', description: '通用服务' }] },
-    ], '通用')).toHaveLength(1)
-    expect(filterServiceGroups([
-      {
-        id: 'custom',
-        label: '我的服务',
-        items: [{
-          value: 'custom:1',
-          label: '本地模型',
-          description: 'http://localhost:11434/v1',
-          searchTerms: ['gemma:7b', 'qwen-local'],
-        }],
-      },
-    ], 'qwen-local')).toHaveLength(1)
-  })
-
   it('filters nested service sections without losing their parent or subgroup', () => {
     const sections = buildServiceSections(options)
     expect(filterServiceSections(sections, '   ')).toBe(sections)
@@ -207,15 +181,6 @@ describe('service catalog helpers', () => {
           items: [{ value: 'newapi', label: 'New API', catalogKind: 'platform' }],
         }],
       },
-    ])
-  })
-
-  it('filters model identifiers case-insensitively', () => {
-    const modelOptions = ['gpt-5-mini', 'GPT-4o', '自定义模型']
-    expect(filterModels(modelOptions, ' ')).toBe(modelOptions)
-    expect(filterModels(modelOptions, 'gpt')).toEqual([
-      'gpt-5-mini',
-      'GPT-4o',
     ])
   })
 
@@ -283,29 +248,6 @@ describe('service catalog helpers', () => {
 
   it('removes decorative recommendation stars from labels', () => {
     expect(cleanServiceLabel('硅基流动⭐️')).toBe('硅基流动')
-  })
-
-  it('keeps common models short and promotes the current selection', () => {
-    const models = ['one', 'two', 'three', 'four', 'five', 'six']
-
-    expect(splitModelOptions(models, 'six')).toEqual({
-      common: ['one', 'two', 'three', 'six'],
-      more: ['four', 'five'],
-    })
-  })
-
-  it('keeps the custom model as the last option when it is selected', () => {
-    expect(splitModelOptions(['one', 'two', 'three', customModelString, 'four'], customModelString)).toEqual({
-      common: ['one', 'two', 'three', 'four'],
-      more: [customModelString],
-    })
-  })
-
-  it('does not create a more group for a short model list', () => {
-    expect(splitModelOptions(['one', 'two'], 'two')).toEqual({
-      common: ['one', 'two'],
-      more: [],
-    })
   })
 
   it('shows the effective model only for services that use model selection', () => {


### PR DESCRIPTION
## 改动

扩展重复打包了赞赏图片，四处 SHA-256/HMAC 调用还导入了整个 crypto-js。改为使用 public 原图和按算法导入，保持图片内容、签名和缓存键不变；移除没有生产调用的 filterServiceGroups、filterModels、splitModelOptions 及其专属测试，保留当前目录搜索实现。

新增 `pnpm analyze:bundle [构建目录] [基线目录]`，报告实际字节数、最大文件和重复资源。保留 AI/OCR/PDF 所需资源，不移除现有功能。

同一基线实测：解压体积减少 160,269 字节（0.30%），ZIP 从 16,944,603 降至 16,831,576 字节（减少 113,027 字节，0.67%）。旧函数已被 tree-shaking 排除，删除收益主要是维护成本。

## 验证

- TypeScript/Vue 编译、测试审计、git diff --check 通过。
- 针对性测试 101 项通过；覆盖率套件 4,083 项通过，覆盖范围内四维均为 100%；架构检查 850 项通过。
- Chrome ZIP、Firefox、userscript 构建及扩展 manifest / userscript verifier 通过。
- 生产扩展在临时后台 Edge 中完成首次语言引导后打开赞赏页，原图加载为 1152×1152，页面无未处理错误，窗口未抢占前台。
- 完整 UI 套件未通过：旧 runner 等待“让阅读自然地流动”，当前标题已为“网页翻译”。此处不宣称完整 UI 回归通过。
