### PR TITLE
fix: 修复腾讯混元默认接口地址导致的连接失败

### DIFF
--- a/docs/config/translation-engines.md
+++ b/docs/config/translation-engines.md
@@ -55,6 +55,14 @@ API Key 中只填站点提供的 Token 值，不加 `Bearer` 前缀。默认通�
 
 使用 Azure 时，模型一栏填写实际的 **部署名称**；地址填写自己的资源地址或服务商给出的完整接口地址。
 
+### 腾讯混元连接失败
+
+选择 **腾讯混元**，填写混元控制台创建的 API Key。默认使用官方混元接口；**腾讯混元翻译**是另一项服务，需要 SecretId 和 SecretKey。
+
+旧版遇到 `Failed to fetch` 时，可以在 **高级设置 → 代理地址** 填入 `https://api.hunyuan.cloud.tencent.com/v1/chat/completions`，再点击 **检查连接**。使用自建代理或 TokenHub 时，请填写对应平台提供的完整接口地址和配套密钥。
+
+接口与密钥申请方式见腾讯官方的[第三方软件集成混元指南](https://cloud.tencent.com/document/product/1729/116755)。
+
 ### Gemini 代理地址
 
 Gemini 代理需要完整请求地址，也支持下面的模板：

--- a/docs/en/config/translation-engines.md
+++ b/docs/en/config/translation-engines.md
@@ -59,6 +59,14 @@ Extra AI context can reference the page title and parts of the article to help w
 
 Restore existing translations before translating with changed settings. Use [glossaries](/en/guide/glossary) for consistent terminology.
 
+### Tencent Hunyuan connection failures
+
+Select **Tencent Hunyuan** and enter an API key created in the Hunyuan console. The default uses the official Hunyuan endpoint. **Tencent Hunyuan Translate** is a separate service that requires a SecretId and SecretKey.
+
+If an older version reports `Failed to fetch`, enter `https://api.hunyuan.cloud.tencent.com/v1/chat/completions` under **Advanced settings → Proxy URL**, then check the connection again. For a custom proxy or TokenHub, use the full endpoint and matching key provided by that platform.
+
+See Tencent's [official integration guide](https://cloud.tencent.com/document/product/1729/116755) for endpoint and API key instructions.
+
 ## Local models
 
 Install and run Ollama and download a model before connecting it. Performance depends on the model and computer.

--- a/src/core/config/constants.ts
+++ b/src/core/config/constants.ts
@@ -68,7 +68,7 @@ export const urls: any = {
     [services.jieyue]: "https://api.stepfun.com/v1/chat/completions",
     [services.yiyan]: "https://qianfan.bj.baidubce.com/v2/chat/completions",
     [services.groq]: "https://api.groq.com/openai/v1/chat/completions",
-    [services.huanYuan]: "https://api.tokenhub.tencent.com/v1/chat/completions",
+    [services.huanYuan]: "https://api.hunyuan.cloud.tencent.com/v1/chat/completions",
     [services.huanYuanTranslation]: "https://hunyuan.tencentcloudapi.com/",
     [services.doubao]: "https://ark.cn-beijing.volces.com/api/v3/chat/completions",
     [services.siliconCloud]: "https://api.siliconflow.cn/v1/chat/completions",

--- a/tests/aiSdkEndpoints.test.ts
+++ b/tests/aiSdkEndpoints.test.ts
@@ -71,7 +71,7 @@ describe('AI SDK 首批服务路由', () => {
         [services.lingyi, 'https://api.lingyiwanwu.com/v1/chat/completions', 'https://api.lingyiwanwu.com/v1'],
         [services.jieyue, 'https://api.stepfun.com/v1/chat/completions', 'https://api.stepfun.com/v1'],
         [services.groq, 'https://api.groq.com/openai/v1/chat/completions', 'https://api.groq.com/openai/v1'],
-        [services.huanYuan, 'https://api.tokenhub.tencent.com/v1/chat/completions', 'https://api.tokenhub.tencent.com/v1'],
+        [services.huanYuan, 'https://api.hunyuan.cloud.tencent.com/v1/chat/completions', 'https://api.hunyuan.cloud.tencent.com/v1'],
         [services.doubao, 'https://ark.cn-beijing.volces.com/api/v3/chat/completions', 'https://ark.cn-beijing.volces.com/api/v3'],
         [services.siliconCloud, 'https://api.siliconflow.cn/v1/chat/completions', 'https://api.siliconflow.cn/v1'],
         [services.openrouter, 'https://openrouter.ai/api/v1/chat/completions', 'https://openrouter.ai/api/v1'],

--- a/tests/aiSdkOpenAICompatible.test.ts
+++ b/tests/aiSdkOpenAICompatible.test.ts
@@ -121,6 +121,28 @@ describe('Vercel AI SDK OpenAI-compatible transport', () => {
     });
   });
 
+  it.each([
+    ['', 'https://api.hunyuan.cloud.tencent.com/v1/chat/completions'],
+    ['https://gateway.example.com/v1/chat/completions', 'https://gateway.example.com/v1/chat/completions'],
+  ])('issue #513：混元使用官方接口且保留显式代理 %s', async (proxy, expectedEndpoint) => {
+    mockConfig.service = services.huanYuan;
+    mockConfig.model[services.huanYuan] = 'hy3';
+    mockConfig.token[services.huanYuan] = 'hunyuan-test-key';
+    mockConfig.proxy[services.huanYuan] = proxy;
+    const fetchMock = vi.fn().mockResolvedValue(successResponse('你好'));
+    setRuntimeFetch(fetchMock);
+
+    await expect(translateWithOpenAICompatibleAiSdk({origin: 'hello'})).resolves.toBe('你好');
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(expectedEndpoint);
+    expect(new Headers(init.headers).get('Authorization')).toBe('Bearer hunyuan-test-key');
+    expect(JSON.parse(String(init.body))).toMatchObject({model: 'hy3', stream: false});
+    expect(mockConfig.token[services.huanYuan]).toBe('hunyuan-test-key');
+    expect(mockConfig.proxy[services.huanYuan]).toBe(proxy);
+  });
+
   it('通过 runtimeFetch 发起 AI SDK 请求，使 userscript 可复用 GM transport', async () => {
     const nativeFetch = vi.fn().mockRejectedValue(new Error('不应调用原生 fetch'));
     vi.stubGlobal('fetch', nativeFetch);

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -1289,7 +1289,7 @@ describe('OpenAI 兼容服务端点', () => {
         expect(MINIMAX_ENDPOINTS.payg.cn).toBe('https://api.minimaxi.com/v1/chat/completions');
         expect(MINIMAX_ENDPOINTS['token-plan'].global).toBe('https://api.minimax.io/v1/chat/completions');
         expect(urls[services.infini]).toBe('https://cloud.infini-ai.com/maas/v1/chat/completions');
-        expect(urls[services.huanYuan]).toBe('https://api.tokenhub.tencent.com/v1/chat/completions');
+        expect(urls[services.huanYuan]).toBe('https://api.hunyuan.cloud.tencent.com/v1/chat/completions');
         expect(tongyiTokenPlanUrl).toBe('https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/chat/completions');
     });
 


### PR DESCRIPTION
## 问题与修复

腾讯混元默认请求发送到 `api.tokenhub.tencent.com`，用户即使填写正确的混元 API Key，仍可能收到 `Failed to fetch`。恢复为腾讯官方混元 OpenAI 兼容接口 `https://api.hunyuan.cloud.tencent.com/v1/chat/completions`，连接检查与翻译共用该地址。保留用户显式代理、模型与密钥，不修改配置迁移和其他服务。

补充实际 AI SDK transport 回归，检查目标地址、Bearer 鉴权、hy3 请求体及代理优先级；补充中英文配置说明与旧版临时解决方法。

Fixes #513

官方依据：https://cloud.tencent.com/document/product/1729/116755

## 验证

- 回归用例在旧地址上失败；修复后相关 3 文件 / 178 测试通过。
- test:audit、架构 887 测试、回归 395 测试通过。
- compile、Chrome/Firefox 构建、双浏览器 manifest verifier、userscript 构建及 verifier、中英文 docs:build、diff --check 通过。
- 单元：3078 通过 / 1 失败；功能：1168 通过 / 1 失败；覆盖率运行：4509 通过 / 2 失败。两项失败分别位于 config.test.ts、configDomainBoundaries.test.ts，断言仍期待缓存默认 5 MiB / 2000 条，实际 main 已为 10 MiB / 10000 条。在未经修改的基线 3e81ce4 独立副本重跑相同两个文件，同样 2 失败 / 144 通过。未修改无关断言，覆盖率门禁未通过。
- 无凭据网络探测：旧域名 TLS 连接失败；官方地址 POST 返回 HTTP 401 / invalid_api_key，确认可达。真实译文由模拟 HTTP 响应验证，未使用真实混元密钥完成鉴权翻译，未做真实浏览器验证。

未修改或借鉴参考仓库。
