### PR TITLE
chore: bump version to 0.0.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "FluentRead-流畅阅读",
   "description": "An open-source browser extension for bilingual translation. 一款开源的浏览器双语翻译插件。",
   "private": true,
-  "version": "0.0.32",
+  "version": "0.0.33",
   "userscriptVersion": "2.0.0",
   "type": "module",
   "engines": {

--- a/tests/extensionManifestContract.test.ts
+++ b/tests/extensionManifestContract.test.ts
@@ -116,23 +116,23 @@ describe('extension manifest capability contract', () => {
             ): string[];
         };
         const expected = [
-            'fluent-read-0.0.32-firefox.zip',
-            'fluent-read-0.0.32-sources.zip',
+            'fluent-read-0.0.33-firefox.zip',
+            'fluent-read-0.0.33-sources.zip',
         ];
 
         expect(verifier.findUnexpectedCurrentVersionArchives([
             ...expected,
             '-0.0.30-firefox.zip',
-            'legacy-10.0.32-sources.zip',
-        ], '0.0.32', expected)).toEqual([]);
+            'legacy-10.0.33-sources.zip',
+        ], '0.0.33', expected)).toEqual([]);
         expect(verifier.findUnexpectedCurrentVersionArchives([
             ...expected,
-            '-0.0.32-firefox.zip',
-            'legacy-v0.0.32-sources.zip',
+            '-0.0.33-firefox.zip',
+            'legacy-v0.0.33-sources.zip',
             'fluent-read-0.0.30-firefox.zip',
-        ], '0.0.32', expected)).toEqual([
-            '-0.0.32-firefox.zip',
-            'legacy-v0.0.32-sources.zip',
+        ], '0.0.33', expected)).toEqual([
+            '-0.0.33-firefox.zip',
+            'legacy-v0.0.33-sources.zip',
         ]);
     });
 


### PR DESCRIPTION
Update FluentRead from 0.0.32 to 0.0.33 and keep the extension archive contract aligned with the release version.

Validation:
- `pnpm exec vitest run tests/extensionManifestContract.test.ts`
- `pnpm compile`
- `pnpm build`
- `pnpm build:firefox`
- `pnpm verify:extension-manifests`
