### PR TITLE
test(browser): align five UI regression fixtures with the redesigned settings

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -261,6 +261,26 @@ node scripts/testing/run-popup-quick-settings-ui-test.cjs \
 
 该脚本不下载模型、不调用外部翻译服务，也不验证播放器字幕质量或 Firefox 真实界面；不能把专项通过等同于其他 UI 套件或真实翻译链路通过。报告分别记录窗口位置、焦点策略、配置行为、布局尺寸、控制台错误和截图。
 
+## 翻译服务目录
+
+服务目录只有“我的服务”和“全部服务”两级入口，自定义 OpenAI 兼容服务在创建后作为“全部服务”中的一个分类出现。两个生产扩展专项使用相同的隔离浏览器参数，分工如下：
+
+```bash
+node scripts/testing/run-service-library-ui-test.cjs \
+  --extension-dir .output/chrome-mv3 \
+  --playwright-root <Node包目录> \
+  --focus-safe-helper <focus-safe-browser.cjs路径> \
+  --artifacts-dir /private/tmp/fluentread-service-library
+
+node scripts/testing/run-service-catalog-ui-test.cjs \
+  --extension-dir .output/chrome-mv3 \
+  --playwright-root <Node包目录> \
+  --focus-safe-helper <focus-safe-browser.cjs路径> \
+  --artifacts-dir /private/tmp/fluentread-service-catalog
+```
+
+`run-service-library-ui-test.cjs` 覆盖个人服务分组、常用标记快速关闭后的持久化、查看服务不改默认服务、显式设为默认的跨页同步、首个自定义服务出现前不显示自定义分类、20 个长名称自定义服务的分类筛选，以及 1440/1024/820/390px、深色和英文界面。`run-service-catalog-ui-test.cjs` 锁定机器翻译、云服务厂商、模型服务商和聚合平台的分类顺序与计数，检查免密钥候选不泄漏为独立服务、跨分类搜索和窄屏布局，并验证免费翻译默认自动均衡、实验候选默认停用，以及切换优先顺序后的启停、排序和重载持久化。默认不请求翻译服务；只有显式 `--live true` 才逐一检查三个免密钥候选的真实连接，结果需与本地断言分开报告。
+
 ## 菜单栏首帧与快速关闭
 
 Popup 必须等待配置服务完成读取或安全降级后再挂载。首个可见界面就应使用保存的皮肤、深浅主题和栏目布局；只有最终截图正确不足以证明没有闪烁。
@@ -276,7 +296,7 @@ node scripts/testing/run-popup-startup-ui-test.cjs \
   --artifacts-dir /private/tmp/fluentread-popup-startup
 ```
 
-该回归在临时 Edge profile 中逐帧记录可见界面，并注入配置读取延迟来放大竞态窗口；报告同时保留正常打开的首个正确帧时间、挂载次数与 DOM 变更计数。对照旧产物时可传 `--expect-flash --skin emoji`，确认用例确实能发现旧版默认界面先绘制的问题。延迟注入数据不能当作正常启动耗时。
+该回归在临时 Edge profile 中逐帧记录可见界面，并注入配置读取延迟来放大竞态窗口；快捷抽屉用例另检查悬停、划词和圈选抽屉打开时焦点进入抽屉、关闭后回到对应卡片，且 Popup 解析的脚本源码不包含只属于完整设置页的快捷键编辑器；报告同时保留正常打开的首个正确帧时间、挂载次数与 DOM 变更计数。对照旧产物时可传 `--expect-flash --skin emoji`，确认用例确实能发现旧版默认界面先绘制的问题。延迟注入数据不能当作正常启动耗时。
 
 快速关闭用例冻结首条保存给 Popup 的回执，让第二次修改确定停留在页面内的队列，再立即关闭。报告必须证明关闭前已向后台交接包含未确认前驱的补丁链，关闭后最终选择仍被保存，且无修改关闭时普通保存与批量交接消息均为零。配置服务和后台处理器另验证前驱在途、已提交去重、字段冲突拒绝及失败后的接续边界。
 
@@ -451,6 +471,8 @@ node scripts/testing/run-codeforces-translation-test.cjs \
 该脚本使用隔离临时 Edge、第二屏后台窗口及本地确定性微软响应，检查默认全文和悬浮的翻译—恢复—再次翻译、公式重排、小点与 Control 划词入口。倒计时夹具连续更新 12 次，断言三个独立文字译文的节点身份不变、零额外请求、卡片高度不变；比赛状态变化仍触发正常更新。`--live` 追加 issue #492 的 Codeforces 实际题面，以及首页倒计时 12 秒的节点稳定性检查，省略时仅运行本地夹具。真实页面与确定性翻译响应的组合不代表真实供应商译文质量。
 
 划词与翻译卡片在中文目标下共同跳过纯汉字选区（包括短词、简繁汉字、数字、标点和表情），不显示入口或占用快捷键。外语目标和含外语的选区保持可用；该规则只用于选区交互，不改变全文语言检测。`chineseLanguage` 与 `contentHotkeyRuntime` 覆盖该边界。
+
+默认运行 `scripts/run-selection-trigger-test.cjs` 时，Popup 快捷抽屉只切换关闭、双语显示和仅译文；触发方式、显示延迟和自定义快捷键在同时打开的完整设置页修改，并断言设置页、Popup 预览、存储配置与网页中的真实划词手势一致。主矩阵固定使用本地夹具拦截的微软翻译，避免默认免费翻译均衡到真实公开接口。
 
 使用 `scripts/run-selection-trigger-test.cjs --chinese-only` 配合原有隔离浏览器参数可验证纯中文的图标、小点、直接弹出、划词快捷键和翻译卡片点击/悬停/快捷键入口，并检查选区替换、目标切换及混排恢复。微软返回值使用本地响应夹具；翻译卡片验证入口，不调用真实 AI 模型。
 

--- a/scripts/run-selection-trigger-test.cjs
+++ b/scripts/run-selection-trigger-test.cjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 // 使用临时 Edge profile 验证划词翻译的完整触发矩阵。
+// Popup 快捷抽屉只负责关闭/双语/仅译文三选一；触发方式、显示延迟和自定义快捷键在完整设置页修改，
+// 两个真实扩展页面同时打开，断言设置页写入、Popup 预览同步与网页中的真实划词手势结果一致。
 // 该脚本只操作本次创建的隔离 profile，不连接用户正在使用的浏览器。
 
 const fs = require('node:fs');
@@ -196,102 +198,161 @@ async function waitForContentScript(page) {
   await page.waitForTimeout(700);
 }
 
+const SELECTION_MODE_VALUES = { 关闭: 'disabled', 双语显示: 'bilingual', 仅译文: 'translation-only' };
+
 async function openSelectionDrawer(popup) {
-  await popup.locator('.feature-card').filter({ hasText: '划词翻译' }).first().click();
+  await activateInputPage(popup);
+  await popup.locator('[data-popup-quick-feature="selection"]').click();
   const drawer = popup.locator('.popup-drawer:visible').last();
-  await drawer.getByText('触发方式', { exact: true }).waitFor({ state: 'visible', timeout: 60000 });
+  await drawer.getByRole('group', { name: '划词翻译模式' }).waitFor({ state: 'visible', timeout: 60000 });
   return drawer;
 }
 
-async function setSelectionEnabled(popup, drawer, enabled) {
-  await activateInputPage(popup);
-  const toggle = drawer.getByRole('switch', { name: '启用或关闭划词翻译' });
-  const current = (await toggle.getAttribute('aria-checked')) === 'true';
-  if (current !== enabled) {
-    await toggle.click();
-    await popup.waitForTimeout(500);
-  }
-  assert((await toggle.getAttribute('aria-checked')) === String(enabled), `划词翻译启用状态错误：${enabled}`);
+async function openSelectionOptions(context, extensionId, result) {
+  const options = await createIsolatedPage(context);
+  options.on('pageerror', (error) => result.consoleErrors.push(`options pageerror: ${error.message}`));
+  options.on('console', (message) => { if (message.type() === 'error') result.consoleErrors.push(`options console: ${message.text()}`); });
+  await options.goto(`chrome-extension://${extensionId}/options.html#settings-translation`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await options.getByRole('radiogroup', { name: '划词翻译模式' }).waitFor({ state: 'visible', timeout: 60000 });
+  return options;
 }
 
-async function setSelectionMode(popup, drawer, label) {
-  await activateInputPage(popup);
-  await drawer.locator('.chips.two button').filter({ hasText: label }).click();
-  await popup.waitForTimeout(450);
-  const selected = await drawer.locator('.chips.two button.selected').textContent();
-  assert(selected?.includes(label), `显示方式没有选中 ${label}：${selected}`);
+async function setSelectionMode(ui, label) {
+  const expected = SELECTION_MODE_VALUES[label];
+  assert(expected, `未知划词模式：${label}`);
+  const button = ui.drawer.getByRole('group', { name: '划词翻译模式' }).getByRole('button', { name: label, exact: true });
+  await activateInputPage(ui.popup);
+  await button.click();
+  const deadline = Date.now() + 10000;
+  let state = null;
+  while (Date.now() < deadline) {
+    const config = await readStoredConfig(ui.storagePage);
+    state = {
+      pressed: await button.getAttribute('aria-pressed'),
+      mode: config.selectionTranslatorMode,
+      disabled: config.disableSelectionTranslator,
+    };
+    if (state.pressed === 'true' && state.mode === expected && state.disabled === (expected === 'disabled')) return state;
+    await ui.popup.waitForTimeout(100);
+  }
+  throw new Error(`划词模式没有保存为 ${label}：${JSON.stringify(state)}`);
+}
+
+async function setSelectionEnabled(ui, enabled) {
+  // 旧启用开关已并入 Popup 三选一模式：关闭即停用，重新启用时明确选择双语显示。
+  const config = await readStoredConfig(ui.storagePage);
+  const currentlyEnabled = config.selectionTranslatorMode !== 'disabled' && config.disableSelectionTranslator !== true;
+  if (currentlyEnabled !== enabled) await setSelectionMode(ui, enabled ? '双语显示' : '关闭');
+  const saved = await readStoredConfig(ui.storagePage);
+  assert((saved.selectionTranslatorMode !== 'disabled') === enabled && saved.disableSelectionTranslator === !enabled,
+    `划词翻译启用状态错误：${JSON.stringify({ enabled, mode: saved.selectionTranslatorMode, disabled: saved.disableSelectionTranslator })}`);
 }
 
 function expectedSelectionTrigger(label) {
   return label === '直接弹出'
-    ? { trigger: 'direct', hotkey: 'none' }
+    ? { trigger: 'direct', hotkey: 'none', preview: '直接弹出' }
     : label === '显示图标'
-      ? { trigger: 'icon', hotkey: 'none' }
+      ? { trigger: 'icon', hotkey: 'none', preview: 'icon' }
       : label === '显示小点'
-        ? { trigger: 'dot', hotkey: 'none' }
+        ? { trigger: 'dot', hotkey: 'none', preview: 'dot' }
         : label === 'Ctrl'
-          ? { trigger: 'Control', hotkey: 'Control' }
+          ? { trigger: 'Control', hotkey: 'Control', preview: 'Ctrl' }
           : label === 'Alt / Option'
-            ? { trigger: 'Alt', hotkey: 'Alt' }
+            ? { trigger: 'Alt', hotkey: 'Alt', preview: 'Alt / Option' }
             : label === 'Shift'
-              ? { trigger: 'Shift', hotkey: 'Shift' }
-              : { trigger: 'custom', hotkey: 'custom' };
+              ? { trigger: 'Shift', hotkey: 'Shift', preview: 'Shift' }
+              : { trigger: 'custom', hotkey: 'custom', preview: 'F9' };
 }
 
-async function waitForSelectionTriggerState(popup, drawer, storagePage, label, timeout = 10000) {
+function selectionTriggerSelect(options) {
+  const input = options.locator('input[aria-label="划词翻译触发方式"]');
+  const wrapper = input.locator('xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " el-select__wrapper ")][1]');
+  return { input, wrapper };
+}
+
+async function readPopupTriggerPreview(drawer) {
+  const preview = drawer.locator('.interaction-preview');
+  if (await preview.count() === 0) return '';
+  return preview.first().evaluate((element) => {
+    if (element.querySelector('.pink-dot')) return 'dot';
+    if (element.querySelector('.selection-preview-icon')) return 'icon';
+    return element.querySelector('kbd, strong')?.textContent?.trim() || '';
+  });
+}
+
+async function waitForSelectionTriggerState(ui, label, timeout = 10000) {
   const expected = expectedSelectionTrigger(label);
+  const { wrapper } = selectionTriggerSelect(ui.options);
   const deadline = Date.now() + timeout;
   let lastState = null;
   while (Date.now() < deadline) {
-    const selected = await drawer.locator('.selection-trigger-chips button.selected').textContent();
-    const config = await readStoredConfig(storagePage);
+    const config = await readStoredConfig(ui.storagePage);
     lastState = {
-      selected,
+      options: (await wrapper.locator('.el-select__placeholder').first().textContent())?.trim() || '',
+      popupPreview: await readPopupTriggerPreview(ui.drawer),
       trigger: config.selectionTranslatorTrigger,
       hotkey: config.selectionTranslatorHotkey,
       customHotkey: config.customSelectionTranslatorHotkey || '',
     };
-    if (selected?.includes(label)
+    if (lastState.options === label
+      && lastState.popupPreview === expected.preview
       && config.selectionTranslatorTrigger === expected.trigger
       && config.selectionTranslatorHotkey === expected.hotkey
       && (label !== '自定义' || config.customSelectionTranslatorHotkey === 'F9')) {
       return { label, ...lastState };
     }
-    await popup.waitForTimeout(100);
+    await ui.options.waitForTimeout(100);
   }
-  throw new Error(`选择 ${label} 后 UI/配置未稳定：${JSON.stringify(lastState)}`);
+  throw new Error(`选择 ${label} 后设置页、Popup 预览或配置未稳定：${JSON.stringify(lastState)}`);
 }
 
-async function setSelectionTrigger(popup, drawer, storagePage, label) {
-  await activateInputPage(popup);
-  await drawer.locator('.selection-trigger-chips button').filter({ hasText: label }).click();
-  await popup.waitForTimeout(500);
+async function setSelectionTrigger(ui, label) {
+  await activateInputPage(ui.options);
+  const { input, wrapper } = selectionTriggerSelect(ui.options);
+  await input.waitFor({ state: 'visible', timeout: 15000 });
+  const current = (await wrapper.locator('.el-select__placeholder').first().textContent())?.trim();
+  if (current !== label) {
+    await wrapper.click();
+    const dropdown = ui.options.locator('.el-select-dropdown:visible').last();
+    await dropdown.waitFor({ state: 'visible', timeout: 10000 });
+    await dropdown.getByRole('option', { name: label, exact: true }).click();
+    await dropdown.waitFor({ state: 'hidden', timeout: 10000 });
+  }
 
   if (label === '自定义') {
-    let dialog = popup.locator('.custom-hotkey-dialog:visible').last();
+    // 首次选择会自动打开录制框；已有 F9 时保持原组合，其他组合通过编辑按钮改回 F9。
+    let dialog = ui.options.locator('.custom-hotkey-dialog:visible').last();
     try {
       await dialog.waitFor({ state: 'visible', timeout: 3000 });
     } catch {
-      const recordButton = drawer.getByRole('button', { name: /录制自定义快捷键|当前：/ });
-      await recordButton.click();
-      dialog = popup.locator('.custom-hotkey-dialog:visible').last();
+      if ((await readStoredConfig(ui.storagePage)).customSelectionTranslatorHotkey !== 'F9') {
+        await ui.options.getByRole('button', { name: '编辑划词翻译快捷键', exact: true }).click();
+        dialog = ui.options.locator('.custom-hotkey-dialog:visible').last();
+        await dialog.waitFor({ state: 'visible', timeout: 10000 });
+      }
     }
-    await dialog.waitFor({ state: 'visible', timeout: 10000 });
-    await dialog.locator('.preset-button').filter({ hasText: 'F9' }).click();
-    await dialog.getByRole('button', { name: '确认', exact: true }).click();
-    await popup.waitForTimeout(600);
+    if (await dialog.isVisible()) {
+      await dialog.getByRole('button', { name: 'F9', exact: true }).click();
+      await dialog.getByRole('button', { name: '确认', exact: true }).click();
+      await dialog.waitFor({ state: 'hidden', timeout: 10000 });
+    }
   }
 
-  return waitForSelectionTriggerState(popup, drawer, storagePage, label);
+  return waitForSelectionTriggerState(ui, label);
 }
 
-async function setSelectionDelay(popup, drawer, storagePage, delay, settleMs = 500) {
-  await activateInputPage(popup);
-  const input = drawer.locator('input[aria-label="划词翻译显示延迟"]');
+async function setSelectionDelay(ui, delay, settleMs = 500) {
+  await activateInputPage(ui.options);
+  const input = ui.options.locator('input[aria-label="划词翻译显示延迟"]');
   await input.fill(String(delay));
   await input.press('Tab');
-  await popup.waitForTimeout(settleMs);
-  const config = await readStoredConfig(storagePage);
+  await ui.options.waitForTimeout(settleMs);
+  const deadline = Date.now() + 5000;
+  let config = await readStoredConfig(ui.storagePage);
+  while (config.selectionTranslatorDelay !== delay && Date.now() < deadline) {
+    await ui.options.waitForTimeout(50);
+    config = await readStoredConfig(ui.storagePage);
+  }
   assert(config.selectionTranslatorDelay === delay,
     `划词显示延迟没有保存：期望 ${delay}，实际 ${config.selectionTranslatorDelay}`);
   return config.selectionTranslatorDelay;
@@ -899,7 +960,8 @@ async function main() {
     await popup.locator('.popup-shell').waitFor({ state: 'visible', timeout: 60000 });
     await popup.locator('.popup-shell[data-config-ready="true"]').waitFor({ state: 'visible', timeout: 60000 });
     await assertBackgroundRoundTrip(popup);
-    await patchStoredConfig(popup, {uiLanguageSetupCompleted: true});
+    // 默认免费翻译会在多个公开接口间均衡分配；固定为本地夹具拦截的微软接口，避免真实网络译文进入断言。
+    await patchStoredConfig(popup, {uiLanguageSetupCompleted: true, service: 'microsoft'});
     await popup.reload({waitUntil: 'domcontentloaded'});
     await popup.locator('.popup-shell[data-config-ready="true"]').waitFor({state: 'visible'});
 
@@ -1156,32 +1218,32 @@ async function main() {
     }
 
     const drawer = await openSelectionDrawer(popup);
-    await setSelectionEnabled(popup, drawer, true);
+    const optionsPage = await openSelectionOptions(context, extensionId, result);
+    const selectionUi = { popup, drawer, options: optionsPage, storagePage: popup };
+    await setSelectionEnabled(selectionUi, true);
     await page.locator('#fluent-read-selection-translator-container').waitFor({ state: 'attached', timeout: 10000 });
-    await setSelectionMode(popup, drawer, '双语显示');
+    await setSelectionMode(selectionUi, '双语显示');
 
-    const initialDelayConfig = await readStoredConfig(popup);
-    const initialDelayInput = await drawer.locator('input[aria-label="划词翻译显示延迟"]').inputValue();
-    assert(initialDelayConfig.selectionTranslatorDelay === 300 && initialDelayInput === '300',
-      `Popup 没有显示默认 300ms 延迟：${JSON.stringify({ stored: initialDelayConfig.selectionTranslatorDelay, input: initialDelayInput })}`);
+    // Popup 抽屉只保留高频模式选择；触发方式、延迟与朗读声音通过底部入口进入完整设置。
+    await activateInputPage(popup);
+    const popupModes = (await drawer.getByRole('group', { name: '划词翻译模式' }).getByRole('button').allTextContents()).map(label => label.trim());
+    assert(JSON.stringify(popupModes) === JSON.stringify(['关闭', '双语显示', '仅译文']), `Popup 划词模式选项异常：${JSON.stringify(popupModes)}`);
+    const popupDetailedControls = {
+      delayInputs: await drawer.locator('input[aria-label="划词翻译显示延迟"]').count(),
+      triggerChips: await drawer.locator('.selection-trigger-chips').count(),
+      hotkeyEditors: await popup.locator('.custom-hotkey-dialog').count(),
+    };
+    assert(Object.values(popupDetailedControls).every(count => count === 0), `Popup 抽屉仍包含完整设置控件：${JSON.stringify(popupDetailedControls)}`);
+    const popupSettingsLink = (await drawer.locator('.drawer-settings-link strong').textContent())?.trim();
+    assert(popupSettingsLink === '划词翻译设置', `Popup 划词抽屉缺少完整设置入口：${popupSettingsLink}`);
+    const initialPopupPreview = await readPopupTriggerPreview(drawer);
+    assert(initialPopupPreview === 'icon', `Popup 没有预览默认的显示图标触发方式：${initialPopupPreview}`);
+    const popupDrawerScreenshot = path.join(args.artifactsDir, 'popup-selection-drawer.png');
+    await popup.screenshot({ path: popupDrawerScreenshot });
+    result.screenshots.push(popupDrawerScreenshot);
+    result.cases.push({ id: 'ui.popup-selection-drawer-quick-controls', status: 'passed', popupModes, popupDetailedControls, popupSettingsLink, initialPopupPreview });
 
-    const drawerBody = popup.locator('.popup-drawer:visible .el-drawer__body');
-    const drawerScroll = await drawerBody.evaluate((element) => {
-      const before = { clientHeight: element.clientHeight, scrollHeight: element.scrollHeight };
-      element.scrollTop = element.scrollHeight;
-      return { ...before, scrollTop: element.scrollTop };
-    });
-    await drawer.getByText('语音回退顺序', { exact: true }).scrollIntoViewIfNeeded();
-    assert(await drawer.getByText('语音回退顺序', { exact: true }).isVisible(), 'Popup 抽屉滚动后仍看不到底部设置');
-    const popupDelayScreenshot = path.join(args.artifactsDir, 'popup-selection-delay.png');
-    await popup.screenshot({ path: popupDelayScreenshot });
-    result.screenshots.push(popupDelayScreenshot);
-    result.cases.push({ id: 'ui.popup-scrolls-to-bottom', status: 'passed', drawerScroll });
-
-    const optionsPage = await createIsolatedPage(context);
-    optionsPage.on('pageerror', (error) => result.consoleErrors.push(`options pageerror: ${error.message}`));
-    optionsPage.on('console', (message) => { if (message.type() === 'error') result.consoleErrors.push(`options console: ${message.text()}`); });
-    await optionsPage.goto(`chrome-extension://${extensionId}/options.html#settings-translation`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await activateInputPage(optionsPage);
     const optionsDelayInput = optionsPage.locator('input[aria-label="划词翻译显示延迟"]');
     try {
       await optionsDelayInput.waitFor({ state: 'visible', timeout: 15000 });
@@ -1202,22 +1264,24 @@ async function main() {
       const diagnostic = { ...pageDiagnostic, storedConfig };
       throw new Error(`完整配置页未显示划词翻译延迟控件：${JSON.stringify(diagnostic)}`, { cause: error });
     }
-    assert(await optionsDelayInput.inputValue() === '300', `完整配置页延迟值错误：${await optionsDelayInput.inputValue()}`);
-    await optionsDelayInput.fill('450');
-    await optionsDelayInput.press('Tab');
-    await optionsPage.waitForTimeout(700);
-    assert((await readStoredConfig(popup)).selectionTranslatorDelay === 450, '完整配置页没有保存 450ms 延迟');
-    await popup.waitForFunction(() => document.querySelector('input[aria-label="划词翻译显示延迟"]')?.value === '450');
+    const initialDelayConfig = await readStoredConfig(popup);
+    const initialDelayInput = await optionsDelayInput.inputValue();
+    assert(initialDelayConfig.selectionTranslatorDelay === 300 && initialDelayInput === '300',
+      `完整配置页没有显示默认 300ms 延迟：${JSON.stringify({ stored: initialDelayConfig.selectionTranslatorDelay, input: initialDelayInput })}`);
+    const initialTriggerState = await waitForSelectionTriggerState(selectionUi, '显示图标');
+    await setSelectionDelay(selectionUi, 450, 700);
+    await optionsPage.reload({ waitUntil: 'domcontentloaded' });
+    await optionsDelayInput.waitFor({ state: 'visible', timeout: 15000 });
+    assert(await optionsDelayInput.inputValue() === '450', `完整配置页重新打开后延迟值错误：${await optionsDelayInput.inputValue()}`);
     const optionsDelayScreenshot = path.join(args.artifactsDir, 'options-selection-delay.png');
     await optionsPage.screenshot({ path: optionsDelayScreenshot });
     result.screenshots.push(optionsDelayScreenshot);
-    result.cases.push({ id: 'ui.options-popup-delay-persistence', status: 'passed', configuredDelay: 450 });
-    await optionsPage.close();
-    await setSelectionDelay(popup, drawer, popup, 300);
+    result.cases.push({ id: 'ui.options-delay-persistence-and-popup-preview', status: 'passed', configuredDelay: 450, initialTriggerState });
+    await setSelectionDelay(selectionUi, 300);
 
     // 显示延迟：计时期间不显示 UI、不发翻译请求；改选后旧计时器必须失效。
-    await setSelectionDelay(popup, drawer, popup, 800);
-    await setSelectionTrigger(popup, drawer, popup, '直接弹出');
+    await setSelectionDelay(selectionUi, 800);
+    await setSelectionTrigger(selectionUi, '直接弹出');
     await resetFixture(page);
     await startSelectionUiTracking(page);
     const delayedRequestsBefore = translationRequestCount;
@@ -1278,8 +1342,8 @@ async function main() {
     result.cases.push({ id: 'delay.changed-selection-invalidates-old-timer', status: 'passed', ui: replacementUi });
 
     await closeSelectionUi(page);
-    await setSelectionDelay(popup, drawer, popup, 1000);
-    await setSelectionTrigger(popup, drawer, popup, 'Ctrl');
+    await setSelectionDelay(selectionUi, 1000);
+    await setSelectionTrigger(selectionUi, 'Ctrl');
     await resetFixture(page);
     const shortcutDelayRequestsBefore = translationRequestCount;
     await selectTextWithDomRange(page, '#target');
@@ -1290,22 +1354,22 @@ async function main() {
     await waitForSelectionUi(page, { tooltip: true, indicator: false, translation: true }, '快捷键等待剩余延迟后显示翻译框');
     result.cases.push({ id: 'delay.shortcut-waits-remaining-time', status: 'passed', duringDelay: duringShortcutDelay });
 
-    // Popup 在线修改延迟后，当前页面按原选区时间重算剩余时长，无需刷新。
+    // 设置页在线修改延迟后，当前页面按原选区时间重算剩余时长，无需刷新。
     await closeSelectionUi(page);
-    await setSelectionTrigger(popup, drawer, popup, '直接弹出');
+    await setSelectionTrigger(selectionUi, '直接弹出');
     await resetFixture(page);
     await selectTextWithDomRange(page, '#target');
     await page.waitForTimeout(150);
     assert(!(await readSelectionUi(page)).tooltip, '在线修改延迟前翻译框已提前显示');
-    await setSelectionDelay(popup, drawer, popup, 200, 100);
+    await setSelectionDelay(selectionUi, 200, 100);
     await waitForSelectionUi(page, { tooltip: true, indicator: false, translation: true }, '在线缩短延迟后显示当前选区');
-    result.cases.push({ id: 'delay.live-popup-reschedule', status: 'passed', configuredDelay: 200 });
+    result.cases.push({ id: 'delay.live-settings-reschedule', status: 'passed', configuredDelay: 200 });
 
     await closeSelectionUi(page);
-    await setSelectionDelay(popup, drawer, popup, 0);
+    await setSelectionDelay(selectionUi, 0);
     await patchStoredConfig(popup, { to: 'fr' });
     await page.waitForTimeout(700);
-    await setSelectionTrigger(popup, drawer, popup, '直接弹出');
+    await setSelectionTrigger(selectionUi, '直接弹出');
     await resetFixture(page);
     translationResponseDelayMs = 500;
     const sameTextRequestsBefore = translationRequestCount;
@@ -1323,13 +1387,13 @@ async function main() {
     await closeSelectionUi(page);
     await patchStoredConfig(popup, { to: 'zh-Hans' });
     await page.waitForTimeout(700);
-    await setSelectionDelay(popup, drawer, popup, 300);
+    await setSelectionDelay(selectionUi, 300);
 
     // 原生三击：普通段落和 JetBrains 评论形状都应显示入口。
     // JetBrains 形状的 Range 会夹带一个 display:none 的 button，但可见选区只有正文。
     await closeSelectionUi(page);
-    await setSelectionDelay(popup, drawer, popup, 0);
-    const tripleClickPopupState = await setSelectionTrigger(popup, drawer, popup, '显示图标');
+    await setSelectionDelay(selectionUi, 0);
+    const tripleClickPopupState = await setSelectionTrigger(selectionUi, '显示图标');
 
     await resetFixture(page);
     const standardTripleClick = await tripleClickTarget(page);
@@ -1417,15 +1481,15 @@ async function main() {
     });
 
     await closeSelectionUi(page);
-    await setSelectionDelay(popup, drawer, popup, 300);
+    await setSelectionDelay(selectionUi, 300);
 
-    // 视觉触发方式：Popup 改设置后不刷新页面，真实鼠标划词仍应反映新模式。
+    // 视觉触发方式：设置页修改后不刷新网页，真实鼠标划词仍应反映新模式。
     for (const mode of [
       { label: '显示图标', className: 'fr-selection-indicator fr-selection-indicator--icon' },
       { label: '显示小点', className: 'fr-selection-indicator fr-selection-indicator--dot' },
     ]) {
       await closeSelectionUi(page);
-      const popupState = await setSelectionTrigger(popup, drawer, popup, mode.label);
+      const popupState = await setSelectionTrigger(selectionUi, mode.label);
       await resetFixture(page);
       const selection = await selectTarget(page);
       await waitForSelectionUi(page, { indicator: true, tooltip: false, indicatorClass: mode.className }, `${mode.label} 显示入口`);
@@ -1442,7 +1506,7 @@ async function main() {
     }
 
     await closeSelectionUi(page);
-    const directPopupState = await setSelectionTrigger(popup, drawer, popup, '直接弹出');
+    const directPopupState = await setSelectionTrigger(selectionUi, '直接弹出');
     await resetFixture(page);
     const directSelection = await selectTarget(page);
     await waitForSelectionUi(page, { tooltip: true, indicator: false, translation: true, resultPrefix: '测试译文：' }, '直接弹出翻译框');
@@ -1478,8 +1542,8 @@ async function main() {
 
     // 显示方式：双语和仅译文应分别渲染对应内容。
     await closeSelectionUi(page);
-    await setSelectionMode(popup, drawer, '仅译文');
-    await setSelectionTrigger(popup, drawer, popup, '直接弹出');
+    await setSelectionMode(selectionUi, '仅译文');
+    await setSelectionTrigger(selectionUi, '直接弹出');
     await resetFixture(page);
     await selectTarget(page);
     await waitForSelectionUi(page, { tooltip: true, original: false, translation: true, resultPrefix: '测试译文：' }, '仅译文模式');
@@ -1488,7 +1552,7 @@ async function main() {
     result.cases.push({ id: 'display.translation-only', status: 'passed', ui: translationOnlyUi });
 
     await closeSelectionUi(page);
-    await setSelectionMode(popup, drawer, '双语显示');
+    await setSelectionMode(selectionUi, '双语显示');
     await resetFixture(page);
     await selectTarget(page);
     await waitForSelectionUi(page, { tooltip: true, original: true, translation: true, resultPrefix: '测试译文：' }, '双语显示模式');
@@ -1498,17 +1562,17 @@ async function main() {
 
     // 关闭/重新启用：关闭后不再挂载划词 UI，重新启用后恢复。
     await closeSelectionUi(page);
-    await setSelectionEnabled(popup, drawer, false);
+    await setSelectionEnabled(selectionUi, false);
     await page.locator('#fluent-read-selection-translator-container').waitFor({ state: 'detached', timeout: 10000 });
     result.cases.push({ id: 'selection.disabled', status: 'passed' });
-    await setSelectionEnabled(popup, drawer, true);
+    await setSelectionEnabled(selectionUi, true);
     await page.locator('#fluent-read-selection-translator-container').waitFor({ state: 'attached', timeout: 10000 });
     result.cases.push({ id: 'selection.re-enabled', status: 'passed' });
 
     // 预设快捷键：选区旁不显示图标/小点，按对应键后直接打开翻译框。
     for (const label of ['Ctrl', 'Alt / Option', 'Shift']) {
       await closeSelectionUi(page);
-      const popupState = await setSelectionTrigger(popup, drawer, popup, label);
+      const popupState = await setSelectionTrigger(selectionUi, label);
       await resetFixture(page);
       await selectTarget(page);
       await page.waitForTimeout(350);
@@ -1527,7 +1591,7 @@ async function main() {
     // 冲突优先级与稳定性：Ctrl 同时配置为划词和鼠标悬浮快捷键时，
     // 有有效选区必须只打开划词框；没有选区时仍回退到悬浮翻译。
     await closeSelectionUi(page);
-    const conflictPopupState = await setSelectionTrigger(popup, drawer, popup, 'Ctrl');
+    const conflictPopupState = await setSelectionTrigger(selectionUi, 'Ctrl');
     await patchStoredConfig(popup, { hotkey: 'Control', customHotkey: '', floatingBallHotkey: 'Control' });
     await page.waitForTimeout(700);
     await resetFixture(page);
@@ -1603,7 +1667,7 @@ async function main() {
     await page.waitForFunction(() => document.querySelectorAll('.fluent-read-bilingual-content').length === 0, undefined, { timeout: 10000 });
 
     await closeSelectionUi(page);
-    const customPopupState = await setSelectionTrigger(popup, drawer, popup, '自定义');
+    const customPopupState = await setSelectionTrigger(selectionUi, '自定义');
     await resetFixture(page);
     await selectTarget(page);
     await page.waitForTimeout(350);
@@ -1649,7 +1713,7 @@ async function main() {
       { label: '自定义', hoverHotkey: 'custom', customHotkey: 'F9' },
     ]) {
       await closeSelectionUi(page);
-      const popupState = await setSelectionTrigger(popup, drawer, popup, conflictCase.label);
+      const popupState = await setSelectionTrigger(selectionUi, conflictCase.label);
       await patchStoredConfig(popup, { hotkey: conflictCase.hoverHotkey, customHotkey: conflictCase.customHotkey });
       await page.waitForTimeout(700);
       await resetFixture(page);

--- a/scripts/testing/run-popup-startup-ui-test.cjs
+++ b/scripts/testing/run-popup-startup-ui-test.cjs
@@ -599,34 +599,61 @@ async function runPersistenceRegression({context, extensionOrigin, popupPath, pa
   report.persistence.quickClose = persistence;
 }
 
-/** 首屏不加载快捷键编辑器，首次懒挂载仍能管理焦点并正确关闭。 */
+/**
+ * 快捷抽屉只保留高频控制，快捷键编辑器归完整设置页：Popup 首屏和打开抽屉后都不能解析含编辑器的脚本；
+ * 抽屉打开时焦点进入抽屉，关闭后回到对应快捷功能卡片，并保留进入完整设置的入口。
+ */
 async function runPopupDeferredUiRegression(context, extensionOrigin, popupPath) {
   const page = await newPageWithoutForeground(context, timeout);
-  const requestedScripts = new Set();
-  const parsedScripts = new Set();
-  const isEditor = url => /CustomHotkeyInput[^/]*\.js$/u.test(url);
-  page.on('request', request => { if (isEditor(request.url())) requestedScripts.add(request.url()); });
+  const parsedScripts = new Map();
+  const editorMarker = 'custom-hotkey-dialog';
   const debuggerSession = await context.newCDPSession(page);
-  debuggerSession.on('Debugger.scriptParsed', event => { if (isEditor(event.url)) parsedScripts.add(event.url); });
+  debuggerSession.on('Debugger.scriptParsed', event => {
+    if (event.url.startsWith(`${extensionOrigin}/`)) parsedScripts.set(event.scriptId, event.url);
+  });
   await debuggerSession.send('Debugger.enable');
+  // chrome-extension 协议不保证写入 Resource Timing；直接检查 V8 实际解析的脚本源码是否带入编辑器。
+  const findEditorScripts = async () => {
+    const matches = [];
+    for (const [scriptId, url] of parsedScripts) {
+      const {scriptSource} = await debuggerSession.send('Debugger.getScriptSource', {scriptId});
+      if (scriptSource.includes(editorMarker)) matches.push(url);
+    }
+    return matches;
+  };
   try {
     await page.setViewportSize({width: 400, height: 600});
     await page.goto(new URL(popupPath, `${extensionOrigin}/`).href, {waitUntil: 'domcontentloaded'});
     await page.locator('.popup-shell[data-config-ready="true"]').waitFor({state: 'visible', timeout});
-    // chrome-extension 协议不保证写入 Resource Timing；用网络事件与 V8 实际模块解析共同验证。
-    if (requestedScripts.size || parsedScripts.size) throw new Error('首屏提前加载了快捷键编辑器');
-    await page.locator('[data-popup-quick-feature="hover"]').click();
-    await page.locator('.popup-drawer').getByRole('button', {name: '自定义', exact: true}).click();
-    const dialog = page.locator('.custom-hotkey-dialog');
-    await dialog.waitFor({state: 'visible', timeout});
-    await page.waitForFunction(() => document.activeElement?.closest('.custom-hotkey-dialog'));
-    if (parsedScripts.size !== 1) throw new Error(`快捷键编辑器未按需解析：${JSON.stringify([...parsedScripts])}`);
-    const dialogScreenshot = await screenshot(page, 'popup-deferred-hotkey-dialog.png');
-    await dialog.getByRole('button', {name: '取消', exact: true}).click();
-    await dialog.waitFor({state: 'detached', timeout});
-    await page.waitForFunction(() => document.activeElement?.closest('.popup-drawer'));
-    return {initialEditorResources: 0, editorLoadedOnDemand: true, requestedScripts: [...requestedScripts],
-      parsedScripts: [...parsedScripts], initialFocus: true, restoredFocus: true, dialogScreenshot};
+    if (!parsedScripts.size) throw new Error('没有捕获到 Popup 解析的扩展脚本，无法证明编辑器未加载');
+    const initialEditorScripts = await findEditorScripts();
+    if (initialEditorScripts.length) throw new Error(`首屏加载了快捷键编辑器：${JSON.stringify(initialEditorScripts)}`);
+    const drawer = page.locator('.popup-drawer');
+    const drawers = [];
+    let drawerScreenshot = '';
+    for (const feature of ['hover', 'selection', 'area']) {
+      const card = page.locator(`[data-popup-quick-feature="${feature}"]`);
+      await card.click();
+      await drawer.locator('.drawer-surface').waitFor({state: 'visible', timeout});
+      await page.waitForFunction(() => document.activeElement?.closest('.popup-drawer'), undefined, {timeout});
+      const settingsLink = drawer.locator('.drawer-settings-link');
+      if (!await settingsLink.isVisible()) throw new Error(`${feature} 抽屉缺少完整设置入口`);
+      if (await page.locator(`.${editorMarker}`).count()) throw new Error(`${feature} 抽屉仍内嵌快捷键编辑器`);
+      if (feature === 'hover') drawerScreenshot = await screenshot(page, 'popup-hover-drawer-no-editor.png');
+      // 划词抽屉有同名的“关闭”模式按钮；只点击抽屉头部的关闭控件。
+      await drawer.locator('.drawer-header').getByRole('button', {name: '关闭', exact: true}).click();
+      await drawer.waitFor({state: 'hidden', timeout});
+      await page.waitForFunction(
+        expected => document.activeElement?.getAttribute('data-popup-quick-feature') === expected,
+        feature,
+        {timeout},
+      );
+      drawers.push({feature, initialFocus: true, restoredFocus: true, settingsLink: (await settingsLink.locator('strong').innerText()).trim()});
+    }
+    const drawerEditorScripts = await findEditorScripts();
+    if (drawerEditorScripts.length) throw new Error(`快捷抽屉加载了快捷键编辑器：${JSON.stringify(drawerEditorScripts)}`);
+    return {initialEditorResources: 0, drawerEditorResources: 0, editorMarker,
+      parsedScripts: [...parsedScripts.values()], drawers, drawerScreenshot};
   } finally { await debuggerSession.detach().catch(() => undefined); await page.close(); }
 }
 

--- a/scripts/testing/run-service-catalog-ui-test.cjs
+++ b/scripts/testing/run-service-catalog-ui-test.cjs
@@ -2,9 +2,11 @@
 
 /**
  * @file scripts/testing/run-service-catalog-ui-test.cjs
- * 文件职责：在屏幕外隔离 Edge 中验证翻译服务目录的二级分类、顺序、折叠、搜索与响应式布局。
- * 主要内容：加载生产扩展，检查动态自定义服务入口、模型服务商和聚合平台清单，覆盖机器翻译手动折叠、搜索自动展开、编辑状态与窄屏无横向溢出。
- * 模块边界：脚本只操作本次创建的临时浏览器 profile，不访问用户日常浏览器，仅修改临时 profile 中的免费候选配置，只有显式 --live true 时调用匿名测试翻译。
+ * 文件职责：在第二屏后台隔离 Edge 中验证翻译服务“全部服务”目录的分类层级、服务顺序与免费翻译候选配置。
+ * 主要内容：加载生产扩展，检查“我的服务 / 全部服务”两级入口、机器翻译、云服务厂商、模型服务商和聚合平台的目录顺序与计数，
+ * 覆盖分类筛选、跨分类搜索、查看服务不改默认服务、窄屏无横向溢出，以及免费翻译的自动均衡/优先顺序、实验候选默认停用、启停、排序和重载持久化。
+ * 模块边界：星标、自定义服务分类、主题与多语言归 run-service-library-ui-test.cjs；本脚本只操作本次创建的临时 profile，
+ * 仅修改其中的免费候选配置，默认不请求任何翻译服务，只有显式 --live true 时才调用匿名测试翻译。
  */
 
 const fs = require('node:fs');
@@ -23,6 +25,18 @@ const artifactsDir = path.resolve(argument('artifacts-dir', '/private/tmp/fluent
 const browserPath = argument('browser-path', '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge');
 const timeout = Number(argument('timeout', '30000'));
 
+const expectedFilters = ['全部分类', '机器翻译', '云服务厂商', '模型服务商', '聚合平台与接口'];
+const expectedSections = ['machine-services', 'cloud-services', 'ai-providers', 'ai-platforms'];
+const expectedMachineServices = [
+  'freeTranslation', 'myMemory', 'microsoft', 'google', 'deepL', 'deeplx', 'xiaoniu', 'youdao', 'localTranslation',
+];
+// Chrome 内置 AI 翻译只在浏览器提供 Translator API 时出现，位置固定在有道翻译与本地模型之间。
+const expectedMachineServicesWithChromeTranslator = [
+  ...expectedMachineServices.slice(0, -1), 'chromeTranslator', 'localTranslation',
+];
+const expectedCloudServices = [
+  'tencent', 'googleCloudTranslation', 'azureTranslator', 'aliyunTranslation', 'baiduTranslation', 'volcTranslation',
+];
 const expectedProviderServices = [
   'deepseek', 'tongyi', 'doubao', 'moonshot', 'zhipu', 'huanYuan',
   'huanYuanTranslation', 'yiyan', 'minimax', 'mimo', 'jieyue', 'openai',
@@ -30,10 +44,16 @@ const expectedProviderServices = [
 ];
 const expectedPlatformServices = [
   'siliconCloud', 'newapi', 'infini', 'openrouter', 'groq', 'azureOpenai',
+  'mistral', 'cohere', 'cerebras', 'togetherai', 'fireworks', 'deepinfra', 'perplexity', 'ollama',
 ];
-const expectedMachineServices = [
-  'freeTranslation', 'myMemory', 'microsoft', 'google', 'deepL', 'deeplx', 'xiaoniu', 'youdao', 'tencent',
+const expectedFreeCandidates = [
+  'microsoft', 'transmart', 'volcengineFree', 'google', 'youdaoFree', 'icibaFree', 'yandexFree', 'deeplx', 'myMemory',
+  'sogouFree', 'reversoFree', 'lingvaFree', 'apertiumFree',
 ];
+const expectedEnabledFreeCandidates = expectedFreeCandidates.slice(0, 9);
+const experimentalFreeCandidates = ['sogouFree', 'reversoFree', 'lingvaFree', 'apertiumFree'];
+// 免密钥网页接口只能作为免费翻译内部候选，不能泄漏成目录中的独立服务。
+const candidateOnlyServices = expectedFreeCandidates.filter(id => !['microsoft', 'google', 'deeplx', 'myMemory'].includes(id));
 
 if (!fs.existsSync(path.join(extensionDir, 'manifest.json'))) throw new Error(`扩展产物不存在：${extensionDir}`);
 if (!fs.existsSync(focusSafeHelper)) throw new Error(`防抢焦点 helper 不存在：${focusSafeHelper}`);
@@ -57,19 +77,43 @@ function assertSameOrder(actual, expected, label) {
   }
 }
 
+async function readStoredConfig(page) {
+  return page.evaluate(async () => {
+    const response = await chrome.runtime.sendMessage({type: 'configStorageRead', key: 'local:config'});
+    if (!response || response.success !== true) throw new Error(`后台配置读取失败：${response?.error || '无响应'}`);
+    return typeof response.value === 'string' ? JSON.parse(response.value) : response.value;
+  });
+}
+
+async function waitForStoredFreeTranslation(page, expected) {
+  const deadline = Date.now() + timeout;
+  let stored;
+  while (Date.now() < deadline) {
+    stored = await readStoredConfig(page);
+    if (stored.freeTranslationMode === expected.mode
+      && JSON.stringify(stored.freeTranslationOrder) === JSON.stringify(expected.order)) {
+      return {mode: stored.freeTranslationMode, order: stored.freeTranslationOrder};
+    }
+    await page.waitForTimeout(100);
+  }
+  throw new Error(`免费候选没有持久化：${JSON.stringify({expected, mode: stored?.freeTranslationMode, order: stored?.freeTranslationOrder})}`);
+}
+
 async function main() {
   const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fluentread-service-catalog-profile-'));
   const consoleErrors = [];
   const report = {
+    ok: false,
     extensionDir,
     artifactsDir,
     launchMode: null,
     focusPolicy: null,
     windowPlacement: null,
     manifest: {},
-    serviceGroups: {},
-    collapse: {},
+    directory: {},
+    editing: {},
     responsive: [],
+    freeCandidates: {},
     consoleErrors,
     screenshots: [],
   };
@@ -101,6 +145,7 @@ async function main() {
     report.launchMode = launched.launchMode;
     report.focusPolicy = launched.focusPolicy;
     report.windowPlacement = launched.windowPlacement;
+    if (report.windowPlacement?.browserFrontmost !== false) throw new Error('隔离 Edge 抢占了前台焦点');
 
     const {context} = launched;
     let workers = context.serviceWorkers().filter(worker => worker.url().startsWith('chrome-extension://'));
@@ -116,167 +161,206 @@ async function main() {
     await page.setViewportSize({width: 1440, height: 1000});
     const catalog = page.locator('.service-catalog');
     await catalog.waitFor({state: 'visible', timeout});
+    const directory = catalog.locator('.service-directory');
+    const rail = catalog.locator('.service-rail');
+    const viewButton = view => catalog.locator(`[data-service-view="${view}"]`);
+    const filterButton = label => directory.locator('.directory-filters').getByRole('button', {name: label, exact: true});
 
-    const topLevelGroups = (await catalog.locator('.group-heading strong').allTextContents()).map(value => value.trim());
-    assertSameOrder(topLevelGroups, ['我的服务', '机器翻译', 'AI翻译'], '顶层服务');
-    const subgroupLabels = (await catalog.locator('.subgroup-heading strong').allTextContents()).map(value => value.trim());
-    assertSameOrder(subgroupLabels, ['模型服务商', '聚合平台与接口'], 'AI 二级');
-
-    const providerServices = await catalog
-      .locator('[data-service-subgroup="ai-providers"] .service-item')
-      .evaluateAll(items => items.map(item => item.getAttribute('data-service-value')));
-    const platformServices = await catalog
-      .locator('[data-service-subgroup="ai-platforms"] .service-item')
-      .evaluateAll(items => items.map(item => item.getAttribute('data-service-value')));
-    assertSameOrder(providerServices, expectedProviderServices, '模型服务商');
-    assertSameOrder(platformServices, expectedPlatformServices, '聚合平台');
-    const customGroup = catalog.locator('.custom-service-group');
-    const customCount = (await customGroup.getByTestId('custom-service-count').textContent())?.trim();
-    if (customCount !== '0 / 20'
-      || await customGroup.getByTestId('custom-service-add').isDisabled()
-      || !await customGroup.getByText('还没有自定义服务', {exact: true}).isVisible()) {
-      throw new Error(`空自定义服务入口异常：${customCount}`);
+    // 两级入口：新用户默认停在“我的服务”，个人列表只有当前默认服务。
+    const views = await catalog.locator('[data-service-view]').evaluateAll(nodes => nodes.map(node => node.dataset.serviceView));
+    assertSameOrder(views, ['mine', 'all'], '服务视图');
+    if (await viewButton('mine').getAttribute('aria-pressed') !== 'true' || await directory.isVisible()) {
+      throw new Error('服务目录没有默认停在“我的服务”');
     }
-    const machineGroup = catalog.locator('[data-service-section="machine"]');
-    const serviceItems = catalog.locator('.service-item');
-    const machineServices = await machineGroup.locator('.service-item')
-      .evaluateAll(items => items.map(item => item.getAttribute('data-service-value')));
-    const chromeMachineServices = [...expectedMachineServices, 'chromeTranslator'];
+    const defaultService = await catalog.getAttribute('data-default-service');
+    const personalGroups = await rail.locator('[data-personal-group]').evaluateAll(groups => groups.map(group => ({
+      id: group.dataset.personalGroup,
+      services: [...group.querySelectorAll('[data-service-value]')].map(item => item.dataset.serviceValue),
+    })));
+    if (defaultService !== 'freeTranslation'
+      || JSON.stringify(personalGroups) !== JSON.stringify([{id: 'default', services: ['freeTranslation']}])) {
+      throw new Error(`新 profile 的个人服务列表异常：${JSON.stringify({defaultService, personalGroups})}`);
+    }
+
+    await viewButton('all').click();
+    await directory.waitFor({state: 'visible', timeout});
+    if (await directory.getAttribute('data-directory-view') !== 'all') throw new Error('全部服务目录没有进入 all 视图');
+    const filters = (await directory.locator('.directory-filters button').allTextContents()).map(value => value.trim());
+    assertSameOrder(filters, expectedFilters, '目录筛选');
+    const sections = await directory.locator('[data-service-section]').evaluateAll(nodes => nodes.map(node => ({
+      id: node.dataset.serviceSection,
+      heading: node.querySelector('h4')?.childNodes[0]?.textContent?.trim() || '',
+      count: Number(node.querySelector('h4 small')?.textContent?.trim() || -1),
+      services: [...node.querySelectorAll('[data-service-value]')].map(item => item.dataset.serviceValue),
+    })));
+    assertSameOrder(sections.map(section => section.id), expectedSections, '顶层目录');
+    assertSameOrder(sections.map(section => section.heading), expectedFilters.slice(1), '目录标题');
+    const byId = Object.fromEntries(sections.map(section => [section.id, section]));
+    const machineServices = byId['machine-services'].services;
     if (JSON.stringify(machineServices) !== JSON.stringify(expectedMachineServices)
-      && JSON.stringify(machineServices) !== JSON.stringify(chromeMachineServices)) {
+      && JSON.stringify(machineServices) !== JSON.stringify(expectedMachineServicesWithChromeTranslator)) {
       throw new Error(`机器翻译分类或顺序异常：${JSON.stringify(machineServices)}`);
     }
-    if (await serviceItems.count() !== machineServices.length + expectedProviderServices.length + expectedPlatformServices.length) {
-      throw new Error(`服务项数量异常：机器翻译 ${machineServices.length}，全部 ${await serviceItems.count()}`);
+    assertSameOrder(byId['cloud-services'].services, expectedCloudServices, '云服务厂商');
+    assertSameOrder(byId['ai-providers'].services, expectedProviderServices, '模型服务商');
+    assertSameOrder(byId['ai-platforms'].services, expectedPlatformServices, '聚合平台');
+    const miscounted = sections.filter(section => section.count !== section.services.length);
+    if (miscounted.length) throw new Error(`目录分组计数与服务数量不一致：${JSON.stringify(miscounted)}`);
+    const allServiceCount = sections.reduce((sum, section) => sum + section.services.length, 0);
+    const allViewCount = Number((await viewButton('all').locator('small').textContent())?.trim());
+    if (allViewCount !== allServiceCount) throw new Error(`全部服务计数异常：${allViewCount} / ${allServiceCount}`);
+    const leakedServices = await directory.locator('[data-service-value]').evaluateAll(
+      (items, forbidden) => items.map(item => item.dataset.serviceValue).filter(value => forbidden.includes(value)),
+      [...candidateOnlyServices, 'custom'],
+    );
+    if (leakedServices.length) throw new Error(`免费候选或旧自定义入口泄漏到独立目录：${JSON.stringify(leakedServices)}`);
+    if (await directory.locator('[data-service-section="custom"]').count() || await filterButton('自定义服务').count()) {
+      throw new Error('没有自定义服务时目录仍显示自定义分类');
     }
-    report.serviceGroups = {
-      topLevelGroups,
-      subgroupLabels,
-      machineServices,
-      providerServices,
-      platformServices,
-      customServices: {count: 0, limit: 20, addEnabled: true},
+    const iconFailures = await directory.locator('[data-service-value]').evaluateAll(items => items
+      .filter(item => !item.querySelector('svg') || item.querySelector('svg text, img, image, [data-service-icon-fallback]'))
+      .map(item => item.dataset.serviceValue));
+    if (iconFailures.length) throw new Error(`服务目录存在未渲染的本地内联图标：${JSON.stringify(iconFailures)}`);
+    report.directory = {
+      views,
+      filters,
+      sections: sections.map(({id, count, services}) => ({id, count, services})),
+      allServiceCount,
+      chromeTranslatorListed: machineServices.includes('chromeTranslator'),
+      candidateOnlyServicesHidden: candidateOnlyServices,
     };
-    if (await serviceItems.locator('.service-brand-icon svg').count() !== await serviceItems.count()) {
-      throw new Error('服务列表存在未渲染的本地图标');
-    }
+    await screenshot(page, 'service-catalog-all.png', report);
 
-    const defaultService = await catalog.getAttribute('data-default-service');
-    const machineToggle = machineGroup.locator('[data-service-section-toggle="machine"]');
-    if (await machineToggle.getAttribute('aria-expanded') !== 'true') {
-      throw new Error(`默认机器翻译服务没有自动展开：${defaultService}`);
-    }
-    const defaultItem = catalog.locator(`.service-item[data-service-value="${defaultService}"]`);
-    if (await defaultItem.count() !== 1 || !await defaultItem.isVisible()) throw new Error('当前默认服务没有保持可见');
-
-    await machineToggle.click();
-    if (await machineToggle.getAttribute('aria-expanded') !== 'false'
-      || await machineGroup.locator('.service-item').first().isVisible()) {
-      throw new Error('机器翻译分组无法收起');
-    }
-    await screenshot(page, 'service-catalog-machine-collapsed.png', report);
-
-    const serviceSearch = catalog.getByPlaceholder('搜索翻译服务');
-    await serviceSearch.fill('微软翻译');
-    await machineGroup.locator('.service-item[data-service-value="microsoft"]').waitFor({state: 'visible', timeout});
-    if (await machineToggle.getAttribute('aria-expanded') !== 'true') throw new Error('搜索机器翻译时没有自动展开分组');
-    if (!await machineToggle.isDisabled()) throw new Error('搜索期间机器翻译折叠按钮仍可操作');
-    await serviceSearch.fill('');
-    await machineGroup.locator('.service-item').first().waitFor({state: 'hidden', timeout});
-    if (await machineToggle.getAttribute('aria-expanded') !== 'false') throw new Error('清空搜索后没有恢复手动折叠状态');
-    if (await machineToggle.isDisabled()) throw new Error('清空搜索后机器翻译折叠按钮没有恢复可用');
-
-    const deepSeekItem = catalog.locator('.service-item[data-service-value="deepseek"]');
-    await deepSeekItem.click();
-    await page.waitForFunction(() => document.querySelector('.service-catalog')?.getAttribute('data-editing-service') === 'deepseek', null, {timeout});
-    if (await catalog.getAttribute('data-default-service') !== defaultService) throw new Error('切换编辑服务时误改默认服务');
-    if (await machineToggle.getAttribute('aria-expanded') !== 'false') throw new Error('选择 AI 服务后覆盖了用户的机器翻译折叠状态');
-    if (!await catalog.getByText('正在配置', {exact: true}).isVisible()) throw new Error('非默认服务没有显示正在配置状态');
-    await screenshot(page, 'service-catalog-providers.png', report);
-
-    const platformHeading = catalog.locator('[data-service-subgroup="ai-platforms"] .subgroup-heading');
-    await platformHeading.scrollIntoViewIfNeeded();
+    // 分类筛选只保留一个分组；在筛选状态下搜索会回到全部分类，跨组查找服务。
+    await filterButton('聚合平台与接口').click();
+    const platformOnly = await directory.locator('[data-service-section]').evaluateAll(nodes => nodes.map(node => node.dataset.serviceSection));
+    assertSameOrder(platformOnly, ['ai-platforms'], '聚合平台筛选');
+    if (await filterButton('聚合平台与接口').getAttribute('aria-pressed') !== 'true') throw new Error('分类筛选按钮没有进入选中状态');
     await screenshot(page, 'service-catalog-platforms.png', report);
-
+    const serviceSearch = catalog.getByRole('searchbox', {name: '搜索所有翻译服务'});
+    await serviceSearch.fill('微软翻译');
+    if (await filterButton('全部分类').getAttribute('aria-pressed') !== 'true') throw new Error('搜索没有回到全部分类');
+    const microsoftResult = await directory.locator('[data-service-value]').evaluateAll(items => items.map(item => item.dataset.serviceValue));
+    assertSameOrder(microsoftResult, ['microsoft'], '机器翻译搜索');
     await serviceSearch.fill('New API');
-    const visibleSearchItems = catalog.locator('.service-item:visible');
-    if (await visibleSearchItems.count() !== 1
-      || await visibleSearchItems.first().getAttribute('data-service-value') !== 'newapi') {
-      throw new Error('聚合平台搜索结果不唯一或不正确');
-    }
+    const newApiResult = await directory.locator('[data-service-value]').evaluateAll(items => items.map(item => item.dataset.serviceValue));
+    assertSameOrder(newApiResult, ['newapi'], '聚合平台搜索');
+    await serviceSearch.fill('nonexistent-service-97531');
+    await directory.getByRole('status').waitFor({state: 'visible', timeout});
     await serviceSearch.fill('');
+    report.directory.filterAndSearch = {platformOnly, microsoftResult, newApiResult, emptyState: true};
 
-    report.collapse = {
-      defaultService,
-      currentMachineServiceAutoExpanded: true,
-      manualCollapse: true,
-      searchAutoExpanded: true,
-      clearSearchRestoredCollapse: true,
-      aiSelectionPreservedCollapse: true,
-    };
+    // 从目录查看服务只切换编辑目标，默认服务、默认标记和个人列表中的默认分组保持不变。
+    await directory.locator('[data-service-value="deepseek"]').click();
+    await page.waitForFunction(() => document.querySelector('.service-catalog')?.getAttribute('data-editing-service') === 'deepseek', null, {timeout});
+    if (await viewButton('mine').getAttribute('aria-pressed') !== 'true') throw new Error('查看服务后没有回到“我的服务”工作区');
+    if (await catalog.getAttribute('data-default-service') !== defaultService) throw new Error('切换编辑服务时误改默认服务');
+    if ((await catalog.locator('.active-badge').textContent())?.trim() !== '正在配置') throw new Error('非默认服务没有显示正在配置状态');
+    if (await rail.locator('[data-personal-group="viewing"] [data-service-value="deepseek"]').count() !== 1
+      || await rail.locator('[data-personal-group="default"] [data-service-value="freeTranslation"]').count() !== 1) {
+      throw new Error('个人列表没有同时保留默认服务与正在查看的服务');
+    }
+    if (!await catalog.getByRole('button', {name: '设为默认', exact: true}).isVisible()) throw new Error('非默认服务缺少显式“设为默认”操作');
+    if ((await readStoredConfig(page)).service !== defaultService) throw new Error('查看服务写入了 config.service');
+    await screenshot(page, 'service-catalog-editing-deepseek.png', report);
+    report.editing = {defaultService, editingService: 'deepseek', badge: '正在配置', storedServiceUnchanged: true};
 
     for (const viewport of [
       {width: 820, height: 900},
       {width: 390, height: 844},
     ]) {
       await page.setViewportSize(viewport);
-      await page.waitForTimeout(150);
-      const metrics = await page.evaluate(() => ({
-        horizontalOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
-        catalogWidth: Math.round(document.querySelector('.service-catalog')?.getBoundingClientRect().width || 0),
-        viewportWidth: window.innerWidth,
-        serviceRailOverflow: (() => {
-          const rail = document.querySelector('.service-rail');
-          return rail ? rail.scrollHeight > rail.clientHeight : false;
-        })(),
-      }));
-      if (metrics.horizontalOverflow || metrics.catalogWidth > metrics.viewportWidth + 1) {
-        throw new Error(`${viewport.width}px 服务目录横向溢出：${JSON.stringify(metrics)}`);
+      for (const view of ['all', 'mine']) {
+        await viewButton(view).click();
+        await page.waitForTimeout(150);
+        const metrics = await page.evaluate(() => ({
+          horizontalOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+          catalogWidth: Math.round(document.querySelector('.service-catalog')?.getBoundingClientRect().width || 0),
+          viewportWidth: window.innerWidth,
+          overflowingControls: [...document.querySelectorAll('.catalog-toolbar button, .catalog-search, .directory-filters button, .directory-grid, .service-rail')]
+            .filter(node => node.getClientRects().length)
+            .filter(node => node.getBoundingClientRect().right > innerWidth + 1 || node.getBoundingClientRect().left < 0).length,
+        }));
+        if (metrics.horizontalOverflow || metrics.catalogWidth > metrics.viewportWidth + 1 || metrics.overflowingControls) {
+          throw new Error(`${viewport.width}px ${view} 服务目录横向溢出：${JSON.stringify(metrics)}`);
+        }
+        report.responsive.push({...viewport, view, ...metrics});
+        await screenshot(page, `service-catalog-${viewport.width}-${view}.png`, report);
       }
-      report.responsive.push({...viewport, ...metrics});
-      await screenshot(page, `service-catalog-${viewport.width}.png`, report);
     }
 
+    // 免费翻译：候选按注册表展示，实验候选默认停用；改为优先顺序后可启停、排序并在重载后保持。
     await page.setViewportSize({width: 1440, height: 1000});
-    await serviceSearch.fill('免费翻译');
-    await catalog.locator('[data-service-value="freeTranslation"]').click();
-    const candidates = page.locator('[data-fallback-provider]');
-    await candidates.first().waitFor({state: 'visible', timeout});
-    const candidateIds = await candidates.evaluateAll(rows => rows.map(row => row.dataset.fallbackProvider));
-    assertSameOrder(candidateIds, ['microsoft', 'deeplx', 'google', 'myMemory', 'transmart', 'yandexFree', 'volcengineFree'], '免费候选');
-    for (const id of ['transmart', 'yandexFree', 'volcengineFree']) {
-      if (await catalog.locator(`[data-service-value="${id}"]`).count()) throw new Error(`免费候选泄漏到独立目录：${id}`);
-      const row = page.locator(`[data-fallback-provider="${id}"]`);
-      if (!(await row.getAttribute('class') || '').includes('is-disabled')) throw new Error(`新增候选默认启用：${id}`);
-      await row.locator('.el-switch').click();
+    await viewButton('mine').click();
+    const openFreeTranslation = async () => {
+      await rail.locator('[data-personal-group="default"] [data-service-value="freeTranslation"]').click();
+      await page.locator('[data-free-translation-settings] [data-fallback-provider]').first().waitFor({state: 'visible', timeout});
+    };
+    await openFreeTranslation();
+    const freeSettings = page.locator('[data-free-translation-settings]');
+    const candidateRows = freeSettings.locator('[data-fallback-provider]');
+    const readCandidates = () => candidateRows.evaluateAll(rows => rows.map(row => ({
+      id: row.dataset.fallbackProvider,
+      enabled: !row.classList.contains('is-disabled'),
+    })));
+    const initialCandidates = await readCandidates();
+    assertSameOrder(initialCandidates.map(row => row.id), expectedFreeCandidates, '免费候选');
+    assertSameOrder(initialCandidates.filter(row => row.enabled).map(row => row.id), expectedEnabledFreeCandidates, '默认启用免费候选');
+    const enabledExperimental = initialCandidates.filter(row => experimentalFreeCandidates.includes(row.id) && row.enabled);
+    if (enabledExperimental.length) throw new Error(`实验候选默认启用：${JSON.stringify(enabledExperimental)}`);
+    const modeRadio = mode => freeSettings.locator(`input[name="free-translation-mode"][value="${mode}"]`);
+    if (!await modeRadio('balanced').isChecked() || await freeSettings.getByRole('button', {name: /^上移 /u}).count()) {
+      throw new Error('免费翻译默认不是自动均衡，或自动均衡仍显示排序按钮');
     }
-    await page.locator('[data-fallback-provider="transmart"]').getByRole('button', {name: '上移 腾讯交互翻译', exact: true}).click();
-    await page.locator('[data-fallback-provider="transmart"]').scrollIntoViewIfNeeded();
-    await screenshot(page, 'free-candidates-enabled.png', report);
-    await page.waitForTimeout(1000);
+
+    await freeSettings.locator('[data-fallback-provider="sogouFree"] .el-switch').click();
+    await modeRadio('sequential').check();
+    await freeSettings.getByRole('button', {name: '上移 搜狗翻译', exact: true}).click();
+    await freeSettings.locator('[data-fallback-provider="yandexFree"] .el-switch').click();
+    const expectedOrder = ['microsoft', 'transmart', 'volcengineFree', 'google', 'youdaoFree', 'icibaFree', 'deeplx', 'sogouFree', 'myMemory'];
+    const sequentialCandidates = await readCandidates();
+    assertSameOrder(sequentialCandidates.filter(row => row.enabled).map(row => row.id), expectedOrder, '优先顺序');
+    assertSameOrder(sequentialCandidates.map(row => row.id).slice(0, expectedOrder.length), expectedOrder, '优先顺序中启用候选置顶');
+    const positions = await freeSettings.locator('.provider-position').allTextContents();
+    if (positions[expectedOrder.indexOf('sogouFree')]?.trim() !== String(expectedOrder.indexOf('sogouFree') + 1)) {
+      throw new Error(`优先顺序序号异常：${JSON.stringify(positions)}`);
+    }
+    if (!await freeSettings.getByRole('button', {name: '上移 微软翻译', exact: true}).isDisabled()) throw new Error('首个候选仍可上移');
+    await freeSettings.locator('[data-fallback-provider="sogouFree"]').scrollIntoViewIfNeeded();
+    await screenshot(page, 'free-candidates-sequential.png', report);
+    const stored = await waitForStoredFreeTranslation(page, {mode: 'sequential', order: expectedOrder});
+
     await page.reload({waitUntil: 'domcontentloaded'});
-    await page.locator('.service-catalog').waitFor({state: 'visible', timeout});
-    await page.getByPlaceholder('搜索翻译服务').fill('免费翻译');
-    await page.locator('.service-catalog [data-service-value="freeTranslation"]').click();
-    await page.locator('[data-fallback-provider]').first().waitFor({state: 'visible', timeout});
-    const saved = await page.locator('[data-fallback-provider]:not(.is-disabled)').evaluateAll(rows => rows.map(row => row.dataset.fallbackProvider));
-    assertSameOrder(saved, ['microsoft', 'deeplx', 'google', 'transmart', 'myMemory', 'yandexFree', 'volcengineFree'], '免费候选持久化');
-    report.freeCandidates = {candidateIds, saved, standaloneEntries: 0};
+    await catalog.waitFor({state: 'visible', timeout});
+    await openFreeTranslation();
+    const reloadedCandidates = await readCandidates();
+    assertSameOrder(reloadedCandidates.filter(row => row.enabled).map(row => row.id), expectedOrder, '免费候选持久化');
+    if (!await modeRadio('sequential').isChecked()) throw new Error('重载后免费翻译模式没有保持优先顺序');
+    report.freeCandidates = {
+      candidateIds: initialCandidates.map(row => row.id),
+      defaultEnabled: expectedEnabledFreeCandidates,
+      experimentalDefaultDisabled: experimentalFreeCandidates,
+      stored,
+      reloaded: reloadedCandidates.filter(row => row.enabled).map(row => row.id),
+      standaloneEntries: 0,
+    };
     await page.setViewportSize({width: 390, height: 844});
+    await page.waitForTimeout(150);
     if (await page.evaluate(() => document.documentElement.scrollWidth > innerWidth + 1)) throw new Error('免费候选在窄屏横向溢出');
-    await page.locator('[data-fallback-provider="transmart"]').scrollIntoViewIfNeeded();
+    await freeSettings.locator('[data-fallback-provider="sogouFree"]').scrollIntoViewIfNeeded();
     await screenshot(page, 'free-candidates-390.png', report);
+
     if (argument('live', 'false') === 'true') {
       report.liveConnections = [];
       await page.setViewportSize({width: 1440, height: 1000});
       for (const id of ['transmart', 'yandexFree', 'volcengineFree']) {
-        const selected = page.locator(`[data-fallback-provider="${id}"]`);
+        const selected = freeSettings.locator(`[data-fallback-provider="${id}"]`);
         if ((await selected.getAttribute('class') || '').includes('is-disabled')) await selected.locator('.el-switch').click();
-        for (const other of candidateIds.filter(value => value !== id)) {
-          const row = page.locator(`[data-fallback-provider="${other}"]`);
+        for (const other of expectedFreeCandidates.filter(value => value !== id)) {
+          const row = freeSettings.locator(`[data-fallback-provider="${other}"]`);
           if (!(await row.getAttribute('class') || '').includes('is-disabled')) await row.locator('.el-switch').click();
         }
-        await page.locator('[data-connection-test-button]').click();
+        await page.locator('[data-connection-test-button]').first().click();
         await page.locator('[data-connection-test-status]:not(.is-testing)').waitFor({state: 'visible', timeout});
         const result = page.locator('[data-connection-test-status]');
         const success = (await result.getAttribute('class') || '').includes('is-success');
@@ -286,6 +370,7 @@ async function main() {
     }
 
     if (consoleErrors.length) throw new Error(`浏览器控制台存在错误：${consoleErrors.join(' | ')}`);
+    report.ok = true;
   } finally {
     fs.writeFileSync(path.join(artifactsDir, 'report.json'), JSON.stringify(report, null, 2));
     await launched?.close();

--- a/scripts/testing/run-service-library-ui-test.cjs
+++ b/scripts/testing/run-service-library-ui-test.cjs
@@ -50,20 +50,22 @@ const save=()=>fs.writeFileSync(path.join(artifacts,'report.json'),JSON.stringif
   const shot=async name=>{const file=path.join(artifacts,`${name}.png`);await page.screenshot({path:file,fullPage:true});report.screenshots.push(file);};
   const invariant=async expected=>assert.equal(await page.locator('.service-catalog').getAttribute('data-default-service'),expected);
   const viewButton=view=>page.locator(`[data-service-view="${view}"]:visible`);
-  assert.equal(await page.locator('[data-service-view]').count(),3);
-  for(const view of ['mine','custom','all']) {
+  // 自定义服务不再占用独立视图，只作为“全部服务”中的目录分类出现。
+  const customCategory=()=>all().getByRole('button',{name:'自定义服务',exact:true});
+  assert.deepEqual(await page.locator('[data-service-view]').evaluateAll(nodes=>nodes.map(n=>n.dataset.serviceView)),['mine','all']);
+  for(const view of ['mine','all']) {
    const box=await viewButton(view).boundingBox();
    assert(box&&box.width>0&&box.height>=40,`服务视图入口不可见：${view}`);
   }
   assert.equal(await mine().locator('[data-service-value]').count(),1);
   await shot('01-first-use');report.cases.push('new-user-default-only');
-  await viewButton('custom').click();
-  assert.equal(await all().getAttribute('data-directory-view'),'custom');
+  await browse();
+  assert.equal(await all().getAttribute('data-directory-view'),'all');
+  assert.equal(await viewButton('all').getAttribute('aria-pressed'),'true');
+  assert((await all().locator('[data-service-value]').count())>40);
   assert.equal(await all().locator('[data-service-section="custom"]').count(),0);
-  assert.equal(await page.locator('[data-service-view="custom"]').getAttribute('aria-pressed'),'true');
-  report.cases.push('custom-view-visible-before-first-custom-service');
-  await browse();assert((await all().locator('[data-service-value]').count())>40);
-  assert.equal(await all().locator('[data-service-section="custom"]').count(),0);
+  assert.equal(await customCategory().count(),0);
+  report.cases.push('no-custom-category-before-first-custom-service');
   await select('openai').click();await invariant('freeTranslation');
   assert.equal(await page.locator('.service-catalog').getAttribute('data-editing-service'),'openai');
   assert.equal(await mine().locator('[data-personal-group="viewing"] [data-service-value="openai"]').count(),1);
@@ -81,13 +83,15 @@ const save=()=>fs.writeFileSync(path.join(artifacts,'report.json'),JSON.stringif
   await page.close();page=await newOptions();await page.locator('[data-personal-group="configured"] [data-service-value="openai"]').waitFor();
   assert.equal(await star('openai').getAttribute('aria-pressed'),'false');
   report.persistenceCases.push('unfavorite-retains-saved-service-after-reopen');
-  await viewButton('custom').click();
-  assert.equal(await all().getAttribute('data-directory-view'),'custom');
-  assert.equal(await all().locator('[data-service-section="custom"] [data-service-value]').count(),1);
-  assert.equal(await all().locator('[data-service-section="custom"] [data-service-value]').getAttribute('data-service-value'),'custom:work');
   await browse();
   assert.equal(await all().locator('[data-service-section="custom"] [data-service-value]').count(),1);
-  report.cases.push('custom-service-is-in-full-catalog');
+  assert.equal(await all().locator('[data-service-section="custom"] [data-service-value]').getAttribute('data-service-value'),'custom:work');
+  await customCategory().click();
+  assert.equal(await customCategory().getAttribute('aria-pressed'),'true');
+  assert.deepEqual(await all().locator('[data-service-section]').evaluateAll(nodes=>nodes.map(n=>n.dataset.serviceSection)),['custom']);
+  assert.equal(await all().locator('[data-service-value]').count(),1);
+  await browse();assert.equal(await customCategory().getAttribute('aria-pressed'),'false');
+  report.cases.push('custom-service-is-a-full-catalog-category');
   await select('deepseek').click();await shot('02-my-services');
   await browse();await shot('03-all-services');
   const icons=await all().locator('[data-service-value]').evaluateAll(nodes=>nodes.map(n=>({service:n.dataset.serviceValue,svg:!!n.querySelector('svg'),text:!!n.querySelector('svg text'),image:!!n.querySelector('img, image'),fallback:!!n.querySelector('[data-service-icon-fallback]')})));
@@ -108,17 +112,19 @@ const save=()=>fs.writeFileSync(path.join(artifacts,'report.json'),JSON.stringif
   await all().getByRole('status').waitFor();report.cases.push('global-search-and-empty-state');
   await seed({service:'freeTranslation',favoriteServices:['deepseek','custom:work','openai'],customOpenAIProviders:Array.from({length:20},(_,i)=>({id:i===0?'custom:work':`custom:test${i}`,name:i===0?'工作翻译接口':`长名称自定义翻译服务 ${i} · 内部模型接口`,endpoint:'http://localhost:11434/v1',models:['local-model']}))});
   await page.reload();await page.locator('[data-service-view="mine"]').waitFor();
-  await viewButton('custom').click();
+  await browse();
+  assert.equal(await all().locator('[data-service-section="custom"] [data-service-value]').count(),20);
+  await customCategory().click();
   assert.equal(await all().locator('[data-service-section="custom"] [data-service-value]').count(),20);
   assert((await all().locator('[data-service-section="custom"] h4').textContent()).includes('自定义服务'));
   assert((await all().locator('[data-service-section="custom"] [data-service-value]').first().textContent()).includes('工作翻译接口'));
-  await browse();
-  assert.equal(await all().locator('[data-service-section="custom"] [data-service-value]').count(),20);
-  report.cases.push('custom-view-and-full-catalog-include-all-custom-services');
+  report.cases.push('full-catalog-and-custom-category-include-all-custom-services');
   for(const width of [1440,1024,820,390]){
    await page.setViewportSize({width,height:1000});
    for(const view of ['all','custom','mine']){
-    await page.locator(`[data-service-view="${view}"]`).click();
+    // “custom”是全部服务中的自定义分类，用于压测 20 个长名称服务的窄屏布局。
+    await page.locator(`[data-service-view="${view==='custom'?'all':view}"]`).click();
+    if(view==='custom')await customCategory().click();
     const metrics=await page.evaluate(()=>({filtersHeight:document.querySelector('.directory-filters').getBoundingClientRect().height,toolbarHeight:document.querySelector('.catalog-toolbar').getBoundingClientRect().height,width:innerWidth,scrollWidth:document.documentElement.scrollWidth,scrollHeight:document.documentElement.scrollHeight,height:innerHeight,overflow:[...document.querySelectorAll('.catalog-toolbar button,.library-favorite,.catalog-search,.directory-grid')].filter(n=>n.getClientRects().length).filter(n=>n.getBoundingClientRect().right>innerWidth+1||n.getBoundingClientRect().left<0).length}));
     if(width===1440){assert(metrics.toolbarHeight<90,JSON.stringify(metrics));if(view==='all')assert(metrics.filtersHeight<100,JSON.stringify(metrics));}
     assert(metrics.scrollWidth<=width+1,JSON.stringify(metrics));assert(metrics.scrollHeight<=metrics.height+1,JSON.stringify(metrics));assert.equal(metrics.overflow,0,JSON.stringify(metrics));

--- a/scripts/testing/run-settings-center-ui-test.cjs
+++ b/scripts/testing/run-settings-center-ui-test.cjs
@@ -64,11 +64,12 @@ function contrastRatio(foreground, background) {
   const [first, second] = colors.map(luminance).sort((left, right) => right - left);
   return (first + .05) / (second + .05);
 }
+// 基础配置按使用顺序排列：先选服务，再设置翻译触发，最后调整界面风格。
 const expectedNavigation = [
   ['settings-general', '通用设置'],
-  ['settings-interface', '界面风格'],
   ['settings-services', '翻译服务'],
   ['settings-translation', '翻译设置'],
+  ['settings-interface', '界面风格'],
   ['settings-harness', '翻译卡片'],
   ['settings-image-translation', '图片翻译'],
   ['settings-area-translation', '圈选翻译'],
@@ -84,14 +85,16 @@ const expectedNavigation = [
   ['settings-about', '关于流畅阅读'],
 ];
 const expectedNavigationGroups = [
-  ['基础配置', ['settings-general', 'settings-interface', 'settings-services', 'settings-translation']],
+  ['基础配置', ['settings-general', 'settings-services', 'settings-translation', 'settings-interface']],
   ['专项翻译', ['settings-harness', 'settings-image-translation', 'settings-area-translation', 'settings-video', 'settings-sites']],
   ['工具与学习', ['settings-writing', 'settings-translation-center', 'settings-vocabulary', 'settings-glossary', 'settings-model-usage']],
   ['系统与数据', ['settings-advanced', 'settings-data', 'settings-about']],
 ];
-const expectedGeneralGroups = ['选择翻译服务', '译文显示', '网页辅助', '悬浮球进阶设置'];
+// 译文显示是“选择翻译服务”内的子分组；悬浮球进阶设置已并入翻译设置。
+const expectedGeneralGroups = ['选择翻译服务', '网页辅助'];
+const expectedGeneralSubgroups = ['译文显示'];
 const expectedInterfaceGroups = ['界面与弹窗', '动画与加载效果', '菜单栏布局', '界面字体'];
-const expectedTranslationGroups = ['鼠标悬浮翻译', '划词翻译', '输入框翻译', '全文翻译'];
+const expectedTranslationGroups = ['鼠标悬浮翻译', '划词翻译', '本地朗读', '输入框翻译', '全文翻译', '右键菜单', '悬浮球进阶设置', '段落复制'];
 const expectedLoadingStyles = [
   ['ring', '柔和圆环'],
   ['minimal', '简洁'],
@@ -1148,6 +1151,7 @@ async function verifyIndependentAreaSettings(page, context, extensionOrigin, rep
     enabled: await page.getByRole('switch', {name: '启用圈选翻译', exact: true}).getAttribute('aria-checked'),
     service: (await readChoice('圈选翻译服务'))?.trim(),
     mode: (await readChoice('翻译方式'))?.trim(),
+    recognitionMode: (await readChoice('文字识别'))?.trim(),
     sourceLanguage: (await readChoice('识别语言'))?.trim(),
   };
   if (before.enabled !== 'true') await page.getByRole('switch', {name: '启用圈选翻译', exact: true}).locator('..').click();
@@ -1161,6 +1165,9 @@ async function verifyIndependentAreaSettings(page, context, extensionOrigin, rep
   await page.keyboard.press('Escape');
   await selectElementPlusOption(page, '圈选翻译服务', 'OpenAI');
   await selectElementPlusOption(page, '翻译方式', 'AI 上下文增强');
+  // 识别语言只对本地 OCR 生效；切到本地 OCR 后折叠区自动展开，再修改语言并立即关闭设置页。
+  await selectElementPlusOption(page, '文字识别', '本地 OCR');
+  await page.locator('#settings-area-translation .area-ocr-details[open]').waitFor({state: 'visible', timeout});
   await selectElementPlusOption(page, '识别语言', '繁體中文');
   const reopenedUrl = page.url();
   await page.close();
@@ -1173,9 +1180,10 @@ async function verifyIndependentAreaSettings(page, context, extensionOrigin, rep
     enabled: await page.getByRole('switch', {name: '启用圈选翻译', exact: true}).getAttribute('aria-checked'),
     service: (await readChoice('圈选翻译服务'))?.trim(),
     mode: (await readChoice('翻译方式'))?.trim(),
+    recognitionMode: (await readChoice('文字识别'))?.trim(),
     sourceLanguage: (await readChoice('识别语言'))?.trim(),
   };
-  if (JSON.stringify(after) !== JSON.stringify({enabled: 'true', service: 'OpenAI', mode: 'AI 上下文增强', sourceLanguage: '繁體中文'})) {
+  if (JSON.stringify(after) !== JSON.stringify({enabled: 'true', service: 'OpenAI', mode: 'AI 上下文增强', recognitionMode: '本地 OCR', sourceLanguage: '繁體中文'})) {
     throw new Error(`圈选设置快速关闭后丢失：${JSON.stringify({before, after})}`);
   }
   report.persistenceCases.push({case: 'independent-area-options-quick-close', before, after, closedImmediatelyAfterChange: true});
@@ -1254,6 +1262,7 @@ async function verifyIndependentAreaSettings(page, context, extensionOrigin, rep
   await selectElementPlusOption(page, '圈选翻译服务', before.service);
   await selectElementPlusOption(page, '翻译方式', before.mode);
   await selectElementPlusOption(page, '识别语言', before.sourceLanguage);
+  await selectElementPlusOption(page, '文字识别', before.recognitionMode);
   if (before.enabled !== 'true') await page.getByRole('switch', {name: '启用圈选翻译', exact: true}).locator('..').click();
   await assertTestBrowserRemainsBackground(context, '独立圈选设置验证完成');
   return page;
@@ -1398,7 +1407,8 @@ async function main() {
         }
         if (id === 'settings-area-translation') {
           const areaCopy = await anchor.innerText();
-          for (const expected of ['圈选翻译服务', '翻译方式', '识别语言', '圈选快捷键', 'Shift+Z', '不上传截图']) {
+          // 默认优先模型识图：识别语言收在 OCR 语言包折叠区，隐私说明提示识图会上传选区图片。
+          for (const expected of ['圈选翻译服务', '文字识别', '优先使用模型识图', '翻译方式', '圈选快捷键', 'Shift+Z', '模型识图会上传选区图片', 'OCR 语言包']) {
             if (!areaCopy.includes(expected)) throw new Error(`圈选独立设置缺少产品信息：${expected}`);
           }
           report.assertions.independentAreaSettings = true;
@@ -2763,7 +2773,7 @@ async function main() {
     report.screenshots.push(await screenshot(page, 'settings-dark-general.png'));
     await page.locator('button[data-section="settings-services"]').click();
     if (await page.getByTestId('model-thinking-control').count() === 0) {
-      // 服务目录分为“我的服务 / 自定义 / 全部服务”；未收藏的 OpenAI 需要从全部服务中打开。
+      // 服务目录分为“我的服务 / 全部服务”；未收藏的 OpenAI 需要从全部服务中打开。
       await page.locator('[data-service-view="all"]').click();
       await page.locator('[data-service-value="openai"]:visible').first().click();
     }
@@ -2820,10 +2830,14 @@ async function main() {
     const generalSection = page.locator('#settings-general');
     const generalGroups = (await page.locator('.settings-section:visible .settings-group-heading h2').allTextContents())
       .map(title => title.trim());
-    if (JSON.stringify(generalGroups) !== JSON.stringify(expectedGeneralGroups)) {
-      throw new Error(`通用设置分组异常：${JSON.stringify(generalGroups)}`);
+    const generalSubgroups = (await page.locator('.settings-section:visible .settings-subgroup-heading h3').allTextContents())
+      .map(title => title.trim());
+    if (JSON.stringify(generalGroups) !== JSON.stringify(expectedGeneralGroups)
+      || JSON.stringify(generalSubgroups) !== JSON.stringify(expectedGeneralSubgroups)) {
+      throw new Error(`通用设置分组异常：${JSON.stringify({generalGroups, generalSubgroups})}`);
     }
     report.informationArchitecture.generalGroups = generalGroups;
+    report.informationArchitecture.generalSubgroups = generalSubgroups;
     report.bilingualHighlightPreview = await verifyBilingualHighlightPreview(page);
     report.screenshots.push(report.bilingualHighlightPreview.screenshot);
     report.assertions.bilingualHighlightPreview = true;
@@ -2834,7 +2848,8 @@ async function main() {
       const item = card.closest('.settings-item');
       const label = item?.querySelector('.settings-item-copy strong');
       const description = item?.querySelector('.settings-item-copy small');
-      const icon = card.querySelector('.service-brand-icon');
+      // 统一下拉框后，服务图标位于 el-select 的前缀槽内，与选中文字同处一个控件。
+      const icon = card.querySelector('.el-select__prefix .service-brand-icon');
       const selected = card.querySelector('.el-select__placeholder');
       const cardStyle = getComputedStyle(card);
       const iconRect = icon?.getBoundingClientRect();
@@ -2857,8 +2872,8 @@ async function main() {
       || !defaultServiceMetrics.selectedService
       || defaultServiceMetrics.backgroundImage !== 'none'
       || defaultServiceMetrics.controlShadow !== 'none'
-      || defaultServiceMetrics.controlDisplay !== 'grid'
-      || defaultServiceMetrics.iconWidth < 39
+      || defaultServiceMetrics.controlDisplay !== 'flex'
+      || defaultServiceMetrics.iconWidth < 20
       || defaultServiceMetrics.selectWidth < 180) {
       throw new Error(`默认翻译服务没有融入标准设置行：${JSON.stringify(defaultServiceMetrics)}`);
     }
@@ -2908,6 +2923,9 @@ async function main() {
       || serviceOnlyMetrics.defaultService !== defaultServiceMetrics.defaultService) {
       throw new Error(`翻译服务页不是纯服务目录：${JSON.stringify(serviceOnlyMetrics)}`);
     }
+    // 服务目录只有“我的服务 / 全部服务”两级入口；分类、顺序与免费候选的完整矩阵归
+    // run-service-catalog-ui-test.cjs，这里只锁定设置中心依赖的目录契约。
+    const expectedServiceSections = ['machine-services', 'cloud-services', 'ai-providers', 'ai-platforms'];
     const expectedProviderServices = [
       'deepseek', 'tongyi', 'doubao', 'moonshot', 'zhipu', 'huanYuan',
       'huanYuanTranslation', 'yiyan', 'minimax', 'mimo', 'jieyue', 'openai',
@@ -2915,16 +2933,27 @@ async function main() {
     ];
     const expectedPlatformServices = [
       'siliconCloud', 'newapi', 'infini', 'openrouter', 'groq', 'azureOpenai',
+      'mistral', 'cohere', 'cerebras', 'togetherai', 'fireworks', 'deepinfra', 'perplexity', 'ollama',
     ];
-    const expectedMachineServices = [
-      'freeTranslation', 'myMemory', 'microsoft', 'google', 'deepL', 'deeplx', 'xiaoniu', 'youdao', 'tencent',
-    ];
-    const providerServices = await serviceCatalog
-      .locator('[data-service-subgroup="ai-providers"] .service-item')
-      .evaluateAll(items => items.map(item => item.getAttribute('data-service-value')));
-    const platformServices = await serviceCatalog
-      .locator('[data-service-subgroup="ai-platforms"] .service-item')
-      .evaluateAll(items => items.map(item => item.getAttribute('data-service-value')));
+    const serviceViews = await serviceCatalog.locator('[data-service-view]')
+      .evaluateAll(buttons => buttons.map(button => button.dataset.serviceView));
+    if (JSON.stringify(serviceViews) !== JSON.stringify(['mine', 'all'])) {
+      throw new Error(`服务目录视图入口异常：${JSON.stringify(serviceViews)}`);
+    }
+    const serviceDirectory = serviceCatalog.locator('.service-directory');
+    await serviceCatalog.locator('[data-service-view="all"]').click();
+    await serviceDirectory.waitFor({state: 'visible', timeout});
+    const serviceSections = await serviceDirectory.locator('[data-service-section]').evaluateAll(sections => sections.map(section => ({
+      id: section.dataset.serviceSection,
+      services: [...section.querySelectorAll('[data-service-value]')].map(item => item.dataset.serviceValue),
+    })));
+    const sectionServices = id => serviceSections.find(section => section.id === id)?.services || [];
+    if (JSON.stringify(serviceSections.map(section => section.id)) !== JSON.stringify(expectedServiceSections)) {
+      throw new Error(`服务目录分类异常：${JSON.stringify(serviceSections.map(section => section.id))}`);
+    }
+    const providerServices = sectionServices('ai-providers');
+    const platformServices = sectionServices('ai-platforms');
+    const machineServices = sectionServices('machine-services');
     if (JSON.stringify(providerServices) !== JSON.stringify(expectedProviderServices)) {
       throw new Error(`模型服务商分类或顺序异常：${JSON.stringify(providerServices)}`);
     }
@@ -2933,7 +2962,7 @@ async function main() {
     }
 
     // 新版自定义 OpenAI 服务使用持久化的 custom:* profile，不再把不可用的旧
-    // static `custom` 入口混入聚合平台。
+    // static `custom` 入口混入聚合平台；首个自定义服务出现前也不显示空的自定义分类。
     const customServiceFixture = {
       name: '浏览器自定义服务',
       endpoint: 'https://custom-browser-fixture.invalid/v1/chat/completions',
@@ -2941,77 +2970,64 @@ async function main() {
       model: 'fixture-model-v1',
       secondModel: 'fixture-model-v2',
     };
-    const customServiceGroup = serviceCatalog.locator('.custom-service-group');
-    const customServiceCount = customServiceGroup.getByTestId('custom-service-count');
-    const customServiceAdd = customServiceGroup.getByTestId('custom-service-add');
-    if ((await customServiceCount.textContent())?.trim() !== '0 / 20') {
-      throw new Error(`自定义服务初始计数异常：${await customServiceCount.textContent()}`);
+    const customServiceSection = serviceDirectory.locator('[data-service-section="custom"]');
+    const customServiceAdd = serviceCatalog.getByTestId('custom-service-add');
+    if (serviceSections.some(section => section.services.includes('custom'))
+      || await customServiceSection.count() !== 0) {
+      throw new Error('没有自定义服务时目录仍显示自定义分类或旧 custom 入口');
     }
-    if (await customServiceAdd.isDisabled()) throw new Error('空自定义服务列表无法添加首个服务');
+    if (!await customServiceAdd.isVisible() || await customServiceAdd.isDisabled()) {
+      throw new Error('服务目录工具栏没有可用的自定义服务入口');
+    }
     let customServiceId;
 
-    const machineGroup = serviceCatalog.locator('[data-service-section="machine"]');
-    const machineServices = await machineGroup.locator('.service-item')
-      .evaluateAll(items => items.map(item => item.getAttribute('data-service-value')));
-    const chromeMachineServices = [...expectedMachineServices, 'chromeTranslator'];
-    if (JSON.stringify(machineServices) !== JSON.stringify(expectedMachineServices)
-      && JSON.stringify(machineServices) !== JSON.stringify(chromeMachineServices)) {
-      throw new Error(`机器翻译分类或顺序异常：${JSON.stringify(machineServices)}`);
-    }
-    const machineToggle = machineGroup.locator('[data-service-section-toggle="machine"]');
-    if (await machineToggle.count() !== 1) throw new Error('机器翻译分组缺少唯一折叠按钮');
-    if (await machineToggle.getAttribute('aria-expanded') === 'true') await machineToggle.click();
-    if (await machineToggle.getAttribute('aria-expanded') !== 'false'
-      || await machineGroup.locator('.service-item').first().isVisible()) {
-      throw new Error('机器翻译分组无法收起');
-    }
-    const serviceSearch = serviceCatalog.getByPlaceholder('搜索翻译服务');
+    const serviceSearch = serviceCatalog.getByRole('searchbox', {name: '搜索所有翻译服务'});
     await serviceSearch.fill('微软翻译');
-    await machineGroup.locator('.service-item[data-service-value="microsoft"]').waitFor({state: 'visible', timeout});
-    if (await machineToggle.getAttribute('aria-expanded') !== 'true') {
-      throw new Error('搜索机器翻译时没有自动展开命中分组');
+    const microsoftSearch = await serviceDirectory.locator('[data-service-section]').evaluateAll(sections => sections.map(section => ({
+      id: section.dataset.serviceSection,
+      services: [...section.querySelectorAll('[data-service-value]')].map(item => item.dataset.serviceValue),
+    })));
+    if (JSON.stringify(microsoftSearch) !== JSON.stringify([{id: 'machine-services', services: ['microsoft']}])) {
+      throw new Error(`服务搜索没有唯一命中机器翻译中的微软翻译：${JSON.stringify(microsoftSearch)}`);
     }
-    if (!await machineToggle.isDisabled()) throw new Error('搜索期间机器翻译折叠按钮仍可操作');
     await serviceSearch.fill('');
-    if (await machineToggle.getAttribute('aria-expanded') !== 'false') {
-      throw new Error('清空搜索后没有恢复机器翻译折叠状态');
-    }
-    if (await machineToggle.isDisabled()) throw new Error('清空搜索后机器翻译折叠按钮没有恢复可用');
-    report.screenshots.push(await screenshot(page, 'settings-service-catalog-collapsed.png'));
-    await machineToggle.click();
-    if (await machineToggle.getAttribute('aria-expanded') !== 'true') throw new Error('机器翻译分组无法重新展开');
+    report.screenshots.push(await screenshot(page, 'settings-service-catalog-all.png'));
 
+    const defaultServiceSection = serviceSections
+      .find(section => section.services.includes(defaultServiceMetrics.defaultService))?.id;
+    if (defaultServiceSection !== 'machine-services') {
+      throw new Error(`AI 上下文开关用例没有运行在机器默认服务下：${defaultServiceSection}`);
+    }
+    await serviceCatalog.locator('[data-service-view="mine"]').click();
     const defaultServiceItem = serviceCatalog.locator(
-      `.service-item[data-service-value="${defaultServiceMetrics.defaultService}"]`,
+      `[data-personal-group="default"] [data-service-value="${defaultServiceMetrics.defaultService}"]`,
     );
-    if (await defaultServiceItem.count() !== 1) throw new Error('服务目录没有显示当前默认服务');
-    const defaultServiceKind = (await defaultServiceItem.locator('.service-copy small').textContent())?.trim();
-    if (defaultServiceKind !== '机器翻译') {
-      throw new Error(`AI 上下文开关用例没有运行在机器默认服务下：${defaultServiceKind}`);
+    if (await defaultServiceItem.count() !== 1 || !await defaultServiceItem.isVisible()) {
+      throw new Error('“我的服务”没有显示当前默认服务');
     }
     report.informationArchitecture.services = serviceOnlyMetrics;
     report.informationArchitecture.serviceCatalogHierarchy = {
+      views: serviceViews,
+      sections: serviceSections.map(section => section.id),
       providerServices,
       platformServices,
       machineServices,
       customService: {
-        initialCount: 0,
-        limit: 20,
+        initialSectionVisible: false,
         addEnabled: true,
       },
-      machineSearchAutoExpanded: true,
-      machineCollapsedStateRestored: true,
+      searchCrossesCategories: true,
     };
     report.informationArchitecture.machineDefaultAiContext = {
       defaultService: defaultServiceMetrics.defaultService,
-      serviceKind: defaultServiceKind,
+      serviceSection: defaultServiceSection,
       before: aiContextBefore,
       after: aiContextAfter,
       restored: aiContextRestored,
     };
     report.assertions.servicesCatalogOnly = true;
     report.assertions.serviceCatalogHierarchy = true;
-    report.assertions.machineServiceGroupCollapsible = true;
+    report.assertions.serviceCatalogSearch = true;
     report.assertions.machineDefaultAiContextOperable = true;
 
     await page.locator('button[data-section="settings-translation"]').click();
@@ -3079,40 +3095,46 @@ async function main() {
     await customServiceDialog.getByTestId('custom-service-model').fill(customServiceFixture.model);
     await customServiceDialog.getByTestId('custom-service-save').click();
     await customServiceDialog.waitFor({state: 'hidden', timeout});
-    const customServiceItem = customServiceGroup.locator('.service-item[data-custom-service-id^="custom:"]');
+    // 新建后直接成为“我的服务”中已保存的编辑目标，同时出现在全部服务的自定义分类里。
+    const customServiceItem = serviceCatalog.locator('[data-personal-group="configured"] [data-service-value^="custom:"]');
     await customServiceItem.waitFor({state: 'visible', timeout});
-    customServiceId = await customServiceItem.getAttribute('data-custom-service-id');
+    customServiceId = await customServiceItem.getAttribute('data-service-value');
     if (!customServiceId?.startsWith('custom:')) throw new Error(`自定义服务没有稳定动态 ID：${customServiceId}`);
-    if ((await customServiceCount.textContent())?.trim() !== '1 / 20') {
-      throw new Error(`创建后的自定义服务计数异常：${await customServiceCount.textContent()}`);
+    if (await customServiceItem.count() !== 1
+      || !(await customServiceItem.textContent())?.includes(customServiceFixture.name)) {
+      throw new Error('新建自定义服务没有以名称出现在“我的服务”已保存配置中');
     }
-    const customServiceDescriptionLayout = await customServiceItem.evaluate(item => {
-      const card = item.getBoundingClientRect();
-      const copy = item.querySelector('.service-copy')?.getBoundingClientRect();
-      const description = item.querySelector('.service-copy small');
-      const descriptionRect = description?.getBoundingClientRect();
-      const descriptionStyle = description ? getComputedStyle(description) : null;
+    await serviceCatalog.locator('[data-service-view="all"]').click();
+    const customDirectoryItems = await customServiceSection.locator('[data-service-value]')
+      .evaluateAll(items => items.map(item => item.dataset.serviceValue));
+    if (JSON.stringify(customDirectoryItems) !== JSON.stringify([customServiceId])) {
+      throw new Error(`全部服务的自定义分类异常：${JSON.stringify(customDirectoryItems)}`);
+    }
+    const customServiceLabelLayout = await customServiceSection.locator(`[data-service-value="${customServiceId}"]`).evaluate(button => {
+      const card = button.closest('.library-item')?.getBoundingClientRect();
+      const label = button.querySelector('.library-copy strong');
+      const labelRect = label?.getBoundingClientRect();
+      const labelStyle = label ? getComputedStyle(label) : null;
       return {
-        cardRight: card.right,
-        copyRight: copy?.right ?? null,
-        descriptionRight: descriptionRect?.right ?? null,
-        descriptionWidth: descriptionRect?.width ?? null,
-        descriptionScrollWidth: description?.scrollWidth ?? null,
-        overflow: descriptionStyle?.overflow ?? '',
-        textOverflow: descriptionStyle?.textOverflow ?? '',
-        whiteSpace: descriptionStyle?.whiteSpace ?? '',
+        cardRight: card?.right ?? null,
+        labelRight: labelRect?.right ?? null,
+        overflow: labelStyle?.overflow ?? '',
+        textOverflow: labelStyle?.textOverflow ?? '',
+        whiteSpace: labelStyle?.whiteSpace ?? '',
+        status: button.querySelector('.library-copy small')?.textContent?.trim() || '',
       };
     });
-    if (customServiceDescriptionLayout.descriptionRight === null
-      || customServiceDescriptionLayout.descriptionRight > customServiceDescriptionLayout.cardRight + 1
-      || customServiceDescriptionLayout.descriptionRight > (customServiceDescriptionLayout.copyRight ?? Infinity) + 1
-      || customServiceDescriptionLayout.overflow !== 'hidden'
-      || customServiceDescriptionLayout.textOverflow !== 'ellipsis'
-      || customServiceDescriptionLayout.whiteSpace !== 'nowrap') {
-      throw new Error(`自定义服务接口地址超出卡片边界：${JSON.stringify(customServiceDescriptionLayout)}`);
+    if (customServiceLabelLayout.labelRight === null || customServiceLabelLayout.cardRight === null
+      || customServiceLabelLayout.labelRight > customServiceLabelLayout.cardRight + 1
+      || customServiceLabelLayout.overflow !== 'hidden'
+      || customServiceLabelLayout.textOverflow !== 'ellipsis'
+      || customServiceLabelLayout.whiteSpace !== 'nowrap'
+      || customServiceLabelLayout.status !== '已保存配置') {
+      throw new Error(`自定义服务目录卡片名称超出边界或缺少已保存状态：${JSON.stringify(customServiceLabelLayout)}`);
     }
-    report.informationArchitecture.serviceCatalogHierarchy.customServiceDescription = customServiceDescriptionLayout;
+    report.informationArchitecture.serviceCatalogHierarchy.customServiceLabel = customServiceLabelLayout;
     report.assertions.customServiceDescriptionBounded = true;
+    await serviceCatalog.locator('[data-service-view="mine"]').click();
     if (await customServiceItem.getAttribute('aria-pressed') !== 'true'
       || await serviceCatalog.getAttribute('data-editing-service') !== customServiceId
       || await serviceCatalog.getAttribute('data-default-service') !== defaultServiceMetrics.defaultService) {
@@ -3122,7 +3144,8 @@ async function main() {
       || await serviceCatalog.getByLabel('自定义服务接口地址').inputValue() !== customServiceFixture.endpoint
       || !(await serviceCatalog.getByTestId('model-picker-trigger').getAttribute('aria-label'))
         ?.includes(customServiceFixture.model)
-      || await serviceCatalog.locator('.credential-field input[type="password"]').inputValue()
+      // API Key 由多密钥列表逐行编辑；新建服务只写入第一行。
+      || await serviceCatalog.locator('[data-api-key-list] input[type="password"]').first().inputValue()
         !== customServiceFixture.apiKey) {
       throw new Error('新建自定义服务的名称、接口、模型或 API Key 没有进入详情配置');
     }
@@ -3259,6 +3282,8 @@ async function main() {
     const importedConfig = {
       ...exportedConfig,
       to: exportedConfig.to === 'en' ? 'ja' : 'en',
+      // 当前备份以有序 apiKeys 为准，token 只镜像首个 Key；两者需同时替换才代表真实的新备份。
+      apiKeys: {...exportedConfig.apiKeys, openai: [sentinels.token]},
       token: {...exportedConfig.token, openai: sentinels.token},
       ak: sentinels.ak,
       sk: sentinels.sk,

--- a/tests/browserFocusSafety.test.ts
+++ b/tests/browserFocusSafety.test.ts
@@ -14,6 +14,8 @@ const FOCUS_SAFE_SCRIPTS = [
     'scripts/testing/run-settings-center-ui-test.cjs',
     'scripts/testing/run-popup-startup-ui-test.cjs',
     'scripts/testing/run-loading-motion-ui-test.cjs',
+    'scripts/testing/run-service-catalog-ui-test.cjs',
+    'scripts/testing/run-service-library-ui-test.cjs',
     'scripts/run-privacy-boundary-test.cjs',
     'scripts/run-site-translation-test.cjs',
     'scripts/run-userscript-smoke-test.cjs',
@@ -28,6 +30,8 @@ const ACTIVATED_EXTENSION_TAB_SCRIPTS = FOCUS_SAFE_SCRIPTS.filter(
         'scripts/testing/run-settings-center-ui-test.cjs',
         'scripts/testing/run-popup-startup-ui-test.cjs',
         'scripts/testing/run-loading-motion-ui-test.cjs',
+        'scripts/testing/run-service-catalog-ui-test.cjs',
+        'scripts/testing/run-service-library-ui-test.cjs',
         'scripts/run-userscript-smoke-test.cjs',
     ].includes(path),
 );
@@ -307,6 +311,38 @@ describe('browser regression focus safety', () => {
         expect(source).not.toContain("getByRole('button', {name: '导出配置'");
         expect(source).not.toContain("getByRole('button', {name: '导入配置'");
         expect(source).not.toContain("getByTestId('config-transfer-dialog')");
+    });
+
+    it('界面回归夹具跟随当前 Popup 快捷抽屉与服务目录结构', () => {
+        const selectionSource = readScript('scripts/run-selection-trigger-test.cjs');
+        expect(selectionSource).toContain('input[aria-label="划词翻译触发方式"]');
+        expect(selectionSource).toContain("getByRole('group', { name: '划词翻译模式' })");
+        expect(selectionSource).toContain("service: 'microsoft'");
+        expect(selectionSource).not.toContain("getByText('触发方式'");
+        expect(selectionSource).not.toContain('.chips.two button');
+
+        const popupStartupSource = readScript('scripts/testing/run-popup-startup-ui-test.cjs');
+        expect(popupStartupSource).toContain('Debugger.getScriptSource');
+        expect(popupStartupSource).toContain("const editorMarker = 'custom-hotkey-dialog'");
+        expect(popupStartupSource).not.toContain("getByRole('button', {name: '自定义', exact: true})");
+
+        const settingsSource = readScript('scripts/testing/run-settings-center-ui-test.cjs');
+        expect(settingsSource).toContain(
+            "['基础配置', ['settings-general', 'settings-services', 'settings-translation', 'settings-interface']]",
+        );
+        expect(settingsSource).toContain("[data-personal-group=\"configured\"] [data-service-value^=\"custom:\"]");
+        for (const staleSelector of ['data-service-subgroup', '.custom-service-group', 'data-service-section-toggle', '.service-item']) {
+            expect(settingsSource).not.toContain(staleSelector);
+        }
+
+        const librarySource = readScript('scripts/testing/run-service-library-ui-test.cjs');
+        expect(librarySource).toContain("['mine','all']");
+        expect(librarySource).not.toContain("viewButton('custom')");
+
+        const catalogSource = readScript('scripts/testing/run-service-catalog-ui-test.cjs');
+        expect(catalogSource).toContain("'machine-services', 'cloud-services', 'ai-providers', 'ai-platforms'");
+        expect(catalogSource).toContain('[data-free-translation-settings]');
+        expect(catalogSource).not.toContain('[data-service-section="machine"]');
     });
 
     it.each(FOCUS_SAFE_SCRIPTS)('%s 的后台路径强制使用焦点安全 helper', (path) => {


### PR DESCRIPTION
## 背景

合入 #584 与 #585 后，`main` 上有五个浏览器回归夹具仍在驱动已被重新设计的界面，因此失败。本 PR 只修改测试夹具、焦点安全源码约束和测试文档，不改产品代码。

## 改动

- **`scripts/run-selection-trigger-test.cjs`**：Popup 划词抽屉现在只提供关闭 / 双语显示 / 仅译文三个选项。触发方式、显示延迟和自定义快捷键对话框改为在同时打开的完整设置页中操作，并断言设置页、Popup 触发预览、存储配置三者一致；原有的真实划词手势矩阵全部保留（37 个用例）。主矩阵固定使用本地夹具拦截的微软翻译：默认的免费翻译会在多个公开接口间均衡分配，此前会随机请求真实网络，导致断言得到真实译文。
- **`scripts/testing/run-settings-center-ui-test.cjs`**：
  - 导航顺序改为通用 / 服务 / 翻译 / 界面。
  - 服务目录改为“我的服务 / 全部服务”两级。
  - “译文显示”作为子分组；翻译设置页新增本地朗读、右键菜单、悬浮球进阶设置、段落复制分组。
  - 圈选默认优先模型识图，识别语言收进 OCR 折叠区。
  - 默认服务图标位于下拉框前缀。
  - API Key 使用多密钥列表。
  - 备份导入同时替换 `apiKeys` 与 `token`，因为当前以有序 `apiKeys` 为准。
- **`scripts/testing/run-service-library-ui-test.cjs`**：服务视图只剩两个；自定义服务作为“全部服务”中的分类出现，并用 20 个长名称服务压测布局。
- **`scripts/testing/run-service-catalog-ui-test.cjs`**：按当前分类（机器翻译 / 云服务厂商 / 模型服务商 / 聚合平台）重写，没有删除——它仍独占免费翻译候选的浏览器覆盖：自动均衡与优先顺序、实验候选默认停用、启停、排序与重载持久化。
- **`scripts/testing/run-popup-startup-ui-test.cjs`**：快捷键编辑器已只属于设置页。改为断言 Popup 解析的脚本源码不含编辑器，且悬停、划词、圈选抽屉打开时焦点进入、关闭后回到对应卡片。
- **`tests/browserFocusSafety.test.ts`**：新增两个服务夹具的焦点安全约束，并锁定上述新选择器，防止改回旧界面结构。
- **`docs/testing.md`**：补充服务目录两个夹具的分工，以及划词、Popup 抽屉的新验证范围。

## 验证

均基于变基到 `871ff3a2` 之后的生产构建 `.output/chrome-mv3`，使用临时 Edge profile 和 focus-safe helper：

| 夹具 | 结果 | 证据目录 |
| --- | --- | --- |
| selection-trigger | 37 用例通过 | `/private/tmp/fluentread-rebased2-selection-trigger` |
| settings-center | 51 项断言通过 | `/private/tmp/fluentread-rebased2-settings-center` |
| service-library | 21 用例通过 | `/private/tmp/fluentread-rebased-service-library` |
| service-catalog | 通过 | `/private/tmp/fluentread-rebased-service-catalog` |
| popup-startup | 通过 | `/private/tmp/fluentread-rebased-popup-startup` |

- 五个报告均为 `launchMode: macos-background-cdp`、`focusPolicy: launchservices-no-foreground`、`windowPlacement.mode: background-visible-no-focus`、`browserFrontmost: false`（第二屏），控制台错误均为 0。
- service-library、service-catalog、popup-startup 最后一次运行基于 `5a397709`；#591 只改右键菜单，因此在 `871ff3a2` 上重跑了会涉及右键菜单配置的设置中心与划词夹具。
- 本地检查：`pnpm test:audit` 通过（337 个文件、4407 个用例），`tests/browserFocusSafety.test.ts` 73 项通过，`pnpm docs:build` 通过，`git diff --check` 通过。
- 调试期间有两次运行被 helper 以“测试 Edge 成为前台应用”中止，都发生在其他运行中正常通过的检查点，当时用户会话正在切换应用；清理后未留下进程，重试通过。

## 观察到但未修改的产品行为

服务目录的分类筛选按钮（全部分类 / 机器翻译 / …）虽有 `aria-pressed`，但没有可见的选中样式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
