### PR TITLE
更新翻译模型目录，默认优先轻量模型并接入 DeepSeek Flash

### DIFF
--- a/docs/config/translation-engines.md
+++ b/docs/config/translation-engines.md
@@ -51,6 +51,22 @@ API Key 中只填站点提供的 Token 值，不加 `Bearer` 前缀。默认通�
 
 ## 使用 AI 服务
 
+新配置优先使用适合日常翻译的轻量模型：
+
+| 服务 | 默认模型 |
+| --- | --- |
+| DeepSeek | `deepseek-flash`（V4.1 Flash） |
+| OpenAI | `gpt-5.4-mini` |
+| Gemini | `gemini-3.5-flash-lite` |
+| 通义千问 | `qwen3.8-flash` |
+| Claude | `claude-haiku-4-5` |
+| 阶跃星辰 | `step-2-mini` |
+| OpenRouter | `google/gemini-3.5-flash-lite` |
+
+更新模型列表不会覆盖你已保存的有效模型或自定义模型。DeepSeek 默认关闭思考；部分模型无法完全关闭思考时，使用其支持的最低档。更大的模型仍可手动选择，实际费用以服务商为准。
+
+DeepSeek 的新编号见[官方更新记录](https://api-docs.deepseek.com/updates/)；原来的 `deepseek-v4-flash` 仍可作为兼容别名使用。已下线的混元 `hy3-preview` 会更新为 `hy3`。
+
 选择已配置的服务和模型。常用列表里没有你的模型时，可以使用 **自定义模型**；模型名称从服务商提供的信息中复制。第三方提供兼容接口时，可在 **我的服务** 添加地址和模型。
 
 使用 Azure 时，模型一栏填写实际的 **部署名称**；地址填写自己的资源地址或服务商给出的完整接口地址。

--- a/docs/en/config/translation-engines.md
+++ b/docs/en/config/translation-engines.md
@@ -51,6 +51,22 @@ These settings apply only to the standalone DeepLX service. DeepLX in the free f
 
 ## AI services
 
+New configurations favor lightweight models for everyday translation:
+
+| Service | Default model |
+| --- | --- |
+| DeepSeek | `deepseek-flash` (V4.1 Flash) |
+| OpenAI | `gpt-5.4-mini` |
+| Gemini | `gemini-3.5-flash-lite` |
+| Qwen | `qwen3.8-flash` |
+| Claude | `claude-haiku-4-5` |
+| StepFun | `step-2-mini` |
+| OpenRouter | `google/gemini-3.5-flash-lite` |
+
+Catalog updates preserve your saved supported and custom models. Thinking is off by default for DeepSeek; models that cannot disable it use their lowest supported level. Larger models remain available for manual selection. Charges depend on the provider.
+
+See the [DeepSeek changelog](https://api-docs.deepseek.com/updates/) for the new ID. The previous `deepseek-v4-flash` ID remains available as a compatibility alias. The retired Hunyuan `hy3-preview` is migrated to `hy3`.
+
 Select a configured service and model. Use the custom-model option if yours is not listed. For a compatible third-party endpoint, add the address and model under your custom services.
 
 For Azure, enter the actual deployment name as the model and your resource or complete API address as the endpoint.

--- a/docs/reports/model-catalog-20260912.md
+++ b/docs/reports/model-catalog-20260912.md
@@ -1,0 +1,44 @@
+# 翻译模型目录核对（2026-09-12）
+
+本次按原厂 API 文档、聚合平台公开模型接口核对模型编号。新配置优先选择 Mini、Flash-Lite、Haiku 等轻量或低成本型号；没有明确小模型档位或缺少当前接口证据的服务保留原默认。模型能力和价格属于厂商公开描述，本次没有用用户密钥进行真实翻译质量或速度对比。
+
+## 已实施
+
+| 服务 | 默认及候选调整 | 官方依据 |
+| --- | --- | --- |
+| DeepSeek | 默认改为 `deepseek-flash`，对应 9 月 10 日发布的 V4.1 Flash；保留 `deepseek-v4-pro` 和旧 `deepseek-v4-flash` 兼容别名 | [更新记录](https://api-docs.deepseek.com/updates/)、[模型与计费](https://api-docs.deepseek.com/quick_start/pricing/) |
+| OpenAI | 默认从 Luna 改为 `gpt-5.4-mini`；Nano 可选，新增 `gpt-6-astra` 为大模型候选 | [Mini](https://developers.openai.com/api/docs/models/gpt-5.4-mini)、[Astra](https://developers.openai.com/api/docs/models/gpt-6-astra) |
+| Azure、自定义兼容服务、New API | 初始建议改为 `gpt-5.4-mini`；Azure 仍需要填写实际部署名称，自建网关仍以其模型列表为准 | [Azure 模型](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models) |
+| Gemini | 默认改为 `gemini-3.5-flash-lite`；新增 3.7/3.8 Flash，保留既有可选型号 | [模型目录](https://ai.google.dev/gemini-api/docs/models) |
+| 通义 | 默认改为 `qwen3.8-flash`；补入 3.7 Flash、3.8 Max，保留 3.6 Flash、Qwen-MT 与既有套餐候选 | [文本模型目录](https://help.aliyun.com/zh/model-studio/model-list-text-generation/) |
+| Claude | 默认仍为 `claude-haiku-4-5`；新增 `claude-fable-5-1` | [Haiku 及别名](https://platform.claude.com/docs/en/models/haiku-4-5/overview)、[Fable 5.1](https://platform.claude.com/docs/en/models/fable-5-1/overview) |
+| 阶跃 | 默认改为极速文本型号 `step-2-mini`；新增 `step-3.5-flash-2603`，保留原 Flash 与其他候选 | [模型总览](https://platform.stepfun.com/docs/zh/guides/models/overview)、[Chat API](https://platform.stepfun.com/docs/zh/api-reference/chat/chat-completion-create) |
+| 混元 | 默认保持 `hy3`；移除已于 8 月 31 日下线的 `hy3-preview` 预设，并迁移到 `hy3` | [下线公告](https://cloud.tencent.com/announce/detail/2391) |
+| GLM | 保持 `glm-4.5-flash` 默认，清除重复的 `glm-5.3` 目录项 | [GLM 发布记录](https://docs.bigmodel.cn/cn/update/new-releases) |
+| Grok | 新增 `grok-4.6` 供手动选择；没有确认更小的当前档位，保留原默认和旧选择 | [官方目录](https://docs.x.ai/developers/models) |
+| OpenRouter | 默认改为 `google/gemini-3.5-flash-lite`；新增 `deepseek/deepseek-v4.1-flash`、`openai/gpt-5.4-mini`、`openai/gpt-6-astra`、`x-ai/grok-4.6` | [公开 Models API](https://openrouter.ai/api/v1/models) |
+| Infini | 继续使用平台自身的 `deepseek-v4-flash`；解除与 DeepSeek 原厂最新编号的共用关系 | 原厂升级不能证明该平台提供同名路由；本轮未更改平台模型 ID |
+
+## 保留项和证据边界
+
+- MiniMax 继续默认 `MiniMax-M2.7-highspeed`，官方确认该速度档有效；MiMo 继续 `mimo-v2.5`，混元翻译继续 `hunyuan-translation-lite`。分别核对 [MiniMax 文本 API](https://platform.minimaxi.com/docs/guides/text-generation)、[MiMo 模型指南](https://platform.xiaomimimo.com/docs/en-US/usage-guide/passing-back-reasoning_content)、[混元翻译 API](https://cloud.tencent.com/document/product/1729/113395)。没有因某个文档页面未列出既有 M3/M3.1 就将其判为退役。
+- Groq 保持 `openai/gpt-oss-20b` 默认；不重新添加会被现有迁移规则替换的 Llama 别名。[Groq 模型目录](https://console.groq.com/docs/models)
+- 豆包官方示例确认 `doubao-seed-2-0-lite-260215` 的 Responses 调用；本轮没有取得最新 Mini/Lite 的 Chat 接口契约，因此保留当前目录。产品展示名称不能直接作为请求编号。[方舟官方示例](https://www.volcengine.com/docs/82379/1795150)
+- Kimi、文心、百川、零一、Infini 和硅基流动未取得足以替换现有型号的当前接口证据，保留原列表与默认。特别是聚合平台不能从原厂编号推测支持情况，也不能把旧版官方文档当成新模型下线证明。
+- 本次没有把网页聊天产品名称、语音、图像生成或专用编码模型自动加入翻译默认。OpenRouter 的公开目录证明编号存在，不证明具体账户调用成功。
+
+## 配置与请求行为
+
+网页和文档默认都来自同一份目录。已有有效选择、自定义模型、模型级 Thinking 偏好和密钥要求保持不变；旧 `deepseek-chat` / `deepseek-reasoner` 继续按原规则迁移，只把目的型号更新为 `deepseek-flash`。旧 V4 Flash 别名保持原编号和其独立偏好。混元预览版迁移同时覆盖网页、文档与模型级偏好。
+
+DeepSeek Chat 显式发送 `thinking.type=disabled`，Responses 发送 `reasoning.effort=none`，避免使用厂商默认开启的思考。Gemini 3.8 Flash 的最低档是 `low`；GPT-6 Astra 同样使用最低 `low`，不会向它发送不支持的 `none`。GPT-5.4 Mini 保持 `none`，Qwen Flash 保持 `enable_thinking=false`。具体来源：[DeepSeek Thinking](https://api-docs.deepseek.com/guides/thinking_mode/)、[Gemini Thinking](https://ai.google.dev/gemini-api/docs/thinking)、[OpenAI Astra](https://developers.openai.com/api/docs/models/gpt-6-astra)。自定义请求体仍有最终覆盖权。
+
+测试覆盖新默认、目录去重、原厂与聚合商编号分离、旧配置与自定义模型保留、停服型号迁移，以及新旧 DeepSeek 编号的两种请求协议。无参考仓库代码或依赖被引入。
+
+## 验证结果
+
+- 最终完整覆盖率回归：227 个文件、4669 个测试通过，statements / branches / functions / lines 均为 100%。
+- 架构检查：27 个文件、897 个测试通过；测试审计和 TypeScript/Vue 类型检查通过。
+- Chrome、Firefox、userscript 构建与 userscript verifier 通过；中英文文档构建通过。
+- 首次完整回归曾出现 `configStorage.test.ts` 中一项存储恢复断言失败；独立干净基线的该文件 28/28 通过，最终完整回归也通过。未修改存储实现或放宽该断言，不能将首次结果定性为稳定基线缺陷。
+- 本次是官方目录核对、确定性测试和构建验证，没有使用账户密钥认证外部模型，也没有进行真实供应商译文质量测评或浏览器运行时测试。

--- a/docs/reports/model-catalog-20260912.md
+++ b/docs/reports/model-catalog-20260912.md
@@ -38,7 +38,9 @@ DeepSeek Chat 显式发送 `thinking.type=disabled`，Responses 发送 `reasonin
 ## 验证结果
 
 - 最终完整覆盖率回归：227 个文件、4669 个测试通过，statements / branches / functions / lines 均为 100%。
-- 架构检查：27 个文件、897 个测试通过；测试审计和 TypeScript/Vue 类型检查通过。
+- 架构检查：27 个文件、899 个测试通过；测试审计和 TypeScript/Vue 类型检查通过。
 - Chrome、Firefox、userscript 构建与 userscript verifier 通过；中英文文档构建通过。
 - 首次完整回归曾出现 `configStorage.test.ts` 中一项存储恢复断言失败；独立干净基线的该文件 28/28 通过，最终完整回归也通过。未修改存储实现或放宽该断言，不能将首次结果定性为稳定基线缺陷。
 - 本次是官方目录核对、确定性测试和构建验证，没有使用账户密钥认证外部模型，也没有进行真实供应商译文质量测评或浏览器运行时测试。
+
+合并前同步了主分支的油猴 Dexie 修复，补齐上游新增测试的 regression 分组登记；该修复相关的 19 项检查通过，并重新完成上述完整回归与构建。

--- a/src/core/config/catalog.ts
+++ b/src/core/config/catalog.ts
@@ -248,6 +248,7 @@ export function resolveConfiguredModel(selectedModel?: string, customModel?: str
     return selectedModel === customModelString ? customModel || '' : selectedModel || '';
 }
 
+// 2026-09-12 核对官方目录；来源与选型依据见 docs/reports/model-catalog-20260912.md。
 // 当前官方模型编号的单一来源，同时供列表和旧配置迁移使用。
 export const currentModelIds = {
     openai: "gpt-5.6-luna",
@@ -260,7 +261,8 @@ export const currentModelIds = {
     claudeSonnet: "claude-sonnet-5",
     claudeOpus: "claude-opus-5",
     claudeHaiku: "claude-haiku-4-5",
-    deepseek: "deepseek-v4-flash",
+    deepseek: "deepseek-flash",
+    infiniDeepseek: "deepseek-v4-flash",
     minimax: "MiniMax-M2.7",
     mimo: "mimo-v2.5-pro",
     jieyue: "step-3.5-flash",
@@ -277,60 +279,61 @@ export const currentModelIds = {
 // 各 AI 服务的开箱默认模型优先选择近期、低延迟或低成本档位。
 // currentModelIds 仍作为官方编号与旧配置迁移的单一来源；用户仍可在模型列表中主动选择更大的模型。
 export const defaultModelIds = {
-    [services.openai]: currentModelIds.openai,
-    [services.azureOpenai]: currentModelIds.openai,
-    [services.gemini]: "gemini-3.6-flash",
+    [services.openai]: "gpt-5.4-mini",
+    [services.azureOpenai]: "gpt-5.4-mini",
+    [services.gemini]: "gemini-3.5-flash-lite",
     [services.yiyan]: currentModelIds.yiyanFast,
-    [services.tongyi]: "qwen3.6-flash",
+    [services.tongyi]: "qwen3.8-flash",
     [services.zhipu]: currentModelIds.zhipuFlash,
     [services.moonshot]: currentModelIds.moonshotCompatible,
     [services.claude]: currentModelIds.claudeHaiku,
-    [services.custom]: currentModelIds.openai,
-    [services.infini]: currentModelIds.deepseek,
+    [services.custom]: "gpt-5.4-mini",
+    [services.infini]: currentModelIds.infiniDeepseek,
     [services.baichuan]: "Baichuan-M3",
     [services.lingyi]: "yi-lightning",
     [services.deepseek]: currentModelIds.deepseek,
     [services.minimax]: "MiniMax-M2.7-highspeed",
     [services.mimo]: "mimo-v2.5",
-    [services.jieyue]: currentModelIds.jieyue,
+    [services.jieyue]: "step-2-mini",
     [services.huanYuan]: currentModelIds.huanYuan,
     [services.huanYuanTranslation]: "hunyuan-translation-lite",
-    [services.newapi]: currentModelIds.openai,
+    [services.newapi]: "gpt-5.4-mini",
     [services.grok]: "grok-4.3",
     [services.doubao]: "doubao-seed-1-6-250615",
     [services.siliconCloud]: "deepseek-ai/DeepSeek-V4-Flash",
     [services.groq]: currentModelIds.groqSmall,
-    [services.openrouter]: "google/gemini-3.6-flash",
+    [services.openrouter]: "google/gemini-3.5-flash-lite",
 } as const;
 
 export const models = new Map<string, Array<string>>([
-    [services.openai, [currentModelIds.openai, "gpt-5.4-mini", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5", "gpt-5.4-nano", "gpt-5-mini", "gpt-5-nano", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", customModelString]],
-    [services.azureOpenai, [currentModelIds.openai, "gpt-5.4-mini", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5", "gpt-5.4-nano", "gpt-5-mini", "gpt-5-nano", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", customModelString]],
-    [services.gemini, [defaultModelIds[services.gemini], "gemini-3.5-flash", "gemini-3.5-flash-lite", "gemini-3.1-pro-preview", "gemini-3.1-flash-lite", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro", customModelString]],
+    [services.openai, [defaultModelIds[services.openai], "gpt-5.4-nano", "gpt-6-astra", currentModelIds.openai, "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5", "gpt-5-mini", "gpt-5-nano", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", customModelString]],
+    [services.azureOpenai, [defaultModelIds[services.azureOpenai], currentModelIds.openai, "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5", "gpt-5.4-nano", "gpt-5-mini", "gpt-5-nano", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", customModelString]],
+    [services.gemini, [defaultModelIds[services.gemini], "gemini-3.8-flash", "gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash", "gemini-3.1-pro-preview", "gemini-3.1-flash-lite", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro", customModelString]],
     [services.yiyan, [defaultModelIds[services.yiyan], currentModelIds.yiyan, "ernie-5.0-thinking-preview", "ernie-x1.1-preview", "ernie-4.5-turbo-128k", "ernie-4.5-21b-a3b", customModelString]],
-    [services.tongyi, [defaultModelIds[services.tongyi], currentModelIds.tongyiTokenPlan, "qwen3.7-max", "qwen3.7-plus", "qwen-mt-plus", "qwen-mt-turbo", "qwen-mt-flash", "qwen-mt-lite", "qwen-long-latest", customModelString]],
-    [services.zhipu, [defaultModelIds[services.zhipu], currentModelIds.zhipu, "glm-5.3-flash","glm-5.3","glm-5.2", "glm-5.1", "glm-5-turbo", "glm-5", "glm-4.7", customModelString]],
+    [services.tongyi, [defaultModelIds[services.tongyi], "qwen3.7-flash", "qwen3.6-flash", "qwen3.8-max", currentModelIds.tongyiTokenPlan, "qwen3.7-max", "qwen3.7-plus", "qwen-mt-plus", "qwen-mt-turbo", "qwen-mt-flash", "qwen-mt-lite", "qwen-long-latest", customModelString]],
+    [services.zhipu, [defaultModelIds[services.zhipu], currentModelIds.zhipu, "glm-5.3-flash", "glm-5.2", "glm-5.1", "glm-5-turbo", "glm-5", "glm-4.7", customModelString]],
     [services.moonshot, [defaultModelIds[services.moonshot], currentModelIds.moonshot, "kimi-k2.7-code-highspeed", "kimi-k2.7-code", "kimi-k2.5", customModelString]],
-    [services.claude, [defaultModelIds[services.claude], currentModelIds.claude, currentModelIds.claudeOpus, currentModelIds.claudeSonnet, "claude-opus-4-8", "claude-sonnet-4-6", customModelString]],
-    [services.custom, [currentModelIds.openai, "gpt-5.4-mini", "gpt-5.6-sol", "gemini-3.6-flash", currentModelIds.claude, currentModelIds.deepseek, "gemma:7b", "llama2:7b", "mistral:7b", customModelString]],
+    [services.claude, [defaultModelIds[services.claude], "claude-fable-5-1", currentModelIds.claude, currentModelIds.claudeOpus, currentModelIds.claudeSonnet, "claude-opus-4-8", "claude-sonnet-4-6", customModelString]],
+    [services.custom, [defaultModelIds[services.custom], currentModelIds.openai, "gpt-5.6-sol", "gemini-3.6-flash", currentModelIds.claude, currentModelIds.deepseek, "gemma:7b", "llama2:7b", "mistral:7b", customModelString]],
     [services.infini, [defaultModelIds[services.infini], "deepseek-v4-pro", currentModelIds.infiniZhipu, "kimi-k2.7-code", currentModelIds.infiniGeneral, "qwen3.6-35b-a3b", customModelString]],
     [services.baichuan, [defaultModelIds[services.baichuan], "Baichuan-M3-Plus", "Baichuan4-Air", "Baichuan4-Turbo", "Baichuan4", customModelString]],
     [services.lingyi, [defaultModelIds[services.lingyi], customModelString]],
-    [services.deepseek, [currentModelIds.deepseek, "deepseek-v4-pro", customModelString]],
+    // 旧 Flash 编号仍由官方兼容路由，保留它以维持已保存的模型与 Thinking 偏好。
+    [services.deepseek, [currentModelIds.deepseek, "deepseek-v4-pro", "deepseek-v4-flash", customModelString]],
     [services.minimax, [defaultModelIds[services.minimax], "MiniMax-M3.1", "MiniMax-M3", currentModelIds.minimax, "MiniMax-M2.5", "MiniMax-M2.5-highspeed", customModelString]],
     [services.mimo, [defaultModelIds[services.mimo], currentModelIds.mimo, customModelString]],
-    [services.jieyue, [currentModelIds.jieyue, "step-3", "step-2", customModelString]],
-    [services.huanYuan, [currentModelIds.huanYuan, "hy3-preview", customModelString]],
+    [services.jieyue, [defaultModelIds[services.jieyue], "step-3.5-flash-2603", currentModelIds.jieyue, "step-3", "step-2", customModelString]],
+    [services.huanYuan, [currentModelIds.huanYuan, customModelString]],
     [services.huanYuanTranslation, [defaultModelIds[services.huanYuanTranslation], "hunyuan-translation", customModelString]],
-    [services.newapi, [currentModelIds.openai, "gpt-5.4-mini", "gpt-5.6-sol", "gemini-3.6-flash", "gemini-3.5-flash-lite", currentModelIds.claude, currentModelIds.deepseek, "kimi-k2.7-code", customModelString]],
-    [services.grok, [defaultModelIds[services.grok], currentModelIds.grok, customModelString]],
+    [services.newapi, [defaultModelIds[services.newapi], currentModelIds.openai, "gpt-5.6-sol", "gemini-3.6-flash", "gemini-3.5-flash-lite", currentModelIds.claude, currentModelIds.deepseek, "kimi-k2.7-code", customModelString]],
+    [services.grok, [defaultModelIds[services.grok], "grok-4.6", currentModelIds.grok, customModelString]],
     [services.doubao, ["doubao-seed-1-6-250615", customModelString]],
 
     // 混合模型。
     [services.siliconCloud, [defaultModelIds[services.siliconCloud], "deepseek-ai/DeepSeek-V4-Pro", "zai-org/GLM-5.2", "Qwen/Qwen3.6-27B", "Qwen/Qwen3.6-35B-A3B", "deepseek-ai/DeepSeek-V3.2", "deepseek-ai/DeepSeek-R1", customModelString]],
 
     [services.groq, [defaultModelIds[services.groq], currentModelIds.groqLarge, "qwen/qwen3.6-27b", customModelString]],
-    [services.openrouter, [defaultModelIds[services.openrouter], "openrouter/auto", "openai/gpt-5.6-luna", "openai/gpt-5.6-sol", "anthropic/claude-fable-5", "anthropic/claude-opus-5", "x-ai/grok-4.5", "deepseek/deepseek-v4-pro", "moonshotai/kimi-k3", "z-ai/glm-5.2", customModelString]]
+    [services.openrouter, [defaultModelIds[services.openrouter], "google/gemini-3.6-flash", "deepseek/deepseek-v4.1-flash", "openai/gpt-5.4-mini", "openai/gpt-6-astra", "x-ai/grok-4.6", "openrouter/auto", "openai/gpt-5.6-luna", "openai/gpt-5.6-sol", "anthropic/claude-fable-5", "anthropic/claude-opus-5", "x-ai/grok-4.5", "deepseek/deepseek-v4-pro", "moonshotai/kimi-k3", "z-ai/glm-5.2", customModelString]]
 ]);
 
 // 每个需要模型选择的 AI 服务都把列表第一项作为开箱即用的默认模型。

--- a/src/core/config/model.ts
+++ b/src/core/config/model.ts
@@ -478,6 +478,8 @@ const modelMigrations: Record<string, Record<string, string>> = {
         'step-1-8k': currentModelIds.jieyue,
     },
     [services.huanYuan]: {
+        // 官方已于 2026-08-31 下线预览版，迁移到正式版并复用模型级偏好迁移。
+        'hy3-preview': currentModelIds.huanYuan,
         'hunyuan-turbos-latest': currentModelIds.huanYuan,
         'hunyuan-t1-latest': currentModelIds.huanYuan,
         'hunyuan-a13b': currentModelIds.huanYuan,
@@ -864,7 +866,7 @@ export function normalizeConfig(value: unknown): Config {
         normalized.model[services.deepseek] = currentModelIds.deepseek;
         normalized.deepseekThinkingMode = 'disabled';
     } else if (selectedModel === 'deepseek-reasoner') {
-        // 官方迁移指南要求 reasoner 使用 v4-flash 并显式开启 thinking。
+        // 旧 reasoner 使用当前 Flash 模型，并显式保留 thinking 开启状态。
         normalized.model[services.deepseek] = currentModelIds.deepseek;
         normalized.deepseekThinkingMode = 'enabled';
     } else if (configuredThinkingMode !== 'enabled' && configuredThinkingMode !== 'disabled') {

--- a/src/services/translation/modelThinking.ts
+++ b/src/services/translation/modelThinking.ts
@@ -2,7 +2,7 @@
  * @file src/services/translation/modelThinking.ts
  *
  * 文件职责：把统一的模型级 Thinking 布尔偏好转换为已确认支持的供应商请求字段，避免向未知 OpenAI-compatible 网关猜测参数。
- * 主要内容：覆盖 DeepSeek Chat/Responses、通义混合思考模型、Gemini 各代最低档与动态档、Claude 自适应思考、Kimi K2.5/K2.6 以及明确支持 reasoning_effort 的 GPT 5.1+ 模型。
+ * 主要内容：覆盖 DeepSeek Chat/Responses、通义混合思考模型、Gemini 各代最低档与动态档、Claude 自适应思考、Kimi K2.5/K2.6 以及明确支持 reasoning_effort 的 GPT 5.1+ 与 GPT-6 Astra 模型。
  * 模块边界：本文件只修改调用方提供的公开请求 payload，不读取全局配置、不发起网络请求；未知服务或模型保持原样，自定义请求体仍由模板层最后合并并拥有覆盖权。
  */
 
@@ -56,7 +56,7 @@ function applyGeminiThinking(
     if (/^gemini-2\.5-pro(?:-|$)/u.test(normalized)) {
         return {effect: enabled ? 'toggle' : 'minimum', payload: withGenerationThinking(payload, {thinkingBudget: enabled ? -1 : 128})};
     }
-    if (/^gemini-3\.7[^/]*flash(?:-lite)?(?:-|$)/u.test(normalized)) {
+    if (/^gemini-3\.(?:7|8)[^/]*flash(?:-lite)?(?:-|$)/u.test(normalized)) {
         return {effect: enabled ? 'toggle' : 'minimum', payload: withGenerationThinking(payload, {thinkingLevel: enabled ? 'medium' : 'low'})};
     }
     if (/^gemini-3(?:\.(?:1|5|6))?-flash(?:-lite)?(?:-|$)/u.test(normalized)) {
@@ -130,6 +130,13 @@ function applyOpenAICompatibleThinking(
         return {
             effect: enabled ? 'toggle' : 'minimum',
             payload: {...payload, reasoning: {effort: enabled ? 'medium' : 'minimal'}},
+        };
+    }
+    if ((service === services.openai || service === services.azureOpenai)
+        && /^gpt-6-astra(?:-|$)/iu.test(model)) {
+        return {
+            effect: enabled ? 'toggle' : 'minimum',
+            payload: {...payload, reasoning_effort: 'low'},
         };
     }
     if ((service === services.openai || service === services.azureOpenai)

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -11,7 +11,7 @@ import {
     normalizeConfig,
 } from '@/src/core/config/model';
 import { getMimoEndpoint, MIMO_ENDPOINTS, MINIMAX_ENDPOINTS, tongyiTokenPlanUrl, urls } from '@/src/core/config/constants';
-import { customModelString, defaultModelIds, defaultModels, defaultOption, models, options, resolveConfiguredModel, services, servicesType } from '@/src/core/config/catalog';
+import { currentModelIds, customModelString, defaultModelIds, defaultModels, defaultOption, models, options, resolveConfiguredModel, services, servicesType } from '@/src/core/config/catalog';
 import {
     CUSTOM_OPENAI_RESERVED_MODEL_ID,
     MAX_CUSTOM_OPENAI_MODELS_PER_PROVIDER,
@@ -80,16 +80,16 @@ describe('AI 模型编号列表', () => {
     });
 
     it('展示当前主流模型，并移除已退役或错误的预设编号', () => {
-        expect(models.get(services.openai)?.at(0)).toBe('gpt-5.6-luna');
+        expect(models.get(services.openai)?.at(0)).toBe('gpt-5.4-mini');
         expect(models.get(services.openai)).toContain('gpt-5.6-sol');
         expect(models.get(services.openai)).not.toContain('gpt5');
         expect(models.get(services.gemini)).toContain('gemini-3.6-flash');
         expect(models.get(services.claude)).toContain('claude-fable-5');
         expect(models.get(services.claude)).toContain('claude-sonnet-5');
         expect(models.get(services.claude)?.at(-1)).toBe(customModelString);
-        expect(models.get(services.tongyi)?.at(0)).toBe('qwen3.6-flash');
+        expect(models.get(services.tongyi)?.at(0)).toBe('qwen3.8-flash');
         expect(models.get(services.tongyi)).toContain('qwen3.7-max');
-        expect(models.get(services.tongyi)).not.toContain('qwen3.7-flash');
+        expect(models.get(services.tongyi)).toContain('qwen3.7-flash');
         expect(models.get(services.zhipu)?.at(0)).toBe('glm-4.5-flash');
         expect(models.get(services.zhipu)).toContain('glm-5.2');
         expect(models.get(services.infini)).toContain('glm-5.2');
@@ -208,6 +208,71 @@ describe('AI 模型编号列表', () => {
             expect(defaultModels.get(service), `${service} 默认模型`).toBe(defaultModel);
             expect(models.get(service)?.at(0), `${service} 模型列表首项`).toBe(defaultModel);
         }
+    });
+
+    it('刷新后的网页和文档默认使用轻量模型，目录没有重复编号', () => {
+        const expected = {
+            [services.openai]: 'gpt-5.4-mini',
+            [services.azureOpenai]: 'gpt-5.4-mini',
+            [services.gemini]: 'gemini-3.5-flash-lite',
+            [services.deepseek]: 'deepseek-flash',
+            [services.infini]: 'deepseek-v4-flash',
+            [services.tongyi]: 'qwen3.8-flash',
+            [services.claude]: 'claude-haiku-4-5',
+            [services.jieyue]: 'step-2-mini',
+            [services.openrouter]: 'google/gemini-3.5-flash-lite',
+        };
+        for (const config of [new Config(), normalizeConfig({}), normalizeConfig({model: {}, documentModel: {}})]) {
+            expect(config.model).toMatchObject(expected);
+            expect(config.documentModel).toMatchObject(expected);
+            expect(config.deepseekThinkingMode).toBe('disabled');
+        }
+        for (const [service, choices] of models) {
+            expect(new Set(choices).size, service).toBe(choices.length);
+        }
+        expect(models.get(services.infini)).not.toContain('deepseek-flash');
+        expect(models.get(services.openrouter)).toContain('deepseek/deepseek-v4.1-flash');
+        expect(models.get(services.openrouter)).not.toContain('deepseek-flash');
+    });
+
+    it('已下线的混元预览版迁移到正式版，保留网页和文档的思考偏好', () => {
+        const normalized = normalizeConfig({
+            model: {[services.huanYuan]: 'hy3-preview'},
+            documentModel: {[services.huanYuan]: 'hy3-preview'},
+            modelThinking: {[services.huanYuan]: {'hy3-preview': false}},
+        });
+        expect(normalized.model[services.huanYuan]).toBe('hy3');
+        expect(normalized.documentModel[services.huanYuan]).toBe('hy3');
+        expect(normalized.modelThinking[services.huanYuan]).toEqual({hy3: false});
+        expect(models.get(services.huanYuan)).not.toContain('hy3-preview');
+    });
+
+    it('刷新默认不覆盖已选模型、DeepSeek 兼容别名、密钥要求及自定义模型', () => {
+        const saved = {
+            ...new Config(),
+            model: {
+                [services.openai]: 'gpt-5.6-luna',
+                [services.gemini]: 'gemini-3.6-flash',
+                [services.tongyi]: 'qwen3.6-flash',
+                [services.deepseek]: 'deepseek-v4-flash',
+            },
+            documentModel: {
+                [services.deepseek]: 'deepseek-v4-pro',
+                [services.openai]: customModelString,
+            },
+            documentCustomModel: {[services.openai]: 'private-document-model'},
+            customModels: {[services.openai]: ['private-document-model']},
+            modelThinking: {[services.deepseek]: {'deepseek-v4-flash': true, 'deepseek-v4-pro': false}},
+            requireApiKey: {'deepseek:deepseek-v4-flash': false},
+        };
+        const normalized = normalizeConfig(saved);
+        expect(normalized.model).toMatchObject(saved.model);
+        expect(normalized.documentModel).toMatchObject(saved.documentModel);
+        expect(normalized.documentCustomModel).toEqual(saved.documentCustomModel);
+        expect(normalized.customModels).toEqual(saved.customModels);
+        expect(normalized.modelThinking).toEqual(saved.modelThinking);
+        expect(normalized.requireApiKey).toEqual(saved.requireApiKey);
+        expect(normalizeConfig(normalized)).toEqual(normalized);
     });
 
     it('把旧自定义接口迁移为 profile，并保留地址、实际模型和其他按服务配置', () => {
@@ -1107,12 +1172,12 @@ describe('旧模型编号兼容迁移', () => {
         const chat = normalizeConfig({model: {[services.deepseek]: 'deepseek-chat'}});
         const reasoner = normalizeConfig({model: {[services.deepseek]: 'deepseek-reasoner'}});
 
-        expect(chat.model[services.deepseek]).toBe('deepseek-v4-flash');
+        expect(chat.model[services.deepseek]).toBe('deepseek-flash');
         expect(chat.deepseekThinkingMode).toBe('disabled');
-        expect(chat.modelThinking[services.deepseek]).toEqual({'deepseek-v4-flash': false});
-        expect(reasoner.model[services.deepseek]).toBe('deepseek-v4-flash');
+        expect(chat.modelThinking[services.deepseek]).toEqual({'deepseek-flash': false});
+        expect(reasoner.model[services.deepseek]).toBe('deepseek-flash');
         expect(reasoner.deepseekThinkingMode).toBe('enabled');
-        expect(reasoner.modelThinking[services.deepseek]).toEqual({'deepseek-v4-flash': true});
+        expect(reasoner.modelThinking[services.deepseek]).toEqual({'deepseek-flash': true});
     });
 
     it('模型 Thinking 默认关闭，并规范化迁移可达模型状态', () => {
@@ -1124,7 +1189,7 @@ describe('旧模型编号兼容迁移', () => {
             modelThinking: {
                 [services.openai]: {
                     gpt5: true,
-                    [defaultModelIds[services.openai]]: false,
+                    [currentModelIds.openai]: false,
                     'private-model': true,
                     orphan: true,
                     invalid: 'yes',
@@ -1136,7 +1201,7 @@ describe('旧模型编号兼容迁移', () => {
 
         expect(normalized.modelThinking).toEqual({
             [services.openai]: {
-                [defaultModelIds[services.openai]]: false,
+                [currentModelIds.openai]: false,
                 'private-model': true,
             },
         });
@@ -1157,11 +1222,11 @@ describe('旧模型编号兼容迁移', () => {
             ...new Config(),
             modelThinking: {[services.openai]: {
                 gpt5: true,
-                [defaultModelIds[services.openai]]: false,
+                [currentModelIds.openai]: false,
             }},
         });
         expect(officialLegacyName.modelThinking[services.openai])
-            .toEqual({[defaultModelIds[services.openai]]: false});
+            .toEqual({[currentModelIds.openai]: false});
     });
 
     it('显式模型级 DeepSeek 值覆盖旧服务级开关并迁移旧模型键', () => {
@@ -1175,12 +1240,12 @@ describe('旧模型编号兼容迁移', () => {
         const legacyKey = normalizeConfig({
             modelThinking: {[services.deepseek]: {'deepseek-reasoner': true}},
         });
-        expect(legacyKey.modelThinking[services.deepseek]).toEqual({'deepseek-v4-flash': true});
+        expect(legacyKey.modelThinking[services.deepseek]).toEqual({'deepseek-flash': true});
 
         const legacyChatKey = normalizeConfig({
             modelThinking: {[services.deepseek]: {'deepseek-chat': false}},
         });
-        expect(legacyChatKey.modelThinking[services.deepseek]).toEqual({'deepseek-v4-flash': false});
+        expect(legacyChatKey.modelThinking[services.deepseek]).toEqual({'deepseek-flash': false});
     });
 
     it('动态自定义服务只保留 profile 中仍可达模型的 Thinking 状态', () => {

--- a/tests/modelThinking.test.ts
+++ b/tests/modelThinking.test.ts
@@ -75,16 +75,19 @@ describe('模型 Thinking 协议映射', () => {
         payload: Record<string, unknown> = {model},
     ) => applyModelThinkingPreference(payload, {protocol, service, model, enabled});
 
-    it('映射 DeepSeek Chat 和 Responses 的开关字段', () => {
-        expect(apply('deepseek-chat', services.deepseek, 'deepseek-v4-flash', true)).toEqual({
+    it.each(['deepseek-v4-flash', 'deepseek-flash'])('映射 DeepSeek Chat 的 %s 开关字段', (model) => {
+        expect(apply('deepseek-chat', services.deepseek, model, true)).toEqual({
             effect: 'toggle',
-            payload: {model: 'deepseek-v4-flash', thinking: {type: 'enabled'}},
+            payload: {model, thinking: {type: 'enabled'}},
         });
-        expect(apply('deepseek-chat', services.deepseek, 'deepseek-v4-flash', false).payload)
+        expect(apply('deepseek-chat', services.deepseek, model, false).payload)
             .toMatchObject({thinking: {type: 'disabled'}});
-        expect(apply('deepseek-responses', services.deepseek, 'deepseek-v4-flash', true).payload)
+    });
+
+    it.each(['deepseek-v4-flash', 'deepseek-flash'])('映射 DeepSeek Responses 的 %s 开关字段', (model) => {
+        expect(apply('deepseek-responses', services.deepseek, model, true).payload)
             .toMatchObject({reasoning: {effort: 'high'}});
-        expect(apply('deepseek-responses', services.deepseek, 'deepseek-v4-flash', false).payload)
+        expect(apply('deepseek-responses', services.deepseek, model, false).payload)
             .toMatchObject({reasoning: {effort: 'none'}});
     });
 
@@ -108,6 +111,8 @@ describe('模型 Thinking 协议映射', () => {
         ['gemini-2.5-pro', false, 'minimum', {thinkingBudget: 128}],
         ['gemini-3.7-flash', true, 'toggle', {thinkingLevel: 'medium'}],
         ['gemini-3.7-flash', false, 'minimum', {thinkingLevel: 'low'}],
+        ['gemini-3.8-flash', true, 'toggle', {thinkingLevel: 'medium'}],
+        ['gemini-3.8-flash', false, 'minimum', {thinkingLevel: 'low'}],
         ['gemini-3-flash', false, 'minimum', {thinkingLevel: 'minimal'}],
         ['gemini-3.1-flash-lite', true, 'toggle', {thinkingLevel: 'medium'}],
         ['gemini-3.5-flash', false, 'minimum', {thinkingLevel: 'minimal'}],
@@ -218,6 +223,10 @@ describe('模型 Thinking 协议映射', () => {
     });
 
     it('只给已确认的 OpenAI、OpenRouter 与 Kimi 模型添加兼容字段', () => {
+        expect(apply('openai-chat', services.openai, 'gpt-6-astra', true).payload)
+            .toMatchObject({reasoning_effort: 'low'});
+        expect(apply('openai-chat', services.openai, 'gpt-6-astra', false))
+            .toMatchObject({effect: 'minimum', payload: {reasoning_effort: 'low'}});
         expect(apply('openai-chat', services.openai, 'gpt-5.6-luna', true).payload)
             .toMatchObject({reasoning_effort: 'low'});
         expect(apply('openai-chat', services.azureOpenai, 'gpt-5.1', false).payload)

--- a/tests/template.test.ts
+++ b/tests/template.test.ts
@@ -297,6 +297,26 @@ describe('模型级 Thinking 请求集成', () => {
         expect(body.reasoning_effort).toBe('low');
     });
 
+    it.each(['deepseek-flash', 'deepseek-v4-flash'])(
+        'DeepSeek %s 在 Chat 和 Responses 中发送正确编号并默认关闭思考', (model) => {
+            mockConfig.service = services.deepseek;
+            mockConfig.model.deepseek = model;
+            expect(JSON.parse(deepseekMsgTemplate('hello'))).toMatchObject({
+                model, thinking: {type: 'disabled'},
+            });
+            expect(JSON.parse(deepseekResponsesMsgTemplate('hello'))).toMatchObject({
+                model, reasoning: {effort: 'none'},
+            });
+            mockConfig.modelThinking = {deepseek: {[model]: true}};
+            expect(JSON.parse(deepseekMsgTemplate('hello'))).toMatchObject({
+                model, thinking: {type: 'enabled'},
+            });
+            expect(JSON.parse(deepseekResponsesMsgTemplate('hello'))).toMatchObject({
+                model, reasoning: {effort: 'high'},
+            });
+        },
+    );
+
     it('DeepSeek 模型级显式 false 覆盖旧服务级 enabled', () => {
         mockConfig.service = services.deepseek;
         mockConfig.model.deepseek = 'deepseek-v4-flash';

--- a/tests/test-matrix.json
+++ b/tests/test-matrix.json
@@ -286,6 +286,7 @@
       "tests/translationDocumentCorpus.test.ts",
       "tests/translationTruncation.test.ts",
       "tests/userscriptCredentialPersistence.test.ts",
+      "tests/userscriptDexieIsolation.test.ts",
       "tests/vocabularyBookComponentLifecycle.test.ts",
       "tests/allNodesTranslationCore.test.ts"
     ]


### PR DESCRIPTION
更新翻译模型目录，让新配置优先选择轻量型号。DeepSeek 默认由 `deepseek-v4-flash` 更新为官方 V4.1 Flash 编号 `deepseek-flash`；OpenAI 使用 `gpt-5.4-mini`，Gemini/OpenRouter 使用 Flash-Lite，通义使用 `qwen3.8-flash`，阶跃使用 `step-2-mini`。同时补齐已核实的新模型候选，清除重复项。

保留已有有效模型、自定义模型和模型级思考偏好；Infini 继续使用平台自己的 DeepSeek 编号。已下线的 `hy3-preview` 迁移到 `hy3`。新型号按官方协议关闭思考或使用最低合法档，中英文使用说明及逐厂商来源记录同步更新，详见 `docs/reports/model-catalog-20260912.md`。

同步最新主分支后，补齐上游新增 `userscriptDexieIsolation.test.ts` 的 regression 分组登记，修复测试审计遗漏；该补充不改变油猴功能代码。

验证：

- 完整覆盖率回归：227 个文件、4669 个测试通过，四维覆盖率均为 100%。
- 架构检查：27 个文件、899 个测试通过；测试审计、TypeScript/Vue 类型检查通过。
- Chrome、Firefox、userscript 构建和 userscript verifier 通过；文档构建通过。
- 最新主分支的油猴 Dexie、Vite 配置及快捷键相关 19 项检查通过。
- 首轮存储恢复测试曾出现一次失败，干净基线该文件 28/28 通过，最终完整回归也通过；没有修改存储逻辑或放宽断言。

模型编号依据官方文档及公开模型目录核对；没有使用账户密钥进行真实供应商译文质量测评，也没有将构建验证表述为真实浏览器验证。
