### PR TITLE
fix: 修复持续翻译时悬浮提示框反复闪烁

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -230,3 +230,7 @@ node scripts/testing/run-area-translation-flow-test.cjs \
 使用临时 Edge profile、防抢焦点 helper、真实截图和 Tesseract，验证可信按键、可编辑输入保护、原/译文核对、整块请求、Esc取消、同截图重试、图像不上传、AI结构错误与重试、关闭后迟到响应、禁用卸载及页面CSS隔离。清晰/小字/暗底英文样本记录字符错误率和语言准备/首次/重试耗时；Google/OpenAI翻译传输是确定性夹具，不能代表外部服务质量或可用性。
 
 标签切换用例通过 `connectOverCDP({noDefaults: true})` 禁用 Playwright 默认焦点模拟，验证浏览器真实的 `visible → hidden` 及在途取消。窄屏用例先稳定布局和页面焦点，再圈选；深色卡片同时断言外围透明，配置变更断言主题和静态进度立即更新。
+
+### 悬浮说明框翻译稳定性
+
+`run-full-page-translation-test.cjs` 在全文翻译会话中动态创建与旧 Bootstrap 相同结构的 tooltip，按原文高度定位，使双语内容增高后覆盖触发图标。真实 CDP 鼠标连续执行两次移入、持续停留和移出，断言每次只打开一次、译文仅一份、图标仍获得鼠标命中，移出后正常关闭。报告的 `tooltipHover` 同时记录语义 tooltip、未翻译提示、交互弹层和恢复原文后的命中边界。该保护只作用于已翻译的纯说明提示框，保留链接、按钮和可聚焦控件的交互。此测试为本地结构夹具，不代表登录后的真实网站验证。

--- a/scripts/run-full-page-translation-test.cjs
+++ b/scripts/run-full-page-translation-test.cjs
@@ -1865,6 +1865,98 @@ async function runFailureActionScenario({
   };
 }
 
+// 模拟页面按原文高度定位的 Bootstrap tooltip；双语增高后会覆盖触发图标。
+async function verifyTranslatedTooltipHover(page, timeout, artifactsDir) {
+  await page.mouse.move(0, 0);
+  await page.evaluate(() => {
+    const trigger = document.createElement('i');
+    trigger.id = 'tooltip-hover-trigger';
+    trigger.setAttribute('aria-label', 'Information');
+    trigger.style.cssText = 'position:fixed;left:600px;top:350px;width:24px;height:24px;z-index:2147483000;background:#ddd';
+    document.body.appendChild(trigger);
+    window.tooltipHoverCounts = {opens: 0, closes: 0};
+    trigger.addEventListener('mouseenter', () => {
+      window.tooltipHoverCounts.opens++;
+      const tooltip = document.createElement('div');
+      tooltip.id = 'translated-hover-tooltip';
+      tooltip.className = 'tooltip fade top';
+      tooltip.style.cssText = 'position:fixed;left:520px;width:220px;z-index:2147483001;background:white;color:black;padding:8px';
+      tooltip.innerHTML = '<div class="tooltip-arrow"></div><div class="tooltip-inner">Set the lowest amount you are happy to receive. You can use suggested amounts to encourage supporters towards your preferred amounts.</div>';
+      document.body.appendChild(tooltip);
+      tooltip.style.top = `${350 - tooltip.getBoundingClientRect().height - 8}px`;
+    });
+    trigger.addEventListener('mouseleave', () => {
+      window.tooltipHoverCounts.closes++;
+      document.querySelector('#translated-hover-tooltip')?.remove();
+    });
+  });
+  const cycles = [];
+  try {
+    for (let cycle = 0; cycle < 2; cycle++) {
+      await page.mouse.move(612, 362);
+      await page.waitForFunction(() => document.querySelector('#translated-hover-tooltip .fluent-read-bilingual-content'), undefined, {timeout});
+      await page.waitForTimeout(1200);
+      const state = await page.evaluate(() => {
+        const tooltip = document.querySelector('#translated-hover-tooltip');
+        const rect = tooltip?.getBoundingClientRect();
+        return {...window.tooltipHoverCounts,
+          wrappers: tooltip?.querySelectorAll('.fluent-read-bilingual-content').length || 0,
+          coversTrigger: Boolean(rect && rect.top < 362 && rect.bottom > 362),
+          hit: document.elementFromPoint(612, 362)?.id,
+        };
+      });
+      if (state.opens !== cycle + 1 || state.closes !== cycle || state.wrappers !== 1 ||
+          !state.coversTrigger || state.hit !== 'tooltip-hover-trigger') {
+        throw new Error(`翻译后 tooltip 抢占鼠标并闪烁：${JSON.stringify(state)}`);
+      }
+      cycles.push(state);
+      if (artifactsDir && cycle === 0) await page.screenshot({path: path.join(artifactsDir, 'tooltip-hover.png')});
+      await page.mouse.move(0, 0);
+      await page.waitForFunction(() => !document.querySelector('#translated-hover-tooltip'));
+    }
+    const boundaries = await page.evaluate(() => {
+      const results = [];
+      for (const [name, attributes, body, expected] of [
+        ['aria tooltip', 'role="tooltip"', '', 'none'],
+        ['untranslated', 'class="tooltip"', '', 'auto'],
+        ['link', 'role="tooltip"', '<a href="#">Help</a>', 'auto'],
+        ['button', 'role="tooltip"', '<button>Help</button>', 'auto'],
+        ['focusable', 'role="tooltip" tabindex="0"', '', 'auto'],
+        ['dialog', 'role="dialog"', '', 'auto'],
+        ['ordinary content', '', '', 'auto'],
+      ]) {
+        const root = document.createElement('div');
+        root.innerHTML = `<div ${attributes}><div class="tooltip-inner">Source${body}</div></div>`;
+        document.body.appendChild(root);
+        const tip = root.firstElementChild;
+        const wrapper = document.createElement('span');
+        wrapper.className = 'fluent-read-bilingual-content';
+        wrapper.setAttribute('data-fr-translation-owned', 'true');
+        if (name !== 'untranslated') tip.firstElementChild.appendChild(wrapper);
+        const actual = getComputedStyle(tip).pointerEvents;
+        wrapper.remove();
+        const restored = getComputedStyle(tip).pointerEvents;
+        root.remove();
+        results.push({name, expected, actual, restored});
+      }
+      return results;
+    });
+    if (boundaries.some(item => item.actual !== item.expected || item.restored !== 'auto')) {
+      throw new Error(`tooltip 交互边界失败：${JSON.stringify(boundaries)}`);
+    }
+    return {cycles, boundaries};
+  } catch (error) {
+    const counts = await page.evaluate(() => window.tooltipHoverCounts);
+    throw new Error(`${error.message}; tooltip lifecycle=${JSON.stringify(counts)}`);
+  } finally {
+    await page.mouse.move(0, 0);
+    await page.evaluate(() => {
+      document.querySelector('#tooltip-hover-trigger')?.remove();
+      document.querySelector('#translated-hover-tooltip')?.remove();
+    });
+  }
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const extensionDir = path.resolve(args.extensionDir);
@@ -2393,6 +2485,7 @@ async function main() {
         )),
       };
     }
+    const tooltipHover = await verifyTranslatedTooltipHover(page, Math.min(args.timeout, 15000), artifactsDir);
     if (artifactsDir) await page.screenshot({
       path: path.join(artifactsDir, 'full-page-translated.png'),
       fullPage: !args.verifyFloatingUi,
@@ -2574,6 +2667,7 @@ async function main() {
       passiveHoverRemount,
       cancelledHoverGesture,
       unchangedAttributeStability,
+      tooltipHover,
       failureActions,
       floatingUi: floatingUiEvidence,
       loadingStyleIsolation: loadingStyleIsolationEvidence,

--- a/src/app/content/page.css
+++ b/src/app/content/page.css
@@ -1,6 +1,6 @@
 /**
  * @file src/app/content/page.css
- * 文件职责：定义内容脚本直接注入宿主文档的 FluentRead 专属视觉状态，覆盖翻译占位、重试、图片覆盖层、输入框反馈和多种双语译文样式。
+ * 文件职责：定义内容脚本直接注入宿主文档的 FluentRead 专属视觉状态，覆盖翻译占位、重试、图片覆盖层、输入框反馈、已翻译提示框的鼠标命中保护和多种双语译文样式。
  * 主要内容：包含错误原因与重试控件、图片翻译按钮和 canvas、输入框 translating/success/error tooltip，以及 dimmed、下划线、卡片、标记、纸张、技术风等显示类；段落 loading 已由自带 Shadow Root 的组件隔离。
  * 模块边界：选择器均以 fluent 前缀或受控状态类约束，不承担 Shadow UI 组件主题，也不决定何时添加类名；DOM 状态由各 content feature 管理，共享 token 由 src/ui/styles 提供。
  */
@@ -310,6 +310,15 @@
     background: transparent; /* 确保背景透明，与周围背景融合 */
     box-sizing: border-box; /* 使用 border-box 模型，确保内外边距和边框计算正确 */
     overflow-wrap: break-word; /* 处理长单词或 URL 的断行，避免溢出 */
+}
+
+/* 纯说明 tooltip 按原文高度定位后，译文增高可能盖住触发图标，导致
+ * mouseleave -> 关闭 -> mouseenter -> 重建的循环。仅让已翻译且没有交互
+ * 控件的语义 tooltip（含旧 Bootstrap 结构）穿透鼠标；恢复原文后自动失效。
+ * 不改宿主属性或监听器，也不影响带链接、表单、可聚焦控件的弹层。 */
+:is([role="tooltip"], .tooltip:has(> .tooltip-inner)):has(:is(.fluent-read-bilingual-content, .fluent-read-single-slot)[data-fr-translation-owned="true"]):not([tabindex], [contenteditable]:not([contenteditable="false"])):not(:has(a[href], button, input, select, textarea, summary, [tabindex], [contenteditable]:not([contenteditable="false"]), [role="button"], [role="link"], [role="dialog"])),
+:is([role="tooltip"], .tooltip:has(> .tooltip-inner)):has(:is(.fluent-read-bilingual-content, .fluent-read-single-slot)[data-fr-translation-owned="true"]):not([tabindex], [contenteditable]:not([contenteditable="false"])):not(:has(a[href], button, input, select, textarea, summary, [tabindex], [contenteditable]:not([contenteditable="false"]), [role="button"], [role="link"], [role="dialog"])) * {
+    pointer-events: none !important;
 }
 
 /* 双语逐句高亮：只绘制不会改变几何尺寸的单层强调，避免动态页面在 hover 时发生布局抖动。 */


### PR DESCRIPTION
## 问题与修复
开启持续全文翻译后，动态 tooltip 插入双语译文会增高并覆盖触发图标，造成 mouseleave 关闭、mouseenter 重建的循环。仅对已翻译且不含交互控件的语义 tooltip 与旧 Bootstrap tooltip 启用鼠标穿透，保持图标命中稳定；恢复原文后自动失效，保留链接、按钮及可聚焦弹层的交互。

## 验证
- 临时后台 Edge、生产扩展、本地确定性翻译夹具：修复前 15 秒打开 183 次、关闭 182 次；修复后两次悬停各只打开一次，译文仅一份，移出正常关闭。
- 完整全文翻译浏览器回归通过，包括翻译、恢复、再次翻译及 tooltip 交互边界；未操作用户日常浏览器或登录页面。本地同类结构夹具不代表登录后真实站点验证。
- 79 项翻译相关测试、853 项架构组测试、test:audit、TypeScript 检查通过。
- Chrome、Firefox、userscript 构建及 userscript verifier、文档构建通过；git diff --check 通过。
