### PR TITLE
fix(translation): 放行 Weglot 在文档根表面注入的 translate=no 外壳 (#498)

### DIFF
--- a/src/core/translation/dom.ts
+++ b/src/core/translation/dom.ts
@@ -2,7 +2,7 @@
  * @file src/core/translation/dom.ts
  *
  * 文件职责：封装翻译候选发现使用的 composed tree 遍历与不可覆盖安全守卫，识别扩展 DOM、其他翻译器已接管的段落、脚本、表单、图标字体、代码及禁止翻译区域。
- * 主要内容：提供抗表单命名属性遮蔽的标签读取、Shadow DOM 父级与祖先遍历、硬裁剪标签、受保护文本元素、text/plain 顶层 pre、独立 tooltip 边界、隐藏/可编辑/no-translate 判断，并限制祖先深度以避免异常页面结构拖垮扫描。 可核对的公开符号包括 maxComposedAncestorDepth、getComposedParent、isDocumentSurface、isExtensionElement、isExtensionElementSelf、isHardPruneTag、isProtectedTextElement、isPlainTextDocumentPre、hasNoTranslateMarker、isTopLevelApplicationShell。
+ * 主要内容：提供抗表单命名属性遮蔽的标签读取、Shadow DOM 父级与祖先遍历、硬裁剪标签、受保护文本元素、text/plain 顶层 pre、独立 tooltip 边界、隐藏/可编辑/no-translate 判断，并限制祖先深度以避免异常页面结构拖垮扫描。 可核对的公开符号包括 maxComposedAncestorDepth、getComposedParent、isDocumentSurface、isExtensionElement、isExtensionElementSelf、isHardPruneTag、isProtectedTextElement、isPlainTextDocumentPre、hasNoTranslateMarker、isDocumentSurfaceNoTranslateShell、isTopLevelApplicationShell。
  * 模块边界：本文件属于可独立测试的 core 候选领域；可以读取传入 DOM 以计算结果，但不访问配置存储、不调用 provider、不注册页面监听器，也不负责译文渲染或 feature 生命周期。
  */
 
@@ -112,6 +112,18 @@ export function hasNoTranslateMarker(element: Element): boolean {
 }
 
 /**
+ * 文档根表面（<html>/<body>）上的 no-translate 标记通常是 Weglot 等多语言框架
+ * 为阻止浏览器自带翻译而设置的全局防护（典型如 <html translate="no">），并非页面
+ * 作者针对具体正文的保护意图。用户显式发起翻译时，这类根级标记若参与祖先链裁剪，
+ * 会导致整页任何文本节点上溯到根节点即被判 inherited-no-translate，从而整页失效。
+ * 因此把"文档根表面自身携带 no-translate 标记"识别为可放行的框架级外壳；真正的
+ * 局部保护（嵌套的 .notranslate / translate="no" 容器）不在此列，仍照常裁剪。
+ */
+export function isDocumentSurfaceNoTranslateShell(element: Element): boolean {
+    return isDocumentSurface(element) && hasNoTranslateMarker(element);
+}
+
+/**
  * 显式翻译可有限穿过应用级 no-translate 外壳，但不能把这个例外扩大到局部区域。
  * 直接挂在 body 下是刻意保守的边界：嵌套 no-translate 容器仍代表页面作者明确保护的内容。
  */
@@ -204,6 +216,7 @@ export function isProtectedDescendantElement(
         isProtectedTextElement(element) ||
         isMathRendererElement(element) ||
         (hasNoTranslateMarker(element) && !ownNoTranslateMarker &&
+            !isDocumentSurfaceNoTranslateShell(element) &&
             !(options?.allowTopLevelApplicationShell === true &&
                 element !== options.protectedElement &&
                 isTopLevelApplicationShell(element))) ||
@@ -221,7 +234,9 @@ export function evaluateElementHardGuard(element: Element): HardGuardResult {
     if (isForeignTranslationBoundary(element)) return {prune: true, reason: 'foreign-translation'};
     if (isHardPruneTag(element)) return {prune: true, reason: `protected-tag:${getElementTagName(element)}`};
     if (isMathRendererElement(element)) return {prune: true, reason: 'math-renderer'};
-    if (hasNoTranslateMarker(element)) return {prune: true, reason: 'inherited-no-translate'};
+    if (hasNoTranslateMarker(element) && !isDocumentSurfaceNoTranslateShell(element)) {
+        return {prune: true, reason: 'inherited-no-translate'};
+    }
     if (hasContentEditableMarker(element)) return {prune: true, reason: 'contenteditable'};
     const presentationProtection = getPresentationProtection(element);
     if (presentationProtection) return {prune: true, reason: presentationProtection};

--- a/tests/translationCore.test.ts
+++ b/tests/translationCore.test.ts
@@ -26,6 +26,7 @@ import {
 import {
     evaluateHardGuard,
     getElementTagName,
+    isDocumentSurfaceNoTranslateShell,
     isTextInNestedTranslationTooltip,
     findElementsAtPoint,
     findNodeAtPoint,
@@ -663,6 +664,42 @@ describe('translation candidate core', () => {
         `).document);
 
         expect(ids).toEqual(['allowed']);
+    });
+
+    it('issue #498：Weglot 在 <html> 根节点设置 translate=no 时全文翻译仍可发现正文', () => {
+        // mapbox.com（Webflow + Weglot）会在文档根节点注入 <html translate="no">，
+        // 这是框架级防护而非局部保护；根表面的该标记不应把整页判成 inherited-no-translate。
+        const {document} = parseHTML(`
+            <html translate="no"><body><main>
+                <h2 id="title">About Tripadvisor</h2>
+                <p id="body-copy">As the world's largest travel guidance platform.</p>
+                <section translate="no"><p id="local-protected">Do not translate this local section.</p></section>
+            </main></body></html>
+        `);
+        const ids = candidateIds(document);
+
+        // 根节点标记被放行：正文可翻译；但真正的局部 translate=no 容器仍被保护。
+        expect(ids).toEqual(expect.arrayContaining(['title', 'body-copy']));
+        expect(ids).not.toContain('local-protected');
+    });
+
+    it('issue #498：仅文档根表面（<html>/<body>）的 no-translate 标记被识别为框架级外壳', () => {
+        const {document} = parseHTML(`
+            <html translate="no"><body class="notranslate">
+                <main><section translate="no"><p id="p">x</p></section></main>
+            </body></html>
+        `);
+        const root = document.documentElement;
+        const body = document.body;
+        const section = document.querySelector('section')!;
+
+        expect(isDocumentSurfaceNoTranslateShell(root)).toBe(true);
+        expect(isDocumentSurfaceNoTranslateShell(body)).toBe(true);
+        expect(isDocumentSurfaceNoTranslateShell(section)).toBe(false);
+
+        // 根表面不再触发整树裁剪，但嵌套的 translate=no 容器仍返回 inherited-no-translate。
+        expect(evaluateHardGuard(root).prune).toBe(false);
+        expect(evaluateHardGuard(section)).toMatchObject({prune: true, reason: 'inherited-no-translate'});
     });
 
     it('keeps full-page discovery strict while allowing explicit translation through a body-level app shell', () => {


### PR DESCRIPTION
## 问题

Weglot 等多语言框架会在文档根节点注入 `<html translate="no">`（典型如 mapbox.com，技术栈为 Webflow + Weglot），用于阻止浏览器自带翻译。

FluentRead 的祖先链安全守卫在遍历时，会把任意文本节点上溯到根节点 `<html>`，命中该根级 `translate="no"` 后整体判定为 `inherited-no-translate`，导致用户**显式发起**的全文翻译整页失效——页面上没有任何文本被识别为翻译候选。

Closes #498

## 根因

根表面（`<html>` / `<body>`）上的 `translate="no"` 通常是框架级的全局防护，并非页面作者针对具体正文的保护意图。但现有守卫未区分这两种情况：

- `evaluateElementHardGuard`（候选发现的硬守卫）
- `isProtectedDescendantElement`（文本节点保护路径）

两处都会因为祖先链最终上溯到带标记的根节点而裁剪掉全部正文。

## 改动

新增 `isDocumentSurfaceNoTranslateShell`，将「文档根表面自身携带 no-translate 标记」识别为可放行的框架级外壳，并在上述两条守卫路径中一致应用该豁免。

关键点：**真正的局部保护仍照常裁剪**。嵌套的 `.notranslate` / `translate="no"` 容器代表页面作者明确的保护意图，不在放行范围内——豁免仅限根表面自身。

## 测试

新增两条针对 issue #498 的回归测试（`tests/translationCore.test.ts`）：

1. `<html translate="no">` 下全文翻译仍能发现正文候选（`title` / `body-copy`），同时嵌套的 `translate="no"` 局部容器（`local-protected`）仍被保护。
2. 仅文档根表面（`<html>` / `<body>`）的 no-translate 标记被识别为框架级外壳；嵌套 `<section translate="no">` 仍返回 `inherited-no-translate`。

完整测试套件通过（`vitest run`：5312 passed）。已在本地 Chrome 构建中于 `https://www.mapbox.com/showcase/tripadvisor` 验证全文翻译恢复正常。
