### PR TITLE
fix(options): stabilize sidebar hover at scroll boundary

### DIFF
--- a/src/features/settings/ui/settings-page.css
+++ b/src/features/settings/ui/settings-page.css
@@ -68,7 +68,10 @@ button:focus-visible, input:focus-visible { outline: 3px solid rgba(239, 71, 118
 .brand div, nav button > span:last-child { display: flex; flex-direction: column; min-width: 0; }
 .brand strong { font-size: 18px; }
 .brand small { margin-top: 3px; color: var(--muted); font-size: 11px; }
-nav { display: grid; gap: 14px; overflow-x: hidden; overflow-y: auto; padding: 2px 0 16px; }
+nav {
+  display: grid; gap: 14px; min-height: 0; overflow-x: hidden; overflow-y: auto; padding: 2px 0 16px;
+  overflow-anchor: none;
+}
 .nav-group { display: grid; gap: 6px; }
 .nav-group-label { padding: 0 12px 4px; color: #9299a8; font-size: 10px; font-weight: 500; letter-spacing: .04em; }
 nav button {
@@ -317,7 +320,7 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
   .settings-app .sidebar nav {
     min-height: 0; gap: 7px; padding: 2px 2px 4px;
     align-content: start; overflow-x: hidden; overscroll-behavior-y: contain;
-    scrollbar-width: thin;
+    scrollbar-gutter: stable; scrollbar-width: thin;
   }
   .settings-app .sidebar .nav-group { gap: 1px; }
   .settings-app .sidebar .nav-group-label { padding-bottom: 2px; line-height: 12px; }

--- a/tests/settingsUiArchitecture.test.ts
+++ b/tests/settingsUiArchitecture.test.ts
@@ -960,6 +960,14 @@ describe('options UI composition architecture', () => {
     expect(tokens).toContain('--surface-soft: var(--fr-color-surface-soft);')
   })
 
+  it('keeps the desktop navigation scroll boundary stable while hovering its final item', () => {
+    const pageStyles = sourceBody('src/features/settings/ui/settings-page.css')
+
+    expect(pageStyles).toMatch(/nav\s*\{[^}]*min-height:\s*0;/u)
+    expect(pageStyles).toMatch(/nav\s*\{[^}]*overflow-anchor:\s*none;/u)
+    expect(pageStyles).toMatch(/@media \(min-width:\s*701px\)[\s\S]*?\.settings-app \.sidebar nav\s*\{[^}]*scrollbar-gutter:\s*stable;/u)
+  })
+
   it('keeps bilingual sentence highlighting opt-in and scoped to bilingual wrappers', () => {
     const page = source('src/app/content/page.css')
 


### PR DESCRIPTION
## Summary

- stabilize the Options sidebar scroll boundary when hovering the final navigation item
- reserve scrollbar space only for the desktop vertical navigation
- disable scroll anchoring inside the navigation container to prevent repeated hover re-entry
- add an architecture regression assertion for the sidebar scrolling rules

## Validation

- `pnpm compile`
- `pnpm test:audit` — 280 test files, 3,688 cases audited
- `pnpm test:architecture` — 27 test files, 896 tests passed
- targeted settings UI test — 29 tests passed
- `pnpm build` — Chrome MV3 production build passed
- `pnpm build:firefox` — Firefox MV2 production build passed
- `git diff --check`

## UI test note

The fix targets the desktop Options sidebar shown in the report. `scrollbar-gutter: stable` is scoped to desktop widths (`min-width: 701px`) so the mobile horizontal navigation does not inherit additional gutter space.

The change prevents scrollbar width and scroll anchoring from repeatedly changing the pointer hit target when the final visible navigation item is hovered.

## Reproduction steps / 问题复现步骤

1. Open the FluentRead Options page in a desktop browser window whose height makes the left navigation scrollable.  
   在桌面浏览器中打开 FluentRead 设置页，并将窗口高度调整到左侧导航栏需要滚动的状态。
2. Scroll the left sidebar to the bottom so the final navigation item is close to the lower edge.  
   将左侧导航栏滚动到底部，使最后一个导航项靠近容器下边缘。
3. Keep the pointer over the final navigation item.  
   将鼠标持续悬停在最后一个导航项上。
4. Observe that the sidebar list rapidly flickers or jitters.  
   可以观察到侧栏列表快速闪动或抖动。

**Expected / 预期结果：** The hovered item and sidebar scroll position remain stable.  
悬停项和侧栏滚动位置应保持稳定。

**Actual / 实际结果：** The sidebar and scrollbar repeatedly shift at the scroll boundary, causing rapid flicker.  
侧栏和滚动条在滚动边界反复偏移，导致列表快速闪动。