### PR TITLE
fix(popup): 缩小翻译服务图标并完整显示服务名称

### DIFF
--- a/src/app/popup/PopupApp.vue
+++ b/src/app/popup/PopupApp.vue
@@ -108,7 +108,7 @@
           :data-selected-model="serviceModelLabel || undefined"
           @click="toggleServicePicker"
         >
-          <ServiceIcon :service="config.service" :label="serviceLabel" />
+          <ServiceIcon :service="config.service" :label="serviceLabel" size="small" />
           <span class="service-copy">
             <small>翻译服务</small>
             <span class="service-value">

--- a/src/app/popup/popup.css
+++ b/src/app/popup/popup.css
@@ -146,6 +146,7 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .service-value { display: flex; min-width: 0; align-items: baseline; gap: 6px; }
 .service-copy strong, .service-model { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .service-copy strong { max-width: 45%; flex: 0 0 auto; font-size: 12px; }
+.service-copy strong:only-child { max-width: 100%; }
 .service-model { flex: 1 1 0; color: var(--muted); font-size: 9px; font-style: normal; font-weight: 600; }
 .chevron { position: absolute; right: 14px; color: var(--muted); font-size: 18px; line-height: 1; transform: translateY(-2px); transition: transform 160ms ease; }
 .chevron.open { transform: translateY(1px) rotate(180deg); }


### PR DESCRIPTION
菜单栏的翻译服务图标占用较多空间，且无模型名称时服务名仍被限制为文字区域的 45%，导致“免费翻译”显示省略号。

将该图标从 40px 调整为 25px，并允许无模型名称的服务名使用完整文字区域；带模型名称的布局保留原有宽度分配。

验证：`pnpm compile`、`pnpm build`、`git diff --check` 通过。生产扩展完整 UI 套件已尝试，但等待 popup 标题时超时，未完成真实浏览器显示验证。
