### PR TITLE
feat(settings): let advanced settings turn page title translation off

### DIFF
--- a/src/core/config/diff.ts
+++ b/src/core/config/diff.ts
@@ -512,6 +512,7 @@ const FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     translationBackoffMaxMs: {group: 'advanced', label: '退避最大间隔', format: (value) => formatNumber(value, ' ms')},
     animations: {group: 'advanced', label: '动画效果', format: formatBoolean},
     translationScope: {group: 'advanced', label: '识别全部节点', format: (value) => formatEnum(value, TRANSLATION_SCOPE_LABELS)},
+    pageTitleTranslationEnabled: {group: 'advanced', label: '翻译页面标题', format: formatBoolean},
     translationLoadingStyle: {group: 'advanced', label: '段落加载样式', format: (value) => formatEnum(value, TRANSLATION_LOADING_STYLE_LABELS)},
 
     documentService: {group: 'tools', label: '文档翻译服务', format: formatService},

--- a/src/core/config/model.ts
+++ b/src/core/config/model.ts
@@ -252,6 +252,7 @@ export class Config {
     enableAIMultiSegment: boolean; // 是否把相邻全文段落合并为一次 AI 翻译请求
     bilingualSentenceHighlightEnabled: boolean; // 是否在双语翻译中同步高亮原文与译文
     contextMenuEnabled: boolean; // 是否显示右键全文翻译菜单
+    pageTitleTranslationEnabled: boolean; // 全文翻译时是否一并翻译页面标题
     translationScope: TranslationScope; // 页面识别正文或全部可见界面文字
     fullPageTranslationMode: FullPageTranslationMode; // 全文翻译按视口加载或立即处理整页
     disableFloatingBall: boolean; // 是否禁用悬浮球
@@ -377,6 +378,7 @@ export class Config {
         this.enableAIMultiSegment = false; // 默认逐段请求，由用户按需开启 AI 多段翻译
         this.bilingualSentenceHighlightEnabled = false; // 默认关闭双语逐句高亮，避免改变现有网页视觉
         this.contextMenuEnabled = true; // 默认显示右键全文翻译入口
+        this.pageTitleTranslationEnabled = true; // 默认随全文翻译一并翻译标题，可在高级设置关闭
         this.translationScope = 'content'; // 默认只识别正文，全部节点由高级设置显式开启
         this.fullPageTranslationMode = 'viewport'; // 默认按阅读进度翻译，避免一次发出过多请求
         this.disableFloatingBall = true; // 默认关闭悬浮球
@@ -965,6 +967,9 @@ export function normalizeConfig(value: unknown): Config {
     normalized.imageTranslationContextMenuEnabled = typeof normalized.imageTranslationContextMenuEnabled === 'boolean' ? normalized.imageTranslationContextMenuEnabled : true;
     if (typeof normalized.contextMenuEnabled !== 'boolean') {
         normalized.contextMenuEnabled = true;
+    }
+    if (typeof normalized.pageTitleTranslationEnabled !== 'boolean') {
+        normalized.pageTitleTranslationEnabled = true;
     }
     if (!['viewport', 'all'].includes(normalized.fullPageTranslationMode)) {
         normalized.fullPageTranslationMode = 'viewport';

--- a/src/core/i18n/messages/en-US.ts
+++ b/src/core/i18n/messages/en-US.ts
@@ -318,6 +318,8 @@ export const enUSMessages = {
     "settings.pageRecognition.title": "Page recognition",
     "settings.pageRecognition.allNodes": "Detect all nodes",
     "settings.pageRecognition.description": "Translate menus, buttons, and node labels. Takes effect with the next translation.",
+    "settings.pageRecognition.pageTitle": "Translate page title",
+    "settings.pageRecognition.pageTitleDescription": "Translate the tab title along with the page, and restore it when the translation is undone.",
     'image.entries': "Entry points",
     'image.hover': "Image hover button",
     'image.hoverDescription': "Show a translate button in the lower-left corner when hovering over an image.",

--- a/src/core/i18n/messages/es-ES.ts
+++ b/src/core/i18n/messages/es-ES.ts
@@ -202,6 +202,8 @@ export const esESMessages = {
     "settings.pageRecognition.title": "Reconocimiento de la página",
     "settings.pageRecognition.allNodes": "Detectar todos los nodos",
     "settings.pageRecognition.description": "Traducir menús, botones y etiquetas de nodos. Se aplica a partir de la próxima traducción.",
+    "settings.pageRecognition.pageTitle": "Traducir el título de la página",
+    "settings.pageRecognition.pageTitleDescription": "Traducir el título de la pestaña junto con la página y restaurarlo al deshacer la traducción.",
     'image.entries': "Formas de acceso",
     'image.hover': "Botón al pasar el cursor",
     'image.hoverDescription': "Mostrar un botón de traducción abajo a la izquierda al pasar el cursor sobre una imagen.",

--- a/src/core/i18n/messages/fr-FR.ts
+++ b/src/core/i18n/messages/fr-FR.ts
@@ -202,6 +202,8 @@ export const frFRMessages = {
     "settings.pageRecognition.title": "Reconnaissance de la page",
     "settings.pageRecognition.allNodes": "Détecter tous les nœuds",
     "settings.pageRecognition.description": "Traduire les menus, boutons et libellés des nœuds. Prend effet à la prochaine traduction.",
+    "settings.pageRecognition.pageTitle": "Traduire le titre de la page",
+    "settings.pageRecognition.pageTitleDescription": "Traduire le titre de l'onglet avec la page et le restaurer lorsque la traduction est annulée.",
     'image.entries': "Modes d’accès",
     'image.hover': "Bouton au survol",
     'image.hoverDescription': "Afficher un bouton de traduction en bas à gauche au survol de l’image.",

--- a/src/core/i18n/messages/ja-JP.ts
+++ b/src/core/i18n/messages/ja-JP.ts
@@ -202,6 +202,8 @@ export const jaJPMessages = {
     "settings.pageRecognition.title": "ページ認識",
     "settings.pageRecognition.allNodes": "すべてのノードを検出",
     "settings.pageRecognition.description": "メニュー、ボタン、ノードのラベルを翻訳します。次回の翻訳から適用されます。",
+    "settings.pageRecognition.pageTitle": "ページタイトルを翻訳",
+    "settings.pageRecognition.pageTitleDescription": "全文翻訳時にタブのタイトルも翻訳し、翻訳を元に戻すと復元します。",
     'image.entries': "操作方法",
     'image.hover': "画像のホバーボタン",
     'image.hoverDescription': "画像にマウスを重ねると左下に翻訳ボタンを表示します。",

--- a/src/core/i18n/messages/ko-KR.ts
+++ b/src/core/i18n/messages/ko-KR.ts
@@ -202,6 +202,8 @@ export const koKRMessages = {
     "settings.pageRecognition.title": "페이지 인식",
     "settings.pageRecognition.allNodes": "모든 노드 인식",
     "settings.pageRecognition.description": "메뉴, 버튼, 노드 라벨을 번역합니다. 다음 번역부터 적용됩니다.",
+    "settings.pageRecognition.pageTitle": "페이지 제목 번역",
+    "settings.pageRecognition.pageTitleDescription": "전체 번역 시 탭 제목도 함께 번역하고, 번역을 취소하면 원래대로 복원합니다.",
     'image.entries': "실행 방법",
     'image.hover': "이미지 호버 버튼",
     'image.hoverDescription': "이미지 위에 마우스를 올리면 왼쪽 아래에 번역 버튼을 표시합니다.",

--- a/src/core/i18n/messages/ru-RU.ts
+++ b/src/core/i18n/messages/ru-RU.ts
@@ -202,6 +202,8 @@ export const ruRUMessages = {
     "settings.pageRecognition.title": "Распознавание страницы",
     "settings.pageRecognition.allNodes": "Найти все узлы",
     "settings.pageRecognition.description": "Переводить меню, кнопки и подписи узлов. Применяется со следующего перевода.",
+    "settings.pageRecognition.pageTitle": "Переводить заголовок страницы",
+    "settings.pageRecognition.pageTitleDescription": "Переводить заголовок вкладки вместе со страницей и восстанавливать его при отмене перевода.",
     'image.entries': "Способы запуска",
     'image.hover': "Кнопка при наведении",
     'image.hoverDescription': "Показывать кнопку перевода слева внизу при наведении на изображение.",

--- a/src/core/i18n/messages/zh-CN.ts
+++ b/src/core/i18n/messages/zh-CN.ts
@@ -317,6 +317,8 @@ export const zhCNMessages = {
     "settings.pageRecognition.title": "页面识别",
     "settings.pageRecognition.allNodes": "识别全部节点",
     "settings.pageRecognition.description": "翻译菜单、按钮和节点标签，下次翻译生效。",
+    "settings.pageRecognition.pageTitle": "翻译页面标题",
+    "settings.pageRecognition.pageTitleDescription": "全文翻译时一并翻译标签页标题，撤销翻译后自动还原。",
     'image.entries': "操作入口",
     'image.hover': "图片悬浮按钮",
     'image.hoverDescription': "鼠标移到图片上时，在左下角显示翻译按钮。",

--- a/src/features/full-page-translation/content/runtime.ts
+++ b/src/features/full-page-translation/content/runtime.ts
@@ -2090,8 +2090,9 @@ export function autoTranslateEnglishPage(invocation: PageTranslationInvocation =
 
     const session = createFullPageSession(root, invocation, inheritedConfig);
     fullPageSession = session;
-    // 标题不在正文候选范围内（<head> 属硬裁剪标签），单独随会话翻译并跟随 SPA 改写。
-    startFullPageTitleTranslation(session.translationConfig);
+    // 标题不在正文候选范围内（<head> 属硬裁剪标签），单独随会话翻译并跟随 SPA 改写；
+    // 高级设置可关闭，关闭后标签页保持原标题。
+    if (config.pageTitleTranslationEnabled !== false) startFullPageTitleTranslation(session.translationConfig);
     document.addEventListener('fluentread-open-shadow-root', (event) => {
         if (!session.active || fullPageSession !== session) return;
         const host = isElementNode(event.target as Node) ? event.target as Element : null;

--- a/src/features/settings/ui/SettingsSections.vue
+++ b/src/features/settings/ui/SettingsSections.vue
@@ -340,6 +340,9 @@
         <SettingsItem :label="t('settings.pageRecognition.allNodes')" :description="t('settings.pageRecognition.description')">
           <el-switch v-model="config.translationScope" active-value="all" inactive-value="content" class="settings-toggle" :aria-label="t('settings.pageRecognition.allNodes')" />
         </SettingsItem>
+        <SettingsItem :label="t('settings.pageRecognition.pageTitle')" :description="t('settings.pageRecognition.pageTitleDescription')">
+          <el-switch v-model="config.pageTitleTranslationEnabled" class="settings-toggle" :aria-label="t('settings.pageRecognition.pageTitle')" />
+        </SettingsItem>
       </SettingsGroup>
       <TranslationCacheSettings v-if="props.activeSection === 'settings-advanced'" :config="config" />
     </section>

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -856,6 +856,16 @@ describe('右键全文翻译配置', () => {
     });
 });
 
+describe('页面标题翻译配置', () => {
+    it('默认开启，并保留用户主动关闭的状态', () => {
+        expect(new Config().pageTitleTranslationEnabled).toBe(true);
+        expect(normalizeConfig({}).pageTitleTranslationEnabled).toBe(true);
+        expect(normalizeConfig({pageTitleTranslationEnabled: false}).pageTitleTranslationEnabled).toBe(false);
+        // 非布尔值（旧配置或被改坏的导入）回到默认开启，而不是被当成关闭。
+        expect(normalizeConfig({pageTitleTranslationEnabled: 'false'}).pageTitleTranslationEnabled).toBe(true);
+    });
+});
+
 describe('全文翻译范围配置', () => {
     it('默认按阅读进度翻译，并保留立即翻译整页的选择', () => {
         expect(new Config().fullPageTranslationMode).toBe('viewport');


### PR DESCRIPTION
## 背景

#141 让全文翻译会替换标签页标题，但没有关闭的途径。有人依赖原标题做书签、历史记录和标签页辨识，因此补一个开关。

## 改动

在**高级设置 → 页面识别**中新增「翻译页面标题」，与「识别全部节点」并列——两者都是在决定"页面有多少内容会被翻译"。

| 接线点 | 内容 |
|---|---|
| `model.ts` | `pageTitleTranslationEnabled` 字段、默认值、归一化 |
| `diff.ts` | 高级组的配置差异标签 |
| `SettingsSections.vue` | 页面识别组内的开关 |
| `i18n/messages/*` | 7 种语言各 2 条文案 |
| `runtime.ts` | `autoTranslateEnglishPage` 中的 gate |

**默认开启**，所以 #141 的既有行为不变，直到用户主动关闭。旧配置或被手工改坏的导入中若该字段不是布尔值，归一化会回到开启而不是被读成关闭。

gate 放在 `autoTranslateEnglishPage` 这个组装点，而不是标题模块内部——该模块的边界注释明确写了"不读取配置存储"，配置由调用方传入。这与 `contextMenuEnabled` 在 `contextMenuRuntime` 中的处理方式一致（两者同样都不在严格覆盖率清单内）。

关闭后对**下次**翻译生效；正在进行的会话保留已翻译的标题，撤销时仍会正常还原。这与相邻「识别全部节点」的"下次翻译生效"语义一致。

## 验证

- 新增 `normalizeConfig` 测试，覆盖默认开启、保留用户关闭、非布尔值回落三种情况
- 覆盖率门禁 `exit=0`，全局四维 **100%**（232 文件 / 4760 测试）
- 串行全量：**5836 测试全通过**
- `pnpm compile`、扩展构建、userscript 构建均通过

> 并行跑全量时 `translationCache`、`vocabularyBook` 等 fake-indexeddb 大数据量用例会撞 5s 超时，这是既有的负载敏感问题（此前已在纯净基线 worktree 上复现确认），与本 PR 无关，串行即全绿。

## 一处实现细节

`diff.ts` 的 `formatBoolean(value, inverted)` 第二个参数是**取反**而非默认值——`disableFloatingBall` 用它是因为字段语义是反的。本字段语义正向，因此直接传 `formatBoolean`，否则配置差异预览里的开关状态会显示反。

相关：#141

🤖 Generated with [Claude Code](https://claude.com/claude-code)
