### PR TITLE
fix(github): remove blank lines below translated list titles

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,6 +49,28 @@ node scripts/verify-userscript-build.mjs  # userscript 元数据与产物边界
 
 ## 翻译核心稳定性回归
 
+### GitHub 列表译文间距
+
+新版 PR 列表的标题旁保留带 padding 的空徽标占位符。行内标题插入块级译文后，
+占位符会另起一行，使标题译文到元信息的间距达到 36px。双语标题现在使用行内块
+容纳原文和译文，恢复原文时自动回到 GitHub 的布局；徽标、链接和检查按钮仍保留。
+新版 PR 列表的用户名、创建/更新时间与检查状态保持原文，标题继续支持悬浮和全文翻译。
+
+`run-github-spacing-test.cjs` 使用与实际 DOM/计算样式一致的最小本地夹具，检查空徽标、
+非空徽标、新旧标题结构、普通正文、1150/360px 内容宽度、悬浮 `[1,0,1]`、全文恢复、
+再次翻译、节点重挂和失败重试。报告保存像素间距、原始 DOM 恢复结果与截图。
+脚本使用生产扩展、确定性微软响应和临时后台 Edge，不代表在线供应商的翻译质量。
+
+```bash
+node scripts/testing/run-github-spacing-test.cjs \
+  --extension-dir .output/chrome-mv3 --playwright-root <Node包目录> \
+  --focus-safe-helper <focus-safe-browser.cjs路径> --background \
+  --artifacts-dir /private/tmp/fluentread-github-spacing
+```
+
+一键浏览器回归已包含此脚本；仅在复核旧产物时追加 `--expect-regression`，它要求旧版
+确实产生至少 30px 的空白及元信息译文，输出属于缺陷复现证据。
+
 排查重复翻译、鼠标经过闪切或原文恢复异常时，先运行以下确定性测试：
 
 ```bash

--- a/scripts/testing/run-full-regression.mjs
+++ b/scripts/testing/run-full-regression.mjs
@@ -42,6 +42,13 @@ const LOCAL_BROWSER_FIXTURES = [
         supportsHeaded: false,
     },
     {
+        id: 'github-spacing',
+        label: 'GitHub bilingual title spacing and metadata browser regression',
+        script: 'scripts/testing/run-github-spacing-test.cjs',
+        backgroundArgs: ['--background'],
+        supportsHeaded: false,
+    },
+    {
         id: 'video-subtitle-fixture',
         label: 'video subtitle fixture browser regression',
         script: 'scripts/run-video-subtitle-fixture-test.cjs',

--- a/scripts/testing/run-github-spacing-test.cjs
+++ b/scripts/testing/run-github-spacing-test.cjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * @file scripts/testing/run-github-spacing-test.cjs
+ * Reproduce GitHub ListView's padded empty badge creating a blank line after bilingual titles.
+ * Use a production extension, local domain fixture and deterministic provider in a temporary,
+ * focus-safe Edge. Inspect geometry, title/metadata ownership, restore, remount and retry.
+ */
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const crypto = require('node:crypto');
+const {createRequire} = require('node:module');
+const {assertFreshProductionExtension} = require('../run-site-translation-test.cjs');
+const root = path.resolve(__dirname, '../..');
+const args = {timeout: 30000};
+for (let i = 2; i < process.argv.length; i++) {
+  const key = process.argv[i];
+  if (key === '--background') continue;
+  if (key === '--expect-regression') { args.expectRegression = true; continue; }
+  assert.ok(key.startsWith('--') && process.argv[i + 1], `Invalid argument ${key}`);
+  args[key.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())] = process.argv[++i];
+}
+for (const key of ['extensionDir', 'playwrightRoot', 'focusSafeHelper', 'artifactsDir']) {
+  assert.ok(args[key], `Missing ${key}`); args[key] = path.resolve(args[key]);
+}
+args.timeout = Number(args.timeout);
+const helper = require(args.focusSafeHelper);
+const {chromium} = createRequire(path.join(args.playwrightRoot, 'github-spacing.cjs'))('playwright');
+const owned = '.fluent-read-bilingual-content';
+const url = 'https://github.com/FluentRead/FluentRead/pulls';
+const report = {scope: 'local-GitHub-ListView-fixture', provider: 'microsoft-local-deterministic-response',
+  profileMode: 'new-temporary-profile', baseline: !!args.expectRegression, cases: [], errors: []};
+fs.mkdirSync(args.artifactsDir, {recursive: true});
+const save = () => fs.writeFileSync(path.join(args.artifactsDir, 'report.json'), JSON.stringify(report, null, 2));
+async function main() {
+  if (!args.expectRegression) assertFreshProductionExtension(args.extensionDir, root);
+  report.contentSha256 = crypto.createHash('sha256').update(fs.readFileSync(path.join(args.extensionDir, 'content-scripts/content.js'))).digest('hex');
+  const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fluentread-github-spacing-'));
+  let session, context, worker, popup, page, sequence = 0;
+  const installedWorkers = new WeakMap();
+  const installWorker = current => {
+    if (!installedWorkers.has(current)) installedWorkers.set(current, current.evaluate(() => {
+      globalThis.spacingRequests = []; globalThis.failSpacingRequests = false;
+      globalThis.fetch = async (input, init) => {
+        const url = new URL(typeof input === 'string' || input instanceof URL ? String(input) : input.url);
+        if (url.hostname !== 'edge.microsoft.com' || url.pathname !== '/translate/translatetext') throw Error('External fetch disabled');
+        const texts = JSON.parse(init?.body ?? await input.text()); globalThis.spacingRequests.push(texts);
+        if (globalThis.failSpacingRequests) return new Response('', {status: 503});
+        return new Response(JSON.stringify(texts.map(text => ({translations: [{text:
+          /translate hovered visual text blocks/.test(text) ? '修复：翻译悬停的视觉文本块' : `测试译文：${text}`}]}))),
+        {status: 200, headers: {'content-type': 'application/json'}});
+      };
+    }));
+    return installedWorkers.get(current);
+  };
+  const patchConfig = async updates => {
+    const result = await popup.evaluate(async ({updates, sequence}) => {
+      const read = await chrome.runtime.sendMessage({type: 'configStorageRead', key: 'local:config'});
+      const c = typeof read.value === 'string' ? JSON.parse(read.value) : read.value;
+      return chrome.runtime.sendMessage({type: 'persistConfig', mode: 'patch', config: updates,
+        expected: Object.fromEntries(Object.keys(updates).map(k => [k, c[k]])),
+        clientId: 'github-spacing', sequence, baseRevision: c.__fluentConfigRevision});
+    }, {updates, sequence: ++sequence});
+    assert.equal(result.success, true, JSON.stringify(result));
+  };
+  const waitCount = (selector, expected) => page.waitForFunction(({selector, expected}) => document.querySelectorAll(selector).length === expected,
+    {selector, expected}, {timeout: args.timeout});
+  const full = async () => {
+    await helper.activateExtensionTabWithoutForeground(context, page);
+    await page.keyboard.down('Alt'); await page.keyboard.press('t'); await page.keyboard.up('Alt');
+  };
+  const hover = async selector => {
+    await helper.activateExtensionTabWithoutForeground(context, page);
+    const box = await page.locator(selector).boundingBox(); assert.ok(box);
+    // Mouse movement + a real Control gesture, without following the title's link.
+    await page.mouse.move(box.x + 15, box.y + 8);
+    await page.keyboard.down('Control'); await page.keyboard.up('Control');
+  };
+  const geometry = () => page.evaluate(owned => ['empty', 'badge', 'issue'].map(id => {
+    const row = document.getElementById(`${id}-row`), heading = row.querySelector('h3');
+    const translation = heading.querySelector(owned), metadata = row.querySelector('.main-content');
+    const badge = row.querySelector('.badge');
+    return {id, rowHeight: row.getBoundingClientRect().height, headingDisplay: getComputedStyle(heading).display,
+      gap: translation ? metadata.getBoundingClientRect().top - translation.getBoundingClientRect().bottom : null,
+      // A real badge may wrap below a long narrow title; its visible row is not blank space.
+      blankGap: translation ? metadata.getBoundingClientRect().top - Math.max(translation.getBoundingClientRect().bottom,
+        badge?.getBoundingClientRect().bottom ?? 0) : null,
+      badgeVisible: !badge || (badge.getBoundingClientRect().width > 0 && badge.getBoundingClientRect().height > 0),
+      overflow: row.scrollWidth > row.clientWidth + 1};
+  }), owned);
+  const assertGeometry = rows => {
+    for (const row of rows) {
+      assert.ok(row.blankGap >= 0 && row.blankGap <= 16, `${row.id}: unwanted blank gap ${row.blankGap}px`);
+      assert.ok(row.badgeVisible); assert.equal(row.overflow, false);
+    }
+  };
+  try {
+    session = await helper.launchFocusSafePersistentContext({chromium, profileDir,
+      browserPath: args.browserPath || '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge', background: true,
+      headless: false, viewport: {width: 1280, height: 900}, displayTarget: 'secondary', timeout: args.timeout,
+      browserArgs: [`--disable-extensions-except=${args.extensionDir}`, `--load-extension=${args.extensionDir}`, '--no-first-run', '--no-default-browser-check']});
+    context = session.context;
+    Object.assign(report, {launchMode: session.launchMode, focusPolicy: session.focusPolicy, windowPlacement: session.windowPlacement});
+    assert.equal(report.launchMode, 'macos-background-cdp'); assert.equal(report.focusPolicy, 'launchservices-no-foreground');
+    assert.equal(report.windowPlacement.mode, 'background-visible-no-focus'); assert.equal(report.windowPlacement.browserFrontmost, false);
+    context.on('serviceworker', current => { void installWorker(current).catch(e => report.errors.push(e.message)); });
+    worker = context.serviceWorkers()[0] || await context.waitForEvent('serviceworker'); await installWorker(worker);
+    const fixture = fs.readFileSync(path.join(root, 'tests/fixtures/translation-pages/github-list-spacing.html'), 'utf8');
+    await context.route('**/*', route => {
+      if (route.request().isNavigationRequest() && route.request().url() === url) return route.fulfill({status: 200, contentType: 'text/html', body: fixture});
+      if (/^https?:/.test(route.request().url())) return route.abort('blockedbyclient');
+      return route.continue();
+    });
+    popup = await helper.newPageWithoutForeground(context, args.timeout);
+    await popup.goto(`chrome-extension://${new URL(worker.url()).host}/popup.html`); await popup.waitForTimeout(600);
+    report.config = {service: 'microsoft', from: 'en', to: 'zh-Hans', display: 1, style: 1, autoTranslate: false,
+      hotkey: 'Control', floatingBallHotkey: 'Alt+T', mouseHoverTranslationDelay: 0, fullPageTranslationMode: 'all',
+      useCache: false, enableAIContext: false, enableAIMultiSegment: false, uiLanguageSetupCompleted: true};
+    await patchConfig(report.config);
+    for (const width of args.expectRegression ? [1150] : [1150, 360]) {
+      page = await helper.newPageWithoutForeground(context, args.timeout);
+      page.on('pageerror', e => report.errors.push(e.message));
+      await page.goto(url); await page.waitForSelector('#fluent-read-page-styles', {state: 'attached'}); await page.waitForTimeout(600);
+      // Resize only the fixture's main content, keeping the safe browser window placement intact.
+      await page.locator('main').evaluate((el, width) => { el.style.width = `${width}px`; }, width);
+      await page.evaluate(() => {
+        window.spacingSourceNodes = [...document.querySelector('main').querySelectorAll('*')];
+        window.spacingClicks = 0; document.getElementById('checks').addEventListener('click', () => window.spacingClicks++);
+      });
+      const original = await page.locator('main').innerHTML();
+      const result = {width, before: await geometry(), hoverCounts: []}; report.cases.push(result);
+      await page.screenshot({path: path.join(args.artifactsDir, `${width}-before.png`)});
+      if (!args.expectRegression) {
+        for (const expected of [1, 0, 1]) {
+          await hover('#empty-title'); await waitCount(`#empty-title ${owned}`, expected);
+          result.hoverCounts.push(await page.locator(`#empty-title ${owned}`).count());
+          assert.equal(await page.locator(`#badge-title ${owned}, #neighbor ${owned}`).count(), 0);
+        }
+        await hover('#empty-title'); await waitCount(owned, 0);
+        assert.equal(await page.locator('main').innerHTML(), original);
+      }
+      await full(); await waitCount(`#empty-row h3 ${owned}`, 1); await waitCount(`#issue-title ${owned}`, 1);
+      await waitCount(`#legacy-title ${owned}`, 1); await waitCount(`#prose ${owned}`, 1); await waitCount('.fluent-read-loading', 0);
+      result.translated = await geometry(); await page.screenshot({path: path.join(args.artifactsDir, `${width}-translated.png`)});
+      if (args.expectRegression) {
+        assert.ok(result.translated[0].gap >= 30, `Expected old blank line: ${JSON.stringify(result.translated)}`);
+        assert.ok(await page.locator(`#empty-meta ${owned}`).count()); report.reproduced = true; break;
+      }
+      assertGeometry(result.translated);
+      assert.equal(await page.locator(`#empty-meta ${owned}, #badge-meta ${owned}, .badge ${owned}, #code ${owned}`).count(), 0);
+      assert.equal(await page.locator(`${owned} ${owned}`).count(), 0);
+      assert.equal(await page.evaluate(() => window.spacingSourceNodes.every(el => el.isConnected)), true);
+      await page.locator('#checks').click(); assert.equal(await page.evaluate(() => window.spacingClicks), 1);
+      await page.evaluate(() => { document.querySelector('#empty-meta relative-time').textContent = '2 months ago'; });
+      await page.waitForTimeout(400);
+      const requests = await worker.evaluate(() => globalThis.spacingRequests.flat());
+      assert.equal(requests.some(text => /example-author|opened|Updated|1\/1/.test(text)), false);
+      await full(); await waitCount(owned, 0); await page.waitForTimeout(200);
+      assert.equal(await page.locator('main').innerHTML(), original.replace('last month</relative-time>', '2 months ago</relative-time>'));
+      result.restored = await geometry(); assert.deepEqual(result.restored, result.before);
+      await full(); await waitCount(`#empty-title ${owned}`, 1); await waitCount(`#issue-title ${owned}`, 1); await waitCount(`#badge-title ${owned}`, 1);
+      await waitCount('.fluent-read-loading', 0); assertGeometry(await geometry());
+      // GitHub may clone/remount a translated row. It must keep one wrapper and remain restorable.
+      await page.locator('#empty-row').evaluate(row => row.replaceWith(row.cloneNode(true)));
+      await page.waitForTimeout(800); await waitCount(`#empty-title ${owned}`, 1); assertGeometry(await geometry());
+      await full(); await waitCount(owned, 0);
+      if (width === 1150) {
+        await worker.evaluate(() => { globalThis.failSpacingRequests = true; });
+        await hover('#empty-title'); await waitCount('#empty-title .fluent-read-retry-wrapper', 1);
+        assert.equal(await page.locator('#empty-row h3').evaluate(el => getComputedStyle(el).display), 'inline');
+        await worker.evaluate(() => { globalThis.failSpacingRequests = false; });
+        await page.locator('#empty-title .fluent-read-retry').click(); await waitCount(`#empty-title ${owned}`, 1);
+        const retryGeometry = await geometry(); assert.ok(retryGeometry[0].gap <= 16); result.retry = retryGeometry[0];
+        await hover('#empty-title'); await waitCount(owned, 0);
+      }
+      assert.equal(page.url(), url); result.passed = true; await page.close(); page = null; save();
+    }
+    assert.deepEqual(report.errors, []); report.passed = true;
+  } catch (error) {
+    report.error = error.stack;
+    if (page) { report.failureGeometry = await geometry().catch(() => null); await page.screenshot({path: path.join(args.artifactsDir, 'failure.png')}).catch(() => {}); }
+    throw error;
+  } finally {
+    save(); if (session) await session.close(); fs.rmSync(profileDir, {recursive: true, force: true, maxRetries: 5, retryDelay: 200});
+  }
+  console.log(JSON.stringify({passed: report.passed, reproduced: report.reproduced, cases: report.cases, artifacts: args.artifactsDir}));
+}
+main().catch(e => { console.error(e); process.exitCode = 1; });

--- a/src/app/content/page.css
+++ b/src/app/content/page.css
@@ -1,7 +1,7 @@
 /**
  * @file src/app/content/page.css
  * 文件职责：定义内容脚本直接注入宿主文档的 FluentRead 专属视觉状态，覆盖翻译占位、重试、图片覆盖层、输入框反馈、已翻译提示框的鼠标命中保护和多种双语译文样式。
- * 主要内容：包含错误原因与重试控件、图片翻译按钮和 canvas、输入框 translating/success/error tooltip，以及 dimmed、下划线、卡片、标记、纸张、技术风等显示类；段落 loading 已由自带 Shadow Root 的组件隔离。
+ * 主要内容：包含错误原因与重试控件、图片翻译按钮和 canvas、输入框 translating/success/error tooltip，以及 dimmed、下划线、卡片、标记、纸张、技术风等显示类和 GitHub ListView 双语标题的空行修复；段落 loading 已由自带 Shadow Root 的组件隔离。
  * 模块边界：选择器均以 fluent 前缀或受控状态类约束，不承担 Shadow UI 组件主题，也不决定何时添加类名；DOM 状态由各 content feature 管理，共享 token 由 src/ui/styles 提供。
  */
 /* 内容脚本注入到宿主页面的 FluentRead 专属样式。 */
@@ -310,6 +310,15 @@
     background: transparent; /* 确保背景透明，与周围背景融合 */
     box-sizing: border-box; /* 使用 border-box 模型，确保内外边距和边框计算正确 */
     overflow-wrap: break-word; /* 处理长单词或 URL 的断行，避免溢出 */
+}
+
+/* GitHub ListView 的行内标题后有带 padding 的空徽标占位符。块级译文会拆开
+ * 行内格式化上下文，把占位符推到独占的空行。仅在标题含自有译文时把原文与
+ * 译文收进同一个行内块，保留相邻徽标；移除译文后由 CSS 自动恢复宿主布局。 */
+[data-listview-item-title-container="true"] > h3:has(.fluent-read-bilingual-content[data-fr-translation-owned="true"]) {
+    display: inline-block;
+    max-width: 100%;
+    vertical-align: top;
 }
 
 /* 纯说明 tooltip 按原文高度定位后，译文增高可能盖住触发图标，导致

--- a/src/core/site-adaptation/catalog/established.json
+++ b/src/core/site-adaptation/catalog/established.json
@@ -41,7 +41,8 @@
           "h1.gh-header-title .js-issue-title",
           "[data-testid=\"issue-title\"]",
           "[data-testid=\"pull-request-title\"]",
-          "[data-testid=\"issue-pr-title-link\"]"
+          "[data-testid=\"issue-pr-title-link\"]",
+          "[data-testid=\"listitem-title-link\"]"
         ],
         "key": "github-issue-or-pr-title",
         "resolve": "closest",
@@ -83,6 +84,7 @@
       }
     ],
     "protect": [
+      "[class*=\"PullsListItem-module__description__\"]",
       "[data-testid=\"issue-labels\"]",
       "span[class*=\"IssueLabel\"]",
       "[data-testid=\"list-row-repo-name-and-number\"]",
@@ -104,6 +106,7 @@
       "[data-listview-item-visibility-label=\"true\"]"
     ],
     "exclude": [
+      "[class*=\"PullsListItem-module__description__\"]",
       "dialog",
       "[role=\"dialog\"]",
       "[data-testid=\"search-modal\"]",
@@ -127,6 +130,7 @@
       "[data-listview-item-visibility-label=\"true\"]"
     ],
     "watchIgnore": [
+      "[class*=\"PullsListItem-module__description__\"]",
       "[data-testid=\"issue-labels\"]",
       "span[class*=\"IssueLabel\"]",
       "[data-testid=\"list-row-repo-name-and-number\"]",

--- a/tests/fixtures/translation-pages/github-list-spacing.html
+++ b/tests/fixtures/translation-pages/github-list-spacing.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>GitHub list spacing regression</title>
+<!-- Minimal independent reproduction of the live ListView geometry inspected on 2026-09-12:
+     inline h3, padded empty trailing badge span, and two grid rows with a 4px gap. -->
+<style>
+* { box-sizing: border-box; }
+body { margin: 24px; font: 14px/21px -apple-system, BlinkMacSystemFont, sans-serif; color: #1f2328; }
+main { max-width: 1150px; margin: auto; }
+h1 { font-size: 22px; }
+ul { padding: 0; list-style: none; }
+.row { display: grid; grid-template-columns: 24px minmax(0,1fr) 44px; grid-template-areas: "status primary metadata" "status main-content metadata"; gap: 4px; border: 1px solid #d1d9e0; padding: 0 12px; background:#f6f8fa; }
+[data-listview-item-title-container] { grid-area: primary; display: block; padding-top: 8px; }
+[data-listview-item-title-container] > h3 { display: inline; margin: 0; font-size: 16px; font-weight: 600; line-height: 24px; overflow: hidden; }
+a { color: inherit; text-decoration: none; }
+a:hover { color: #0969da; text-decoration: underline; }
+.Title-module__trailingBadgesSpacer__fixture { padding-right: 4px; }
+.Title-module__trailingBadgesContainer__fixture { vertical-align: top; position:relative; top:1px; overflow:hidden; }
+.badge { display: inline-block; padding: 0 7px; font: 12px/20px sans-serif; border: 1px solid #a5b0bd; border-radius: 12px; }
+.main-content { grid-area: main-content; padding-bottom: 10px; }
+.PullsListItem-module__description__fixture, .issue-metadata, .legacy-meta { font-size: 12px; line-height: 18px; color:#59636e; }
+.status { grid-area: status; padding-top: 12px; color: #1a7f37; }
+.checks { grid-area:metadata; align-self:center; color: #59636e; }
+.legacy { padding: 8px 12px; border: 1px solid #d1d9e0; }
+.markdown-title { font-size:16px;line-height:24px; }
+button { font:inherit; }
+</style></head><body><main>
+<h1>Pull requests</h1><ul>
+<li id="empty-row" class="row"><div data-listview-item-title-container="true"><h3><a id="empty-title" data-testid="listitem-title-link" href="/FluentRead/FluentRead/pull/243"><span>fix: translate hovered visual text blocks</span></a></h3><span class="Title-module__trailingBadgesSpacer__fixture"></span><span class="Title-module__trailingBadgesContainer__fixture"></span></div><span class="status" aria-hidden="true">⑂</span><div class="main-content"><div id="empty-meta" class="PullsListItem-module__description__fixture"><span>#243 </span><span data-testid="timestamp-container">· <a data-testid="author-filter-link" href="/example-author">example-author</a> opened <relative-time>last month</relative-time> · Updated last month</span> <button id="checks" data-testid="checks-status-badge-button">✓ 1/1</button></div></div><span class="checks" translate="no">5</span></li>
+<li id="badge-row" class="row"><div data-listview-item-title-container="true"><h3><a id="badge-title" data-testid="listitem-title-link" href="/FluentRead/FluentRead/pull/303">feat: add Google Drive configuration sync</a></h3><span class="Title-module__trailingBadgesSpacer__fixture"></span><span class="Title-module__trailingBadgesContainer__fixture"><span class="badge prc-Token-IssueLabel-fixture">enhancement</span></span></div><span class="status" aria-hidden="true">⑂</span><div class="main-content"><div id="badge-meta" class="PullsListItem-module__description__fixture">#303 · author opened last month · Draft</div></div></li>
+<li id="issue-row" class="row"><div data-listview-item-title-container="true"><h3><a id="issue-title" data-testid="issue-pr-title-link" href="/FluentRead/FluentRead/issues/521">Rate limits per API provider</a></h3><span class="Title-module__trailingBadgesSpacer__fixture"></span><span class="Title-module__trailingBadgesContainer__fixture"></span></div><span class="status" aria-hidden="true">○</span><div class="main-content issue-metadata"><span data-testid="list-row-repo-name-and-number">#521</span><span data-testid="created-at"> · author opened yesterday</span></div></li>
+</ul><div class="legacy"><a id="legacy-title" class="markdown-title" href="/FluentRead/FluentRead/pull/243">Fix translation on the legacy pull request list</a><div class="legacy-meta" translate="no">#243 opened last month by example-author</div></div>
+<article class="markdown-body"><p id="prose">This ordinary paragraph must retain its original layout and translate normally.</p><p id="neighbor">This adjacent paragraph must remain unchanged during hover translation.</p><pre><code id="code">const blankLine = false;</code></pre></article>
+</main></body></html>

--- a/tests/fullRegressionRunner.test.ts
+++ b/tests/fullRegressionRunner.test.ts
@@ -94,11 +94,12 @@ describe('full regression runner', () => {
         const plan = dryRun(['--browser', ...BROWSER_ARGS]);
         const browserSteps = plan.steps.filter((step: {phase: string}) => step.phase === 'browser');
 
-        expect(browserSteps).toHaveLength(9);
+        expect(browserSteps).toHaveLength(10);
         expect(browserSteps.map((step: {id: string}) => step.id)).toEqual([
             'selection-trigger',
             'full-page-translation',
             'translation-mutation',
+            'github-spacing',
             'video-subtitle-fixture',
             'document-translation',
             'settings-center-ui',
@@ -195,6 +196,7 @@ describe('full regression runner', () => {
         expect(headedSteps.every((step: {focusPolicy: string}) => step.focusPolicy === 'foreground-authorized')).toBe(true);
         expect(backgroundSteps.map((step: {id: string}) => step.id)).toEqual([
             'translation-mutation',
+            'github-spacing',
             'video-subtitle-fixture',
             'document-translation',
             'settings-center-ui',

--- a/tests/translationCore.test.ts
+++ b/tests/translationCore.test.ts
@@ -1437,6 +1437,38 @@ describe('translation candidate core', () => {
         expect(createTranslationSourceSnapshot(document.getElementById('topics')!, core.shouldStayOriginal).slots).toEqual([]);
     });
 
+    it('recognizes the new GitHub PR list title and protects author, dates and checks from both entry points', () => {
+        const {document, core} = page(`
+            <main><li>
+                <div data-listview-item-title-container="true"><h3>
+                    <a id="title" data-testid="listitem-title-link" href="/FluentRead/FluentRead/pull/243">
+                        <span>fix: translate hovered visual text blocks</span>
+                    </a>
+                </h3><span class="Title-module__trailingBadgesSpacer__fixture"></span></div>
+                <div id="metadata" class="Description-module__container__fixture PullsListItem-module__description__fixture">
+                    <span>#243</span><span data-testid="timestamp-container">·
+                        <a id="author" data-testid="author-filter-link">jeanchristophe13v</a> opened
+                        <relative-time>last month</relative-time> · Updated last month
+                    </span><button id="checks" data-testid="checks-status-badge-button">1/1</button>
+                </div>
+            </li><article class="markdown-body"><p id="prose">The author updated the status checks.</p></article></main>
+        `, 'https://github.com/FluentRead/FluentRead/pulls');
+        const title = document.getElementById('title')!;
+        const metadata = document.getElementById('metadata')!;
+        const before = metadata.outerHTML;
+        expect(core.discover(document).map(({element}) => element.id)).toEqual(['title', 'prose']);
+        expect(core.resolve(title.querySelector('span')!.firstChild))
+            .toMatchObject({element: title, adapterId: 'github', reason: 'github-issue-or-pr-title'});
+        for (const element of [metadata, ...metadata.querySelectorAll('*')]) {
+            expect(core.resolve(element.firstChild)).toBeNull();
+            expect(core.shouldStayOriginal(element)).toBe(true);
+            expect(core.shouldIgnoreMutation(element)).toBe(true);
+        }
+        metadata.querySelector('relative-time')!.textContent = '2 months ago';
+        expect(core.discover(metadata)).toEqual([]);
+        expect(metadata.outerHTML).toBe(before.replace('last month</relative-time>', '2 months ago</relative-time>'));
+    });
+
     it('keeps GitHub issue-list labels and metadata original while translating titles', () => {
         const {document, core} = page(`
             <main>


### PR DESCRIPTION
GitHub 新版 PR 列表的行内标题插入块级译文后，旁边带 padding 的空徽标占位符会另起一行，导致译文到元信息之间出现 36px 的空白。此修复仅在 ListView 标题包含 FluentRead 自有译文时使用行内块容纳标题，使间距恢复为 12px；移除译文后自动恢复宿主布局，保留真实徽标和链接。

同时识别新版 `listitem-title-link`，保护 PR 列表的用户名、创建/更新时间及检查状态，避免把这些元信息再次翻译。

验证：
- 在用户授权下只读测量实际 GitHub DOM；独立本地夹具重现相同的 36px 空白，旧生产产物通过缺陷复现断言。
- 修复后的生产扩展在临时后台 Edge 中验证 1150/360px 内容宽度、空/非空徽标、新旧标题、普通正文、悬浮 [1,0,1]、全文恢复/再次翻译、动态重挂及失败重试。空徽标行间距为 12px，恢复后的 DOM 与尺寸匹配原文；实际徽标在窄屏允许正常换行。
- 227 个测试文件、4660 个用例通过，覆盖率 statements/branches/functions/lines 均为 100%；架构测试 896 个用例、测试审计及相关回归通过。
- TypeScript、Chrome、Firefox、Userscript、文档构建，以及 manifest/userscript verifier 通过。

浏览器测试使用本地确定性微软响应，不代表在线翻译服务质量；未修改用户当前页面，也未修改参考仓库。新增专项已接入一键浏览器回归。
