### PR TITLE
test(translation): 修正 mutation 回归的截图副作用并收紧非候选控件断言

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -163,7 +163,7 @@ node scripts/testing/run-translation-mutation-test.cjs \
   --artifacts-dir /private/tmp/fluentread-translation-mutation
 ```
 
-该回归检查宿主为新增链接写入 `tabindex=-1/0` 时保持同一个译文节点，避免把键盘焦点管理误判为内容损坏；正文、链接目的地或隐藏状态变化仍由确定性测试验证失效行为。仅译文模式还检查相邻 DOM 更新不会因原文位于扩展槽内而撤销翻译。固定高度按钮覆盖嵌套 flex/grid 标签、文字边界、点击与“翻译—恢复—再次翻译”，使用确定性翻译服务排除网络响应波动；真实 GitHub 页面结果需单独记录，不能以本地夹具代替。
+该回归检查宿主为新增链接写入 `tabindex=-1/0` 时保持同一个译文节点，避免把键盘焦点管理误判为内容损坏；正文、链接目的地或隐藏状态变化仍由确定性测试验证失效行为。仅译文模式还检查相邻 DOM 更新不会因原文位于扩展槽内而撤销翻译。固定高度按钮覆盖嵌套 flex/grid 标签、文字边界、点击与“翻译—恢复—再次翻译”，使用确定性翻译服务排除网络响应波动；真实 GitHub 页面结果需单独记录，不能以本地夹具代替。表单内的具名 submit 与用户输入框属于非候选控件，按完整 `outerHTML` 比对翻译前后与恢复原文，确保布局租约不在同层控件上留下属性残留。此类断言要求证据截图保持非侵入：Playwright 默认的 `caret: 'hide'` 会给每个 `input`/`textarea`/`[contenteditable]` 写入 `caret-color` 再以空值清除，在宿主控件上留下空 `style` 属性，因此浏览器回归截图统一使用 `caret: 'initial'`。
 
 ### Reddit 多翻译器共存
 

--- a/scripts/testing/run-translation-mutation-test.cjs
+++ b/scripts/testing/run-translation-mutation-test.cjs
@@ -4,6 +4,8 @@
  * 在临时、无前台激活的 Edge 中验证翻译 DOM 所有权：宿主 tabindex 修饰不得重建译文，
  * 单语槽须承受邻接 DOM/样式变化，固定高度交互控件必须原位单行翻译并保留事件。
  * 页面使用精确域名夹具，微软请求在测试 worker 中返回确定性响应；禁止外部网络及日常 profile。
+ * 断言基于宿主 DOM 的完整 outerHTML，因此证据截图必须保持非侵入（caret: 'initial'），
+ * 不得让 Playwright 自身的 caret 隐藏在宿主 input/textarea 上留下残留属性。
  */
 const assert = require('node:assert/strict');
 const crypto = require('node:crypto');
@@ -155,6 +157,10 @@ async function main() {
   };
   const snapshot = async page => ({...await page.evaluate(() => window.translationMutationTest.snapshot()),
     requests: await worker.evaluate(() => globalThis.translationMutationRequests.length)});
+  // Playwright 默认 caret:'hide' 会给每个 input/textarea/[contenteditable] 写入
+  // caret-color 再以空值清除，在宿主控件上留下空 style 属性。DOM 所有权断言必须
+  // 比对完整 outerHTML，因此证据截图一律使用 caret:'initial'，不改写被断言的页面。
+  const capture = (page, name) => page.screenshot({path: path.join(args.artifactsDir, name), caret: 'initial'});
   try {
     session = await helper.launchFocusSafePersistentContext({chromium, profileDir, browserPath: args.browserPath,
       background: true, headless: false, viewport: {width: 1280, height: 900}, displayTarget: args.display,
@@ -205,7 +211,7 @@ async function main() {
         await page.waitForTimeout(600);
         await installTracker(page);
         result.before = await snapshot(page);
-        await page.screenshot({path: path.join(args.artifactsDir, `${item.id}-before.png`)});
+        await capture(page, `${item.id}-before.png`);
         await toggle(page);
         await page.waitForFunction(selector => document.querySelectorAll(selector).length > 0, ownedSelector, {timeout: args.timeout});
         await page.waitForFunction(selector => {
@@ -219,7 +225,7 @@ async function main() {
           return signature.endsWith(':0') && Date.now() - state.settledAt >= 1800;
         }, ownedSelector, {timeout: args.timeout});
         result.first = await snapshot(page);
-        await page.screenshot({path: path.join(args.artifactsDir, `${item.id}-translated.png`)});
+        await capture(page, `${item.id}-translated.png`);
         if (item.id === 'single-slots') {
           await page.evaluate(() => {
             const owner = document.querySelector('#single-prose');
@@ -280,11 +286,12 @@ async function main() {
             const label = form.tag === 'input' ? form.value : form.text;
             assert.ok(hasChinese(label), `${form.id}: 按钮标签未替换为译文（${label}）`);
           }
-          // 具名 submit 的 value 会随表单提交，输入框 value 是用户数据，二者都必须原样保留。
-          // 只核对标签与译文工件：布局租约会在同层表单控件上留下空 style 属性，属于既有行为。
+          // 具名 submit 的 value 会随表单提交，输入框 value 是用户数据；二者既不能改写，
+          // 也不能被属性或译文工件触碰，因此整段 outerHTML 必须与翻译前完全一致。
+          assert.equal(result.stable.untouchedForms.length, 2);
           for (const form of result.stable.untouchedForms) {
             const original = result.before.untouchedForms.find(item => item.id === form.id);
-            assert.equal(form.value, original.value, `${form.id}: 参与提交或承载用户输入的 value 被改写`);
+            assert.equal(form.html, original.html, `${form.id}: 非候选表单控件被翻译改写`);
             assert.equal(form.wrappers + form.segments, 0, `${form.id}: 表单控件中出现了译文工件`);
           }
         }
@@ -304,6 +311,7 @@ async function main() {
           assert.equal(form.value, original.value, `${form.id}: 恢复原文后未回到原始按钮标签`);
           assert.equal(form.text, original.text, `${form.id}: 恢复原文后仍残留译文`);
           assert.equal(form.wrappers + form.segments, 0, `${form.id}: 恢复原文后仍残留译文工件`);
+          assert.equal(form.html, original.html, `${form.id}: 恢复原文后仍残留属性或样式`);
         }
         await toggle(page);
         await page.waitForFunction(({selector, count}) => document.querySelectorAll(selector).length === count,
@@ -326,7 +334,7 @@ async function main() {
           await page.locator(`#${control.id}`).click();
           assert.equal(await page.locator(`#${control.id}`).getAttribute('data-click-count'), '2');
         }
-        await page.screenshot({path: path.join(args.artifactsDir, `${item.id}-retranslated.png`)});
+        await capture(page, `${item.id}-retranslated.png`);
         result.passed = true;
         process.stdout.write(`${item.id}: passed; translated/restored/retranslated ${result.first.owned.length}/0/${result.retranslated.owned.length}\n`);
       } catch (error) {
@@ -334,7 +342,7 @@ async function main() {
         result.failure = await snapshot(page).catch(() => null);
         result.events = await page.evaluate(() => window.translationMutationTest?.events || []).catch(() => []);
         result.requests = await worker.evaluate(() => globalThis.translationMutationRequests).catch(() => []);
-        await page.screenshot({path: path.join(args.artifactsDir, `${item.id}-failure.png`)}).catch(() => {});
+        await capture(page, `${item.id}-failure.png`).catch(() => {});
         throw error;
       } finally {
         save();


### PR DESCRIPTION
## 背景

全文翻译后，宿主表单控件会出现空 `style=""` 残留：

```
before: <input id="text-input" type="text" name="q" value="Private draft text">
after:  <input id="text-input" type="text" name="q" value="Private draft text" style="">
```

此前把它记为布局租约（`acquireTranslationLayoutOverride` / `restoreSharedTranslationLayoutOverride`）的既有行为，并因此放宽了 `run-translation-mutation-test.cjs` 中非候选表单控件的断言，只比对 `value`/`text`/wrapper。

## 定位结论：残留来自回归脚本自身，不是扩展写入

- DOM 探针确认只有真实的 `setProperty` → `removeProperty` 组合才会留下空 `style` 属性；纯读取和空值写入都不会。
- 在隔离世界（`content.js`）与 MAIN world（`shadowBridge.js`）同时插桩 `CSSStyleDeclaration.setProperty`/`removeProperty`/`cssText` 与 `Element.setAttribute`/`removeAttribute`：插桩确实生效（捕获到 `.fluent-read-loading` 等写入），但**在任何表单控件上没有捕获到一次来自扩展的写入**。
- 宿主 `MutationObserver`（`attributeOldValue`）记录的唯一来源，对全部六个 input（含 `#empty-submit`）一致：

  ```
  style: null → "caret-color: transparent !important;"
  style: "caret-color: transparent !important;" → ""
  ```

- 根因在 `playwright-core/lib/server/screenshotter.js:60-73`：`page.screenshot()` 默认 `caret: 'hide'`，对每个 `input, textarea, [contenteditable]` 执行 `setProperty('caret-color','transparent','important')`，清理时把空的旧值写回 —— 属性被移除，但空的 `style` 属性留了下来。它运行在 Playwright 自己的 utility world，所以内容脚本世界的插桩看不到。
- **对照实验（不加载扩展、不触发翻译，仅 `page.setContent(夹具)` + 一次 `page.screenshot()`）**：六个 input 全部出现 `style=""`；改用 `caret: 'initial'` 后一个都没有。

脚本在 `before` 快照之后立刻截 `${id}-before.png`，所以 `before` 干净、之后每个阶段都带残留。与翻译完全无关，布局租约从未参与。

## 改动

- 四处截图统一走 `capture()` 并使用 `caret: 'initial'`，让回归脚本不再改写自己要断言的 DOM。
- 恢复被放宽的断言：
  - `stable` 阶段：`untouchedForms` 改为完整 `outerHTML` 比对（原先只比 `value`），并加上数量守卫。
  - `restored` 阶段：为全部 `buttonForms` 与 `untouchedForms` 增加完整 `outerHTML` 相等断言。
- 替换归因错误的注释，并在文件头与 `docs/testing.md` 记录“证据截图必须非侵入”这条规则。

`src/` 无需改动。收紧后的 `outerHTML` 断言全部通过，反过来正面证明布局租约不会在同层非候选控件上留下属性残留，被翻译的控件恢复原文后也逐字节一致。

## 验证

- `pnpm compile` ✅
- `pnpm test` ✅ 325 文件 / 6420 用例
- `pnpm test:audit` ✅
- `pnpm docs:build` ✅
- `pnpm build` ✅，真实浏览器回归四个用例全通过：`generic-focus`、`github-focus`、`button-controls`、`single-slots`
  - launch mode `macos-background-cdp`，focus policy `launchservices-no-foreground`，window `background-visible-no-focus`（`browserFrontmost=false`），临时 profile
  - 证据目录 `/private/tmp/fluentread-mutation-rebased`；report 确认未触碰控件在 `before`/`first`/`stable`/`restored`/`retranslated` 五个阶段完全一致
- `pnpm test:coverage` ⚠️ 本机满载下有超时抖动（1–3 个用例命中 5s 超时，每次集合不同）。已确认为既有问题：未改动的基线提交同样失败，相关文件单独运行 1–2s 通过。本 PR 只改一个 `.cjs` 脚本和一行文档，都不在覆盖率范围内。

## 附注

另有约 30 个浏览器脚本调用 `page.screenshot()`，同样暴露在这个 Playwright 副作用下。已 grep 确认只有本脚本因此放宽过 DOM 相等断言，所以目前没有其他被掩盖的断言；但如果将来别的脚本开始对可编辑控件比对 `outerHTML`，需要注意这一点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)