### PR TITLE
test(site-adaptation): 固化 GitHub @提及 评论的悬停翻译回归夹具

### DIFF
--- a/scripts/site-translation/site-adaptation-established-fixtures.json
+++ b/scripts/site-translation/site-adaptation-established-fixtures.json
@@ -173,5 +173,17 @@
     "restoreSelectors": [
       "#body1"
     ]
+  },
+  {
+    "id": "github-mention",
+    "url": "https://github.com/example/project/issues/157",
+    "html": "<main><div class=\"markdown-body\" data-testid=\"markdown-body\"><p id=\"mention\" dir=\"auto\"><a class=\"user-mention notranslate\" data-hovercard-type=\"user\" href=\"https://github.com/example\">@example</a> like this comment, the line must still translate when the pointer rests on the mention.</p><p id=\"plain\" dir=\"auto\">A second comment paragraph stays independently selectable during hover translation.</p></div></main>",
+    "required": [
+      "#mention",
+      "#plain"
+    ],
+    "forbidden": [
+      "#mention > a.user-mention"
+    ]
   }
 ]


### PR DESCRIPTION
## 背景

[#157](https://github.com/FluentRead/FluentRead/issues/157) 反馈 GitHub issue 中「以 @ 开头的行」无法悬停翻译。

复核后确认该行为在当前 `main` 上已经正常：GitHub 适配规则的 `github-markdown-prose` 把 `.markdown-body` 下的 `p / li / blockquote / 标题 / 表格单元格` 作为整段候选（`resolve: closest`），指针即使停在开头的 `@用户名` 上也会向上解析到整条评论段落；`@用户名` 本身带 GitHub 的 `notranslate`，作为受保护内容保持原文并被排除在翻译请求之外。

但这条链路此前没有常驻回归覆盖：既有 `github` 夹具的段落以普通文字开头，悬停手势永远落不到受保护的行内提及上。

## 改动

`scripts/site-translation/site-adaptation-established-fixtures.json` 新增 `github-mention` 夹具：

- 评论段落以 GitHub 真实渲染结构 `<a class="user-mention notranslate">@example</a>` 开头，`scripts/run-site-adaptation-test.cjs` 的悬停手势会直接落在提及文字上；
- `required` 覆盖该评论段落与相邻评论，验证整段翻译、恢复、再次翻译与邻段独立性；
- `forbidden` 断言 `#mention > a.user-mention` 保持原文、不含译文节点，并由既有的 provider 载荷校验确认 `@example` 从未进入翻译请求。

仅新增夹具数据，无产品代码改动。

## 验证

- `pnpm exec vitest run tests/siteTranslationHarness.test.ts tests/siteAdaptationCatalog.test.ts tests/siteAdaptationCore.test.ts tests/translationCore.test.ts` → 422 passed
- `node scripts/testing/audit-test-suite.mjs` → 318 files / 4199 cases
- `pnpm compile`
- `pnpm build` 后运行 `scripts/run-site-adaptation-test.cjs`：
  - `--cases github-mention`：hover `[1, 0, 1, 0]`、full `[1, 0, 1]`、`protected: 1`、`providerProtection: true`
  - 全量夹具：`59/59 passed`，无 console 错误、无外部请求
  - 浏览器层为独立临时 profile 的 Edge，`launchMode: macos-background-cdp`、`focusPolicy: launchservices-no-foreground`、`browserFrontmost: false`，翻译响应使用本地确定性桩

未验证范围：真实 github.com 线上页面（匿名访问下评论区不渲染），本次使用 `github.com` 域名下的合成评论夹具。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
