### PR TITLE
feat: add community support to settings about page

### DIFF
--- a/scripts/testing/run-settings-center-ui-test.cjs
+++ b/scripts/testing/run-settings-center-ui-test.cjs
@@ -1404,6 +1404,46 @@ async function main() {
           report.assertions.independentAreaSettings = true;
         }
       }
+      if (id === 'settings-about') {
+        const supportPanel = anchor.locator('.about-support-panel');
+        const supportMethods = supportPanel.locator('.about-support-method');
+        if (await supportPanel.count() !== 1 || await supportMethods.count() !== 2) {
+          throw new Error('关于页缺少微信与 Ko-fi 两个赞赏入口');
+        }
+        const supportLinks = await supportMethods.evaluateAll(methods => methods.map(method => ({
+          provider: method.dataset.supportMethod,
+          href: method.getAttribute('href'),
+          text: method.textContent?.trim(),
+        })));
+        if (supportLinks[0]?.provider !== 'wechat' || supportLinks[0]?.href !== '/misc/approve.jpg'
+          || supportLinks[1]?.provider !== 'kofi' || supportLinks[1]?.href !== 'https://ko-fi.com/thinkstu') {
+          throw new Error(`关于页赞赏链接异常：${JSON.stringify(supportLinks)}`);
+        }
+        const qrBounds = await supportPanel.locator('.about-support-qr').boundingBox();
+        if (!qrBounds || qrBounds.width < 200 || qrBounds.height < 200) {
+          throw new Error(`关于页没有直接展示足够大的二维码：${JSON.stringify(qrBounds)}`);
+        }
+        const [qrPage] = await Promise.all([
+          context.waitForEvent('page', {timeout}),
+          supportPanel.locator('.about-support-wechat').click(),
+        ]);
+        await qrPage.waitForLoadState('domcontentloaded', {timeout});
+        if (!qrPage.url().endsWith('/misc/approve.jpg')) {
+          throw new Error(`点击二维码没有打开原图：${qrPage.url()}`);
+        }
+        await qrPage.close();
+        if (await supportPanel.locator('.about-support-original-link').count() !== 0) {
+          throw new Error('关于页仍显示多余的原图文字链接');
+        }
+        const supportCopy = await supportPanel.innerText();
+        if (!supportCopy.includes('FluentRead的发展离不开社区的慷慨支持，你可以通过微信赞赏或Ko-fi支持我们。')) {
+          throw new Error('关于页赞赏说明没有使用当前中文 i18n 文案');
+        }
+        if (await anchor.locator('.about-feature-list').count() !== 0) {
+          throw new Error('关于页仍显示已替换的核心体验列表');
+        }
+        report.assertions.aboutSupportArea = true;
+      }
       const visiblePageHeadings = await page.locator('.topbar h1:visible').count();
       if (visiblePageHeadings !== 1) throw new Error(`${id} 页面级标题数量异常：${visiblePageHeadings}`);
       if (await page.locator('.card-intro:visible').count() !== 0) throw new Error(`${id} 仍有重复 card intro`);

--- a/src/app/options/OptionsApp.vue
+++ b/src/app/options/OptionsApp.vue
@@ -64,14 +64,38 @@
           </div>
 
           <div class="about-grid">
-            <article class="about-panel">
-              <span class="about-panel-kicker">{{ t('options.aboutCoreExperience') }}</span>
-              <h3>{{ t('options.aboutBornForReading') }}</h3>
-              <p>{{ t('options.aboutCoreDescription') }}</p>
-              <div class="about-feature-list">
-                <span><b><UiIcon name="translate" :size="16" /></b>{{ t('options.aboutWebReading') }}</span>
-                <span><b><UiIcon name="book" :size="16" /></b>{{ t('options.aboutReadingTools') }}</span>
-                <span><b><UiIcon name="plug" :size="16" /></b>{{ t('options.aboutFlexibleServices') }}</span>
+            <article class="about-panel about-support-panel">
+              <span class="about-panel-kicker">{{ t('popup.donationEyebrow') }}</span>
+              <h3>{{ t('popup.donationTitle') }}</h3>
+              <p>{{ t('options.aboutThanks') }}</p>
+              <div class="about-support-options">
+                <section class="about-support-option about-support-wechat-option">
+                  <h4>{{ t('popup.donationWechat') }}</h4>
+                  <a
+                    class="about-support-method about-support-wechat"
+                    data-support-method="wechat"
+                    href="/misc/approve.jpg"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    :aria-label="t('popup.donationOpenCode')"
+                  >
+                    <img class="about-support-qr" src="/misc/approve.jpg" :alt="t('popup.donationCodeAlt')" width="1152" height="1152" />
+                  </a>
+                </section>
+                <section class="about-support-option about-support-kofi-option">
+                  <h4>Ko-fi</h4>
+                  <a
+                    class="about-support-method about-support-kofi-link"
+                    data-support-method="kofi"
+                    href="https://ko-fi.com/thinkstu"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <strong>{{ t('popup.donationKofi') }}</strong>
+                    <UiIcon name="external" :size="16" />
+                  </a>
+                  <span class="about-support-account">ko-fi.com/thinkstu</span>
+                </section>
               </div>
             </article>
 
@@ -83,12 +107,10 @@
                 <a href="https://github.com/Bistutu/FluentRead" target="_blank" rel="noreferrer">{{ t('options.aboutProject') }} <span>↗</span></a>
                 <a href="https://fluent.thinkstu.com/" target="_blank" rel="noreferrer">{{ t('options.aboutDocs') }} <span>↗</span></a>
                 <a href="https://github.com/Bistutu/FluentRead/issues" target="_blank" rel="noreferrer">{{ t('options.aboutFeedback') }} <span>↗</span></a>
-                <a href="https://github.com/FluentRead/FluentRead#support" target="_blank" rel="noopener noreferrer">{{ t('popup.donationTitle') }} <span>↗</span></a>
               </div>
             </article>
           </div>
 
-          <p class="about-footer">{{ t('options.aboutThanks') }}</p>
         </section>
         <LearningCenter v-else-if="activeSection === 'settings-vocabulary'" @navigate="selectSection" />
         <SettingsSections v-else :active-section="activeSection" />

--- a/src/core/i18n/messages/en-US.ts
+++ b/src/core/i18n/messages/en-US.ts
@@ -608,7 +608,7 @@ export const enUSMessages = {
     'options.aboutProject': 'Open-source project',
     'options.aboutDocs': 'Documentation',
     'options.aboutFeedback': 'Report an issue',
-    'options.aboutThanks': 'FluentRead is an open-source project whose continued development is made possible by the generous support of its community.',
+    'options.aboutThanks': 'FluentRead is an open-source project whose continued development depends on the generous support of its community. You can support it through WeChat or Ko-fi.',
     'popup.donationTitle': 'Support FluentRead',
     'popup.donationDescription': 'Thank you for supporting this open-source project.',
     'popup.donationClose': 'Close support dialog',

--- a/src/core/i18n/messages/es-ES.ts
+++ b/src/core/i18n/messages/es-ES.ts
@@ -456,7 +456,7 @@ export const esESMessages = {
     'options.aboutProject': 'Proyecto de código abierto',
     'options.aboutDocs': 'Documentación',
     'options.aboutFeedback': 'Informar de un problema',
-    'options.aboutThanks': 'FluentRead es un proyecto de código abierto cuyo desarrollo continuo es posible gracias al generoso apoyo de su comunidad.',
+    'options.aboutThanks': 'FluentRead es un proyecto de código abierto cuyo desarrollo continuo depende del generoso apoyo de su comunidad. Puedes apoyarlo mediante WeChat o Ko-fi.',
     'popup.donationTitle': 'Apoyar a FluentRead',
     'popup.donationDescription': 'Gracias por apoyar este proyecto de código abierto.',
     'popup.donationClose': 'Cerrar la ventana de apoyo',

--- a/src/core/i18n/messages/fr-FR.ts
+++ b/src/core/i18n/messages/fr-FR.ts
@@ -456,7 +456,7 @@ export const frFRMessages = {
     'options.aboutProject': 'Projet open source',
     'options.aboutDocs': 'Documentation',
     'options.aboutFeedback': 'Signaler un problème',
-    'options.aboutThanks': 'FluentRead est un projet open source dont le développement continu est rendu possible grâce au généreux soutien de sa communauté.',
+    'options.aboutThanks': 'FluentRead est un projet open source dont le développement continu dépend du généreux soutien de sa communauté. Vous pouvez le soutenir via WeChat ou Ko-fi.',
     'popup.donationTitle': 'Soutenir FluentRead',
     'popup.donationDescription': 'Merci de soutenir ce projet open source.',
     'popup.donationClose': 'Fermer la fenêtre de soutien',

--- a/src/core/i18n/messages/ja-JP.ts
+++ b/src/core/i18n/messages/ja-JP.ts
@@ -456,7 +456,7 @@ export const jaJPMessages = {
     'options.aboutProject': 'オープンソースプロジェクト',
     'options.aboutDocs': 'ドキュメント',
     'options.aboutFeedback': '問題を報告',
-    'options.aboutThanks': 'FluentRead は、コミュニティの皆さまからの温かいご支援により、継続的な開発が支えられているオープンソースプロジェクトです。',
+    'options.aboutThanks': 'FluentRead はオープンソースプロジェクトです。継続的な開発はコミュニティの温かい支援に支えられています。WeChat または Ko-fi で任意にご支援いただけます。',
     'popup.donationTitle': 'FluentRead を支援',
     'popup.donationDescription': 'オープンソースプロジェクトへのご支援に感謝します。',
     'popup.donationClose': '支援画面を閉じる',

--- a/src/core/i18n/messages/ko-KR.ts
+++ b/src/core/i18n/messages/ko-KR.ts
@@ -456,7 +456,7 @@ export const koKRMessages = {
     'options.aboutProject': '오픈 소스 프로젝트',
     'options.aboutDocs': '문서',
     'options.aboutFeedback': '문제 신고',
-    'options.aboutThanks': 'FluentRead는 커뮤니티의 아낌없는 지원 덕분에 지속적인 개발이 가능한 오픈 소스 프로젝트입니다.',
+    'options.aboutThanks': 'FluentRead는 오픈 소스 프로젝트이며, 지속적인 개발은 커뮤니티의 아낌없는 지원으로 이어집니다. WeChat 또는 Ko-fi로 원하는 방식으로 후원할 수 있습니다.',
     'popup.donationTitle': 'FluentRead 후원',
     'popup.donationDescription': '오픈 소스 프로젝트를 후원해 주셔서 감사합니다.',
     'popup.donationClose': '후원 창 닫기',

--- a/src/core/i18n/messages/ru-RU.ts
+++ b/src/core/i18n/messages/ru-RU.ts
@@ -456,7 +456,7 @@ export const ruRUMessages = {
     'options.aboutProject': 'Проект с открытым исходным кодом',
     'options.aboutDocs': 'Документация',
     'options.aboutFeedback': 'Сообщить о проблеме',
-    'options.aboutThanks': 'FluentRead — проект с открытым исходным кодом, дальнейшее развитие которого возможно благодаря щедрой поддержке сообщества.',
+    'options.aboutThanks': 'FluentRead — проект с открытым исходным кодом, дальнейшее развитие которого зависит от щедрой поддержки сообщества. Вы можете поддержать его через WeChat или Ko-fi.',
     'popup.donationTitle': 'Поддержать FluentRead',
     'popup.donationDescription': 'Спасибо за поддержку проекта с открытым исходным кодом.',
     'popup.donationClose': 'Закрыть окно поддержки',

--- a/src/core/i18n/messages/zh-CN.ts
+++ b/src/core/i18n/messages/zh-CN.ts
@@ -607,7 +607,7 @@ export const zhCNMessages = {
     'options.aboutProject': '开源项目',
     'options.aboutDocs': '使用文档',
     'options.aboutFeedback': '问题反馈',
-    'options.aboutThanks': 'FluentRead 是一个开源项目，其持续开发离不开社区的慷慨支持。',
+    'options.aboutThanks': 'FluentRead的发展离不开社区的慷慨支持，你可以通过微信赞赏或Ko-fi支持我们。',
     'popup.donationTitle': '支持 FluentRead',
     'popup.donationDescription': '感谢您对开源项目的支持。',
     'popup.donationClose': '关闭赞赏窗口',

--- a/src/features/settings/ui/settings-page.css
+++ b/src/features/settings/ui/settings-page.css
@@ -306,6 +306,17 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
 .about-feature-list { display: grid; gap: 10px; }
 .about-feature-list span { display: flex; align-items: center; gap: 10px; color: var(--ink); font-size: 13px; font-weight: 650; }
 .about-feature-list b { display: inline-grid; place-items: center; width: 28px; height: 28px; border-radius: 9px; color: var(--brand-strong); background: var(--brand-soft); font-size: 11px; }
+.about-support-options { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; margin: 2px -8px 0; }
+.about-support-option { display: flex; min-width: 0; padding: 18px 8px 0; flex-direction: column; align-items: center; text-align: center; }
+.about-support-option h4 { margin: 0 0 12px; color: var(--ink); font-size: 13px; font-weight: 750; }
+.about-support-method { color: var(--ink); text-decoration: none; }
+.about-support-wechat { display: block; width: min(100%, 220px); border-radius: 12px; background: #fff; box-shadow: 0 10px 24px rgba(31, 40, 61, .08); transition: transform 160ms ease, box-shadow 160ms ease; }
+.about-support-wechat:hover { transform: translateY(-2px); box-shadow: 0 14px 30px rgba(31, 40, 61, .14); }
+.about-support-qr { display: block; width: 100%; height: auto; aspect-ratio: 1; border-radius: 12px; object-fit: contain; }
+.about-support-kofi-option { justify-content: center; }
+.about-support-kofi-link { display: inline-flex; align-items: center; gap: 6px; max-width: 100%; color: var(--brand-strong); font-size: 16px; font-weight: 750; line-height: 1.4; text-decoration: underline; text-decoration-thickness: 1.5px; text-underline-offset: 4px; }
+.about-support-kofi-link:hover { color: var(--brand); }
+.about-support-account { margin-top: 22px; color: var(--ink); font-size: 17px; letter-spacing: .01em; }
 .about-links { display: grid; gap: 8px; }
 .about-links a { display: flex; align-items: center; justify-content: space-between; padding: 11px 12px; border: 1px solid var(--line); border-radius: 12px; color: var(--ink); background: var(--surface); font-size: 13px; font-weight: 650; text-decoration: none; transition: border-color 160ms ease, color 160ms ease, transform 160ms ease; }
 .about-links a:hover { border-color: #ef9ab1; color: var(--brand-strong); transform: translateX(2px); }
@@ -419,6 +430,9 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
   .about-logo { width: 64px; height: 64px; border-radius: 18px; }
   .about-hero h3 { font-size: 21px; }
   .about-grid { grid-template-columns: 1fr; }
+  .about-support-options { grid-template-columns: 1fr; }
+  .about-support-option + .about-support-option { margin-top: 18px; padding-top: 18px; }
+  .about-support-kofi-option { min-height: 150px; }
 }
 
 @media (max-width: 480px) {
@@ -457,6 +471,7 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
 :root.dark .about-hero { border-color: rgba(255, 138, 171, .28); background: linear-gradient(135deg, rgba(239, 71, 118, .12), var(--surface) 58%, #222631); }
 :root.dark .about-panel { border-color: var(--line); background: var(--surface-soft); }
 :root.dark .about-links a { border-color: var(--line); background: var(--surface); }
+:root.dark .about-support-wechat { box-shadow: 0 10px 24px rgba(0, 0, 0, .22); }
 :root.dark .style-preview-card { border-color: var(--line); background: linear-gradient(145deg, var(--surface-soft), rgba(239, 71, 118, .08)); }
 :root.dark .style-preview-example { border-color: var(--line); background: var(--surface); }
 :root.dark .style-preview-source,


### PR DESCRIPTION
## Summary
- Replace the About page Core Experience panel with a compact community support area.
- Show the full WeChat appreciation image as a clickable original-image link.
- Add a Ko-fi support link and synchronize support copy across locale catalogs.
- Add Settings Center assertions for QR size, click-through, links, copy, and removal of the old feature list.

## Verification
- `pnpm compile`
- `pnpm test -- tests/i18n.test.ts tests/optionsNavigation.test.ts` (62 tests)
- `pnpm build`
- Production settings visual audit: light, dark, narrow; no overflow or console errors.
- Settings Center support assertions passed; the suite later stops on the existing baseline error `Popup 缺少 AI 圈选能力边界说明`.

This PR contains only the support UI changes; unrelated local site-adaptation changes remain in the original working directory.