### PR TITLE
style(settings): 用分组边框区分设置页层级

### DIFF
--- a/docs/reports/settings-group-frames-20260908/README.md
+++ b/docs/reports/settings-group-frames-20260908/README.md
@@ -1,0 +1,12 @@
+# 设置页分组边框
+
+设置分组的标题、说明和选项现在位于同一个圆角框内。浅底标题栏与组内细分隔线区分阅读层级，组间留白为 24px，窄屏为 18px。无标题的分组保留完整圆角。颜色沿用主题变量，增强外框边界，不改变配置、导航或保存行为，也未借鉴参考仓库。
+
+## 验证
+
+- 类型检查、测试归类审计、设置 UI 架构测试 28 项通过。
+- Chrome MV3 与 Firefox MV2 生产构建通过；Firefox 未运行真实 UI 测试。
+- Chrome MV3 产物在临时 Edge profile 中验证通用设置、翻译设置、高级选项；覆盖 1440px / 390px 和浅色 / 深色，共 12 个截图场景。断言分组边框为 1px、没有横向溢出，无页面异常。
+- 启动模式 `macos-background-cdp`，焦点策略 `launchservices-no-foreground`，窗口位于第二屏，`browserFrontmost=false`。测试结束关闭本次实例并删除临时 profile。
+- 完整 `--suite full` 已尝试，在旧 Popup 标题 `让阅读自然地流动|翻译功能已暂停` 定位处超时，未进入设置检查，不算完整回归通过。
+- 本机专项证据：`/private/tmp/settings-frames-visual/`；完整套件证据：`/private/tmp/settings-frames-full/`。

--- a/src/features/settings/ui/components/SettingsGroup.vue
+++ b/src/features/settings/ui/components/SettingsGroup.vue
@@ -1,7 +1,7 @@
 <!--
 @file src/features/settings/ui/components/SettingsGroup.vue
 文件职责：建立设置页面的二级分组容器，用一致的标题、说明和卡片边界区分相关配置而不重复页面级介绍。
-主要内容：按需渲染分组标题与描述，通过默认插槽承载设置项，并统一相邻分隔线、悬停反馈、响应式间距和表面样式。
+主要内容：将可选标题、说明与设置项包入同一圆角边框，以浅底标题栏、组间留白及组内细分隔线建立层级，并适配主题与窄屏。
 模块边界：本组件是无业务状态的布局壳，不解释配置、不读写 store，也不决定导航分类；具体字段及控件由调用页面和 SettingsItem 提供。
 -->
 <template>
@@ -25,12 +25,22 @@ defineProps<{
 
 <style scoped>
 .settings-group {
+  box-sizing: border-box;
   width: min(100%, 1080px);
-  margin: 0 auto 22px;
+  min-width: 0;
+  margin: 0 auto 24px;
+  border: 1px solid color-mix(in srgb, var(--line) 78%, var(--muted));
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: 0 2px 6px rgba(31, 40, 61, .035), 0 8px 24px rgba(31, 40, 61, .025);
 }
 
 .settings-group-heading {
-  margin: 0 4px 10px;
+  margin: 0;
+  padding: 15px 18px;
+  border-bottom: 1px solid var(--line);
+  border-radius: 15px 15px 0 0;
+  background: var(--surface-soft);
 }
 
 .settings-group-heading h2 {
@@ -50,10 +60,13 @@ defineProps<{
 
 .settings-group-body {
   overflow: hidden;
-  border: 1px solid var(--line);
-  border-radius: 16px;
+  border-radius: 15px;
   background: var(--surface);
-  box-shadow: 0 7px 22px rgba(31, 40, 61, .035);
+}
+
+.settings-group-heading + .settings-group-body {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .settings-group-body :deep(.settings-item + .settings-item) {
@@ -81,6 +94,6 @@ defineProps<{
 
 @media (max-width: 700px) {
   .settings-group { margin-bottom: 18px; }
-  .settings-group-heading { margin-right: 2px; margin-left: 2px; }
+  .settings-group-heading { padding: 13px 12px; }
 }
 </style>


### PR DESCRIPTION
## 改动

设置分组标题与选项原先分离，长页面不易辨认所属区域。现在将标题、说明和选项收进同一圆角边框，通过浅底标题栏、组内细分隔线和组间留白区分层级；沿用主题变量并适配窄屏。配置与保存行为不变。

## 验证

- 类型检查、测试归类审计、28 项设置 UI 架构测试、文档构建通过。
- Chrome MV3、Firefox MV2 生产构建通过。
- 隔离 Edge 生产产物验证：通用设置、翻译设置、高级选项，1440px / 390px，浅色 / 深色，共 12 个场景；边框正常，无横向溢出或页面异常。
- 完整 UI 套件在旧 Popup 标题定位处超时，未完成；Firefox 仅构建验证。
