### PR TITLE
fix: 统一支持项目入口到 GitHub README

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitepress'
 import { localeBootstrap } from './theme/locale-preference.mjs'
 
+const supportUrl = 'https://github.com/FluentRead/FluentRead#support'
+
 const guide = (en = false) => {
   const p = en ? '/en' : ''
   const item = (zh: string, english: string, path: string) => ({
@@ -57,7 +59,7 @@ const guide = (en = false) => {
       items: [
         item('常见问题', 'Troubleshooting', '/guide/faq'),
         item('数据与隐私', 'Data & privacy', '/guide/privacy'),
-        item('支持项目', 'Support the project', '/guide/support'),
+        { text: en ? 'Support the project' : '支持项目', link: supportUrl },
       ],
     },
   ]
@@ -84,7 +86,7 @@ const theme = (en = false) => ({
     },
     {
       text: en ? 'Support' : '支持项目',
-      link: en ? '/en/guide/support' : '/guide/support',
+      link: supportUrl,
     },
   ],
   sidebar: en

--- a/src/app/options/OptionsApp.vue
+++ b/src/app/options/OptionsApp.vue
@@ -83,7 +83,7 @@
                 <a href="https://github.com/Bistutu/FluentRead" target="_blank" rel="noreferrer">{{ t('options.aboutProject') }} <span>↗</span></a>
                 <a href="https://fluent.thinkstu.com/" target="_blank" rel="noreferrer">{{ t('options.aboutDocs') }} <span>↗</span></a>
                 <a href="https://github.com/Bistutu/FluentRead/issues" target="_blank" rel="noreferrer">{{ t('options.aboutFeedback') }} <span>↗</span></a>
-                <a :href="language === 'zh-CN' ? 'https://fluent.thinkstu.com/guide/support' : 'https://fluent.thinkstu.com/en/guide/support'" target="_blank" rel="noopener noreferrer">{{ t('popup.donationTitle') }} <span>↗</span></a>
+                <a href="https://github.com/FluentRead/FluentRead#support" target="_blank" rel="noopener noreferrer">{{ t('popup.donationTitle') }} <span>↗</span></a>
               </div>
             </article>
           </div>
@@ -120,7 +120,7 @@ import {
 import {applyInterfaceSkin} from '@/src/ui/interfaceAppearance'
 
 const version = process.env.VUE_APP_VERSION
-const {language, t, translateLegacy} = useUiI18n()
+const {t, translateLegacy} = useUiI18n()
 const query = ref('')
 const interfaceSkin = ref(getInterfaceSkinOption(runtimeConfig.interfaceSkin))
 const activeSection = ref('settings-general')


### PR DESCRIPTION
官网中英文导航、文档侧栏及扩展设置页的“支持项目”入口原先指向 `/guide/support` 或 `/en/guide/support`。现在统一直接打开 https://github.com/FluentRead/FluentRead#support，不再按界面语言拼接官网支持页地址，并移除设置页因此不再使用的 `language` 解构。

验证：

- `pnpm test:audit`、`pnpm compile` 通过。
- 设置页导航生命周期与 UI 架构相关测试共 31 项通过。
- `pnpm docs:build`、`pnpm build`、`pnpm build:firefox` 通过。
- 检查 48 个构建 HTML 页面中的 91 个“支持项目”入口，全部指向指定 GitHub 地址。
- Chrome 与 Firefox 构建产物包含新的 GitHub 支持地址，不再包含旧的官网支持页 URL。

本次仅修改支持入口，既有支持文档及其语言切换保持原样；未进行线上部署或真实浏览器点击验证。
