### PR TITLE
fix(userscript): stop Dexie from registering a shared global singleton

### DIFF
--- a/tests/hotkey.test.ts
+++ b/tests/hotkey.test.ts
@@ -38,6 +38,9 @@ describe('hotkey parsing', () => {
     });
 
     it('合并重复修饰键并按平台生成展示名', () => {
+        // 展示名取决于 navigator.platform。Node 21 起全局就存在 navigator，宿主平台会
+        // 泄漏进来，因此非 macOS 分支同样要显式 stub，不能依赖 navigator 缺失。
+        vi.stubGlobal('navigator', {platform: 'Win32'});
         expect(parseHotkey('Ctrl+Control+Alt+Space')).toEqual({
             modifiers: ['ctrl', 'alt'],
             key: 'space',

--- a/tests/userscriptDexieIsolation.test.ts
+++ b/tests/userscriptDexieIsolation.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @file tests/userscriptDexieIsolation.test.ts
+ * 覆盖 issue #524：dexie 官方 ESM 入口把自身注册到 globalThis[Symbol.for('Dexie')]，
+ * 并在版本不一致时于模块求值阶段抛错。油猴脚本与宿主页面共享同一个 world，
+ * 该注册一旦进入产物，任何自带其他 Dexie 版本的页面都会让整个脚本在入口处中断。
+ */
+import {describe, expect, it} from 'vitest';
+
+const DEXIE_GLOBAL_KEY = Symbol.for('Dexie');
+
+describe('userscript dexie entry isolation', () => {
+    it('不注册全局 Dexie 单例，宿主页面的其他 Dexie 版本无法中断脚本', async () => {
+        expect(Reflect.get(globalThis, DEXIE_GLOBAL_KEY)).toBeUndefined();
+
+        // 模拟宿主页面已经注册了另一个版本的 Dexie：官方入口在这种情况下会直接抛错。
+        Reflect.set(globalThis, DEXIE_GLOBAL_KEY, {semVer: '0.0.0-host-page'});
+        try {
+            const {default: Dexie} = await import('@/userscript/dexie');
+
+            expect(typeof Dexie).toBe('function');
+            // 仍然拿到的是真实实现，而不是被宿主页面的副本顶替。
+            expect(Reflect.get(globalThis, DEXIE_GLOBAL_KEY)).toEqual({semVer: '0.0.0-host-page'});
+            expect(typeof (Dexie as unknown as {semVer: string}).semVer).toBe('string');
+            expect((Dexie as unknown as {semVer: string}).semVer).not.toBe('0.0.0-host-page');
+        } finally {
+            Reflect.deleteProperty(globalThis, DEXIE_GLOBAL_KEY);
+        }
+    });
+
+    it('导出的构造函数可以正常建库并声明 schema', async () => {
+        const {default: Dexie} = await import('@/userscript/dexie');
+
+        const database = new Dexie('FluentReadUserscriptDexieProbe');
+        database.version(1).stores({entries: 'key'});
+
+        expect(database.name).toBe('FluentReadUserscriptDexieProbe');
+        expect(database.tables.map((table) => table.name)).toContain('entries');
+    });
+});

--- a/tests/userscriptViteConfig.test.ts
+++ b/tests/userscriptViteConfig.test.ts
@@ -3,6 +3,7 @@ import {describe, expect, it} from 'vitest';
 import {
     executionGuardEnd,
     executionGuardStart,
+    findDexieGlobalRegistration,
     injectUserscriptBrowserImports,
     userscriptAliases,
     wrapUserscriptEntry,
@@ -39,6 +40,23 @@ describe('userscript browser shim injection', () => {
         expect(stringAliases.get('@/src/platform/storage/credentialContext')).toMatch(/userscript\/credentialContext\.ts$/u);
         expect(stringAliases.get('@/src/platform/storage/configStorageRuntime')).toMatch(/userscript\/storage\.ts$/u);
         expect(userscriptAliases.at(-1)?.find).toBe('@');
+    });
+
+    it('把 dexie 换成不注册全局单例的入口，且不改写 dexie 自身的实现产物路径', () => {
+        const dexieAlias = userscriptAliases.find((entry) => entry.find instanceof RegExp
+            && (entry.find as RegExp).test('dexie'));
+
+        expect(dexieAlias?.replacement).toMatch(/userscript\/dexie\.ts$/u);
+        // 别名必须严格匹配裸模块名；否则 userscript/dexie.ts 内部对实现产物的引用会被改写回自身。
+        expect((dexieAlias!.find as RegExp).test('dexie/dist/dexie.min.js')).toBe(false);
+    });
+
+    it('产物中残留 Dexie 全局注册时能被构建守卫识别', () => {
+        expect(findDexieGlobalRegistration('const s=Symbol.for("Dexie");globalThis[s]=D;')).toBe(true);
+        expect(findDexieGlobalRegistration("globalThis[Symbol.for('Dexie')]=D;")).toBe(true);
+        expect(findDexieGlobalRegistration('Symbol . for ( "Dexie" )')).toBe(true);
+        expect(findDexieGlobalRegistration('Symbol.for("vercel.ai.schema")')).toBe(false);
+        expect(findDexieGlobalRegistration('const label="Dexie";')).toBe(false);
     });
 
     it('imports only unresolved browser globals', () => {

--- a/userscript/dexie-dist.d.ts
+++ b/userscript/dexie-dist.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @file userscript/dexie-dist.d.ts
+ * 文件职责：为 dexie 的实现产物 dist/dexie.min.js 补充类型声明，使油猴构建可以绕开会注册全局符号的官方入口。
+ * 主要内容：以环境模块声明复用 dexie 自带的默认导出类型。
+ * 模块边界：本文件必须保持为全局脚本（不含顶层 import/export），否则 declare module 会退化为模块增强而无法生效；
+ * 运行时替换逻辑见 userscript/dexie.ts 与 userscript/vite.config.ts 中的别名。
+ */
+declare module 'dexie/dist/dexie.min.js' {
+    const Dexie: typeof import('dexie')['default'];
+    export default Dexie;
+}

--- a/userscript/dexie.ts
+++ b/userscript/dexie.ts
@@ -1,0 +1,21 @@
+/**
+ * @file userscript/dexie.ts
+ * 文件职责：为油猴脚本提供不注册全局符号的 Dexie 入口，避免与宿主页面或其他脚本携带的 Dexie 副本互相判定为版本冲突。
+ * 主要内容：直接引入 dexie 的实现产物 dist/dexie.min.js，跳过官方 import-wrapper 对 globalThis[Symbol.for('Dexie')] 的注册与 semVer 校验。
+ * 模块边界：本文件只改写模块入口，不修改 Dexie 行为、不读写存储、不访问脚本管理器 API；扩展构建仍走 dexie 官方入口，此替换只在 userscript/vite.config.ts 的别名中生效。
+ *
+ * 背景（issue #524）：dexie 的 ESM 入口会把自身挂到跨 realm 共享的 globalThis[Symbol.for('Dexie')]，
+ * 并在版本不一致时于模块求值阶段直接抛错。扩展内容脚本运行在独立 world，不受影响；而 Safari
+ * Userscripts 等脚本管理器把脚本注入页面主 world，只要宿主页面或另一个脚本已注册了别的 Dexie
+ * 版本，整个 bundle 就会在入口处中断，表现为脚本完全没有反应。
+ *
+ * 这里只导出默认构造函数：共享核心目前仅使用 `import Dexie, {type Table} from 'dexie'`，Table 是纯类型。
+ * 若将来有模块引入 dexie 的运行时具名导出，打包会在此处报缺失导出而直接失败，便于及时补齐。
+ */
+import DexieImplementation from 'dexie/dist/dexie.min.js';
+
+/** 与 dexie/import-wrapper-prod.mjs 引入同一份实现产物，仅去掉全局注册与 semVer 校验。 */
+const Dexie = DexieImplementation as unknown as typeof import('dexie')['default'];
+
+export {Dexie};
+export default Dexie;

--- a/userscript/vite.config.ts
+++ b/userscript/vite.config.ts
@@ -16,6 +16,14 @@ const unicodeNotice = `/*\n${fs.readFileSync(resolve(root, 'public/third-party-n
 const browserShimPath = resolve(root, 'userscript/browser.ts');
 const projectRoot = `${normalizePath(root)}/`;
 
+// dexie 的官方入口以 Symbol.for('Dexie') 作为跨 realm 的单例注册表；该注册一旦进入油猴产物，
+// 与宿主页面的 Dexie 副本撞上不同版本就会在入口处抛错。用产物文本兜底，防止别名将来被改坏。
+const DEXIE_GLOBAL_REGISTRATION = /Symbol\s*\.\s*for\s*\(\s*(['"])Dexie\1\s*\)/u;
+
+export function findDexieGlobalRegistration(code: string): boolean {
+    return DEXIE_GLOBAL_REGISTRATION.test(code);
+}
+
 export const compatibilityPreludeStart = '/* FluentRead userscript compatibility prelude:start */';
 export const compatibilityPreludeEnd = '/* FluentRead userscript compatibility prelude:end */';
 export const executionGuardStart = '/* FluentRead userscript execution guard:start */';
@@ -211,6 +219,13 @@ function bundleUserscriptCss(): Plugin {
             if (leakedGlobals.length > 0) {
                 throw new Error(`Userscript bundle contains unresolved extension globals: ${leakedGlobals.join(', ')}`);
             }
+
+            if (findDexieGlobalRegistration(entry.code)) {
+                throw new Error(
+                    'Userscript bundle registers globalThis[Symbol.for("Dexie")]; import dexie through userscript/dexie.ts '
+                    + 'so a host page carrying another Dexie version cannot abort the script (issue #524)',
+                );
+            }
           },
         },
         writeBundle(_options, bundle) {
@@ -238,6 +253,10 @@ function unwrapWxtEntrypoints(): Plugin {
 }
 
 export const userscriptAliases = [
+    // dexie 官方 ESM 入口把自身注册到跨 realm 共享的 globalThis[Symbol.for('Dexie')]，版本不一致时会在
+    // 模块求值阶段直接抛错。脚本管理器（如 Safari 的 Userscripts）把脚本注入页面主 world，与宿主页面共享
+    // 该注册表，必须换成不注册全局符号的入口，否则整个 bundle 会在入口处中断（issue #524）。
+    {find: /^dexie$/u, replacement: resolve(root, 'userscript/dexie.ts')},
     {find: '@/src/platform/storage/credentialContext', replacement: resolve(root, 'userscript/credentialContext.ts')},
     {find: '@/src/platform/storage/configStorageRuntime', replacement: resolve(root, 'userscript/storage.ts')},
     // app/content 只依赖 feature 公开契约；在此边界替换，才能保证扩展专属 runtime 不进入产物。


### PR DESCRIPTION
## 问题

油猴脚本在 Safari 下完全没有反应：不翻译、没有悬浮球、也找不到设置入口（#524）。

控制台给出的是 Dexie 的致命错误：

```
Error: Two different versions of Dexie loaded in the same app: 4.4.5 and 4.4.4
```

## 根因

Dexie 的 ESM 入口 `dexie/import-wrapper-prod.mjs` 把自身发布到 `globalThis[Symbol.for("Dexie")]`，发现已有别的 `semVer` 就抛错：

```js
const DexieSymbol = Symbol.for("Dexie");
const Dexie = globalThis[DexieSymbol] || (globalThis[DexieSymbol] = _Dexie);
if (_Dexie.semVer !== Dexie.semVer) throw new Error(`Two different versions of Dexie loaded in the same app: ...`);
```

`Symbol.for()` 用的是 realm 级共享注册表。脚本元数据声明了 `@inject-into content`，而 Safari 的 Userscripts 扩展会把**所有**脚本放进同一个共享 content world —— 宿主页面或另一个脚本只要带着不同版本的 Dexie，这句 throw 就会在**模块求值阶段、bundle 入口处**触发，整个脚本当场中断。这解释了用户看到的全部现象：不是各个功能分别坏了，而是脚本根本没启动。

浏览器扩展版不受影响，其内容脚本本就运行在独立 world。

## 改动

- 新增 `userscript/dexie.ts`：直接引入官方 wrapper 所用的同一份实现产物 `dist/dexie.min.js`，跳过全局注册与 semVer 校验
- 新增 `userscript/dexie-dist.d.ts`：该产物无随附类型，补环境模块声明（必须是全局脚本文件，否则 `declare module` 会退化为模块增强）
- `userscript/vite.config.ts`：别名 `/^dexie$/u` → 上述 shim。**锚定正则是必须的**，否则 shim 内部对实现产物的引用会被改写回自身
- `userscript/vite.config.ts`：新增 `generateBundle` 守卫，产物中若再次出现该全局注册则直接构建失败

扩展构建未受影响：`wxt.config.ts` 没有任何 dexie/alias 引用。

## 验证

- 产物中 `Symbol.for("Dexie")` 与那句 throw 均归零；Dexie 本体仍在（体积仅减约 200B，正是 wrapper 那几行）
- 临时移除别名重新构建 → 守卫如期拦截，确认守卫真的接线成功
- 新增测试：模拟「宿主页面已注册其他版本 Dexie」后，shim 仍返回真实实现并能正常建库声明 schema；另覆盖别名锚定性与守卫正则
- `pnpm compile` 通过；`pnpm test` 全绿 **5710/5710**

## 附带：第二个 commit（与 #524 无关）

`test(hotkey): stub navigator platform for the non-macOS display name`

`tests/hotkey.test.ts` 在 origin/main 上已经是**失败的基线**（在纯净 worktree 中复现）。`generateDisplayName` 读取 `navigator.platform`，而该用例的非 macOS 分支没有 stub navigator —— 这只在 `navigator` 不存在时成立，而 Node 自 v21 起提供全局 `navigator`，宿主平台因此泄漏进来，在 macOS 上断言得到 `Control+Option+Space`。紧挨着的 macOS 分支本来就是 stub 过的。

这里把两个分支都显式 stub，让用例真正测它名字所说的事，而不是依赖运行环境。**生产代码未改动。** 单独成一个 commit，便于分开审阅。

Fixes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)
