### PR TITLE
Refactor proxy URL handling in gemini.ts

### DIFF
--- a/src/providers/translation/gemini.ts
+++ b/src/providers/translation/gemini.ts
@@ -28,8 +28,12 @@ async function gemini(message: TranslationProviderRequest<string>) {
 
     const model = message.modelOverride
         || (current.model[service] === customModelString ? current.customModel[service] : current.model[service]);
-    const proxyUrl = current.proxy[service]?.trim();
-    const usesOfficialEndpoint = !proxyUrl;
+    const rawProxyUrl = current.proxy[service]?.trim() || "";
+    const proxyUrl = rawProxyUrl
+        .replace("{model}", encodeURIComponent(model))
+        .replace("{key}", encodeURIComponent(current.token[service] || ""));
+
+    const usesOfficialEndpoint = !rawProxyUrl;
     const url = proxyUrl
         || `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent`;
 


### PR DESCRIPTION
使用 沉浸式阅读 中的 代理地址 格式 https://myproxy.com/v1beta/models/{model}:generateContent?key={key}
对其中的 {model} 和 {key} 进行替换， 以实现 代理地址 的 自动拼接

Fix #494 