### PR TITLE
修复本地模型日志误报及 OCR 旧参数提示

### DIFF
--- a/scripts/testing/run-ocr-diagnostics-smoke.cjs
+++ b/scripts/testing/run-ocr-diagnostics-smoke.cjs
@@ -1,0 +1,104 @@
+'use strict';
+
+// 在隔离扩展副本中比较原始与已适配的真实 OCR core；语言包从指定本地测试目录读取。
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const assert = require('node:assert/strict');
+const arg = (name, fallback) => { const i = process.argv.indexOf(`--${name}`); return i < 0 ? fallback : process.argv[i + 1]; };
+const source = path.resolve(arg('extension-dir', '.output/chrome-mv3'));
+const languageDirectory = arg('language-dir');
+assert.ok(languageDirectory, '--language-dir must contain chi_sim.traineddata and eng.traineddata');
+const languages = path.resolve(languageDirectory);
+const artifacts = path.resolve(arg('artifacts-dir', '/private/tmp/fluentread-ocr-diagnostics'));
+const {chromium} = require(path.join(arg('playwright-root', '/Users/thinkstu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/node_modules'), 'playwright'));
+const {launchFocusSafePersistentContext, newPageWithoutForeground} = require(arg('focus-safe-helper', '/Users/thinkstu/.codex/skills/fluentread-extension-ui-test/scripts/focus-safe-browser.cjs'));
+for (const language of ['chi_sim', 'eng']) assert.ok(fs.existsSync(path.join(languages, `${language}.traineddata`)), `Missing ${language} test data`);
+const profile = fs.mkdtempSync(path.join(os.tmpdir(), 'fluentread-ocr-diagnostics-profile-'));
+const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'fluentread-ocr-diagnostics-extension-'));
+fs.mkdirSync(artifacts, {recursive: true});
+fs.cpSync(source, fixture, {recursive: true});
+fs.mkdirSync(path.join(fixture, 'probe-data'));
+for (const language of ['chi_sim', 'eng']) fs.copyFileSync(path.join(languages, `${language}.traineddata`), path.join(fixture, 'probe-data', `${language}.traineddata`));
+fs.copyFileSync(path.resolve('public/fluent-read-ocr/core/tesseract-core-simd-lstm.wasm.js'), path.join(fixture, 'probe-ocr-baseline.js'));
+fs.copyFileSync(path.resolve('node_modules/tesseract.js/dist/tesseract.min.js'), path.join(fixture, 'probe-tesseract.js'));
+fs.writeFileSync(path.join(fixture, 'probe.html'), '<!doctype html><title>OCR diagnostics verification</title><h1>OCR diagnostics verification</h1>');
+const report = {source, cases: [], pageErrors: [], evidence: 'Real packaged Tesseract SIMD LSTM core, local chi_sim + eng models and a generated printed-text fixture; no handwriting or live-page accuracy claim.'};
+(async () => {
+    let session;
+    try {
+        session = await launchFocusSafePersistentContext({chromium, profileDir: profile,
+            browserPath: '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge', headless: false, background: true,
+            viewport: {width: 1100, height: 800}, browserArgs: ['--no-first-run', '--no-default-browser-check', `--disable-extensions-except=${fixture}`, `--load-extension=${fixture}`]});
+        Object.assign(report, {launchMode: session.launchMode, focusPolicy: session.focusPolicy, windowPlacement: session.windowPlacement});
+        const {context} = session;
+        const background = context.serviceWorkers().find(worker => worker.url().startsWith('chrome-extension://')) || await context.waitForEvent('serviceworker', {timeout: 30000});
+        const origin = background.url().match(/^chrome-extension:\/\/[^/]+/)[0];
+        const page = await newPageWithoutForeground(context);
+        const logs = [];
+        page.on('console', message => logs.push({type: message.type(), text: message.text()}));
+        page.on('pageerror', error => report.pageErrors.push(error.message));
+        await page.goto(`${origin}/probe.html`);
+        await page.addScriptTag({url: `${origin}/probe-tesseract.js`});
+        for (const label of ['baseline', 'adapted']) {
+            logs.length = 0;
+            const result = await page.evaluate(async ({label, origin}) => {
+                const canvas = document.createElement('canvas');
+                canvas.width = 1000; canvas.height = 130;
+                const ctx = canvas.getContext('2d');
+                ctx.fillStyle = '#ffffff'; ctx.fillRect(0, 0, canvas.width, canvas.height);
+                ctx.fillStyle = '#000000'; ctx.font = '42px Arial';
+                ctx.fillText('流畅阅读 FluentRead 123', 30, 80);
+                const dataUrl = canvas.toDataURL('image/png');
+                const worker = await Tesseract.createWorker(['chi_sim', 'eng'], 1, {
+                    workerPath: `${origin}/fluent-read-ocr/worker/worker.min.js`,
+                    corePath: `${origin}/${label === 'baseline' ? 'probe-ocr-baseline.js' : 'fluent-read-ocr/core/tesseract-core-simd-lstm.wasm.js'}`,
+                    langPath: `${origin}/probe-data`, gzip: false, cacheMethod: 'none', workerBlobURL: false,
+                    errorHandler: () => {},
+                }, {tessedit_load_sublangs: ''});
+                try {
+                    await worker.setParameters({tessedit_pageseg_mode: 11, preserve_interword_spaces: '1'});
+                    const first = await worker.recognize(dataUrl, {}, {blocks: true});
+                    const second = await worker.recognize(dataUrl, {}, {blocks: true});
+                    return {text: first.data.text, confidence: first.data.confidence, repeatedText: second.data.text};
+                } finally {await worker.terminate();}
+            }, {label, origin});
+            report.cases.push({label, ...result, logs: [...logs]});
+            assert.match(result.text, /FluentRead 123/);
+            assert.equal(result.text, result.repeatedText);
+        }
+        assert.equal(report.cases[0].text, report.cases[1].text);
+        assert.equal(report.cases[0].confidence, report.cases[1].confidence);
+        const oldParameter = entry => /Warning: Parameter not found: language_model_ngram_on/.test(entry.text);
+        assert.ok(report.cases[0].logs.some(entry => oldParameter(entry) && entry.type === 'warning'));
+        assert.ok(report.cases[1].logs.some(entry => oldParameter(entry) && entry.type === 'debug'));
+        assert.equal(report.cases[1].logs.filter(entry => ['warning', 'error'].includes(entry.type)).length, 0);
+        logs.length = 0;
+        // 仅破坏这次临时 Worker 的虚拟文件；不修改下载目录、浏览器缓存或用户数据。
+        report.failureCase = await page.evaluate(async origin => {
+            const worker = await Tesseract.createWorker('eng', 1, {
+                workerPath: `${origin}/fluent-read-ocr/worker/worker.min.js`,
+                corePath: `${origin}/fluent-read-ocr/core/tesseract-core-simd-lstm.wasm.js`,
+                langPath: `${origin}/probe-data`, gzip: false, cacheMethod: 'none', workerBlobURL: false,
+                errorHandler: () => {},
+            }, {tessedit_load_sublangs: ''});
+            try {
+                await worker.FS('unlink', ['/eng.traineddata']);
+                try {await worker.reinitialize('eng', 1, {tessedit_load_sublangs: ''}); return {rejected: false};}
+                catch (error) {return {rejected: true, error: String(error)};}
+            } finally {await worker.terminate();}
+        }, origin);
+        report.failureCase.logs = [...logs];
+        assert.equal(report.failureCase.rejected, true);
+        assert.ok(logs.some(entry => entry.type === 'error' && /Error|Failed|couldn.t/i.test(entry.text)));
+        assert.deepEqual(report.pageErrors, []);
+        report.ok = true;
+    } catch (error) {report.ok = false; report.failure = error.stack; process.exitCode = 1;}
+    finally {
+        fs.writeFileSync(path.join(artifacts, 'report.json'), JSON.stringify(report, null, 2));
+        console.log(JSON.stringify(report, null, 2));
+        if (session) await session.close();
+        fs.rmSync(profile, {recursive: true, force: true});
+        fs.rmSync(fixture, {recursive: true, force: true});
+    }
+})();

--- a/scripts/testing/run-ort-runtime-smoke.cjs
+++ b/scripts/testing/run-ort-runtime-smoke.cjs
@@ -13,13 +13,14 @@ function arg(name, fallback) { const i = process.argv.indexOf(`--${name}`); retu
 const source = path.resolve(arg('extension-dir', '.output/chrome-mv3'));
 const artifacts = path.resolve(arg('artifacts-dir', '/private/tmp/fluentread-ort-smoke'));
 const prototype = process.argv.includes('--prototype');
+const diagnostics = process.argv.includes('--diagnostics');
 const {chromium} = require(path.join(arg('playwright-root', '/Users/thinkstu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/node_modules'), 'playwright'));
 const {launchFocusSafePersistentContext, newPageWithoutForeground} = require(arg('focus-safe-helper', '/Users/thinkstu/.codex/skills/fluentread-extension-ui-test/scripts/focus-safe-browser.cjs'));
 const profile = fs.mkdtempSync(path.join(os.tmpdir(), 'fluentread-ort-smoke-profile-'));
 const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'fluentread-ort-smoke-extension-'));
 fs.mkdirSync(artifacts, {recursive: true});
 fs.cpSync(source, fixture, {recursive: true});
-const report = {source, prototype, cases: [], errors: [], evidence: 'Real ONNX Identity session in an owned extension Worker; this does not claim full translation, speech synthesis or transcription quality.'};
+const report = {source, prototype, diagnostics, cases: [], errors: [], evidence: 'Real ONNX Identity session in an owned extension Worker; this does not claim full translation, speech synthesis or transcription quality.'};
 const expectedDigests = {};
 
 // ONNX ModelProto: Identity(float32[1]) with opset 13, generated without a model download.
@@ -29,7 +30,9 @@ const message = (field, data) => { const bytes = typeof data === 'string' ? Buff
 const valueInfo = name => message(name === 'input' ? 11 : 12, Buffer.concat([
   message(1, name), message(2, message(1, Buffer.concat([scalar(1, 1), message(2, message(1, scalar(1, 1)))]))),
 ]));
-const graph = Buffer.concat([message(1, Buffer.concat([message(1, 'input'), message(2, 'output'), message(4, 'Identity')])), message(2, 'identity'), valueInfo('input'), valueInfo('output')]);
+// 未使用的 initializer 会让真实 ORT 在建会话时发出 WARNING，验证打包 glue 的实际分级。
+const unused = diagnostics ? message(5, Buffer.concat([scalar(1, 1), scalar(2, 1), message(8, 'unused_diagnostic_probe'), message(9, Buffer.from([0, 0, 128, 63]))])) : Buffer.alloc(0);
+const graph = Buffer.concat([message(1, Buffer.concat([message(1, 'input'), message(2, 'output'), message(4, 'Identity')])), message(2, 'identity'), valueInfo('input'), valueInfo('output'), unused]);
 const model = Buffer.concat([scalar(1, 8), message(7, graph), message(8, scalar(2, 13))]);
 fs.writeFileSync(path.join(fixture, 'probe-model.onnx'), model);
 fs.writeFileSync(path.join(fixture, 'probe.html'), '<!doctype html><title>ORT packaged runtime verification</title><h1>ORT packaged runtime verification</h1>');
@@ -84,10 +87,13 @@ self.onmessage = async ({data: {backend}}) => {
     const background = context.serviceWorkers().find(worker => worker.url().startsWith('chrome-extension://')) || await context.waitForEvent('serviceworker', {timeout: 30000});
     const origin = background.url().match(/^chrome-extension:\/\/[^/]+/)[0];
     const page = await newPageWithoutForeground(context);
+    const consoleLogs = [];
+    page.on('console', message => consoleLogs.push({type: message.type(), text: message.text()}));
     page.on('pageerror', error => report.errors.push(error.message));
     await page.goto(`${origin}/probe.html`);
     for (const label of ['opus-whisper', 'kokoro']) {
       for (const backend of ['wasm', 'webgpu']) {
+      const logStart = consoleLogs.length;
       const result = await page.evaluate(({label, backend}) => new Promise((resolve, reject) => {
         const worker = new Worker(new URL(`probe-${label}.mjs`, location.href), {type: 'module'});
         const timer = setTimeout(() => {worker.terminate(); reject(new Error('ORT initialization timed out'));}, 45000);
@@ -100,6 +106,12 @@ self.onmessage = async ({data: {backend}}) => {
       assert.deepEqual(result.output, [42]);
       assert.deepEqual(result.reusedOutput, [-7]);
       assert.equal(result.digest, expectedDigests[label], '解压结果必须逐字节等于锁定依赖中的 WASM');
+      if (diagnostics) {
+        const logs = consoleLogs.slice(logStart);
+        report.cases.at(-1).logs = logs;
+        assert.ok(logs.some(entry => entry.type === 'warning' && entry.text.includes('unused_diagnostic_probe')), '真实 ORT 警告必须以 warning 输出');
+        assert.ok(!logs.some(entry => entry.type === 'error'), '正常推理不能把警告记录为 error');
+      }
       }
     }
     assert.deepEqual(report.errors, []);

--- a/scripts/wasm/diagnostics.js
+++ b/scripts/wasm/diagnostics.js
@@ -1,0 +1,27 @@
+/**
+ * WASM 私有 stderr 适配器，由构建器插入各引擎 glue 的闭包内。
+ * 不覆盖全局 console，不更改模型、执行后端、参数或 Promise 错误传播。
+ * 本文件保留为普通 JS，让发布资产中的诊断不被业务构建的 drop:console 删除。
+ */
+function fluentReadWasmStderr(message) {
+    const text = String(message).replace(/\u001b\[[0-9;]*m/g, '');
+    // ORT 将所有严重级别写入 stderr，Emscripten 默认全部转为 console.error。
+    const onnx = !/[\r\n]/.test(text.trim())
+        && /^(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ )?\[([VIWEF]):onnxruntime[:\]]/.exec(text);
+    if (onnx) {
+        const level = {V: 'debug', I: 'info', W: 'warn', E: 'error', F: 'error'}[onnx[1]];
+        console[level](text);
+        return;
+    }
+    // 官方 CJK traineddata 仍带有 Legacy 引擎参数；LSTM-only core 不包含这些参数。
+    // 只降级已核对的完整单行提示；陌生参数或附带其他错误的输出仍然可见。
+    if (/^Warning: Parameter not found: (?:language_model_ngram_on|segsearch_max_char_wh_ratio|language_model_ngram_space_delimited_language|language_model_ngram_scale_factor|language_model_use_sigmoidal_certainty|language_model_ngram_nonmatch_score|classify_integer_matcher_multiplier|assume_fixed_pitch_char_segment|chop_enable|allow_blob_division)\s*$/.test(text)
+        || /^Estimating resolution as \d+\s*$/.test(text)) {
+        console.debug(text);
+    } else if (/^Warning:[^\r\n]*\s*$/.test(text)) {
+        console.warn(text);
+    } else {
+        // 未知 stderr 采用保守的错误级别；不能因为首行像提示就吞掉后续失败。
+        console.error(text);
+    }
+}

--- a/scripts/wasm/package-diagnostics.ts
+++ b/scripts/wasm/package-diagnostics.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** 仅适配锁定依赖的浏览器 stderr 出口，保留 vendor 文件和 WASM 二进制原样。 */
+export function instrumentWasmDiagnostics(source: string, runtime: 'onnx' | 'tesseract', adapter: string): string {
+    const factory = runtime === 'onnx'
+        ? /(?:async function\(moduleArg = \{\}\) \{|async function ortWasmThreaded\(moduleArg=\{\}\)\{)/g
+        : /function\(TesseractCore = \{\}\)  \{/g;
+    const stderr = runtime === 'onnx' ? 'console.error.bind(console)' : 'console.warn.bind(console)';
+    // 格式变化必须在构建时失败，避免升级后静默失去分级或替换错误位置。
+    if ([...source.matchAll(factory)].length !== 1 || source.split(stderr).length !== 2) {
+        throw new Error(`Unsupported ${runtime} WASM diagnostic glue`);
+    }
+    const result = source.replace(factory, match => `${match}\n${adapter}\n`).replace(stderr, 'fluentReadWasmStderr');
+    // ORT 的 pthread 分支还有单独的 stderr 转发；只改 vendor 源中的出口，不能改适配器本身。
+    return runtime === 'onnx'
+        ? result.replace(/console\.error\(([a-z])\)/g, 'fluentReadWasmStderr($1)')
+        : result;
+}
+
+export function packageWasmDiagnostics(root: string, sourcePath: string, fileName: string, runtime: 'onnx' | 'tesseract'): string {
+    const adapter = fs.readFileSync(path.resolve(root, 'scripts/wasm/diagnostics.js'), 'utf8');
+    const source = fs.readFileSync(sourcePath, 'utf8');
+    const output = path.resolve(root, '.wxt/packaged-wasm', fileName);
+    fs.mkdirSync(path.dirname(output), {recursive: true});
+    fs.writeFileSync(output, instrumentWasmDiagnostics(source, runtime, adapter));
+    return output;
+}

--- a/tests/test-matrix.json
+++ b/tests/test-matrix.json
@@ -253,6 +253,7 @@
       "tests/localTtsBackground.test.ts",
       "tests/localTtsModelCache.test.ts",
       "tests/onnxWasmBinary.test.ts",
+      "tests/wasmDiagnostics.test.ts",
       "tests/onnxWebGpu.test.ts",
       "tests/localTtsWorker.test.ts"
     ],

--- a/tests/wasmDiagnostics.test.ts
+++ b/tests/wasmDiagnostics.test.ts
@@ -1,0 +1,66 @@
+import {describe, expect, it, vi} from 'vitest';
+import {readFileSync} from 'node:fs';
+import {runInNewContext} from 'node:vm';
+import {instrumentWasmDiagnostics} from '../scripts/wasm/package-diagnostics';
+
+const adapter = readFileSync(new URL('../scripts/wasm/diagnostics.js', import.meta.url), 'utf8');
+const createLog = () => {
+    const output = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()};
+    const write = runInNewContext(`${adapter}\nfluentReadWasmStderr`, {console: output});
+    return {output, write};
+};
+
+describe('packaged WASM diagnostic severity', () => {
+    it('保留 ONNX 原始严重级别，去除终端颜色并保留性能警告', () => {
+        const {output, write} = createLog();
+        const warning = '2026-09-13 15:13:13.499400 [W:onnxruntime:, session_state.cc:1280 VerifyEachNodeIsAssignedToAnEp] Some nodes were not assigned to the preferred execution providers';
+        write(`\u001b[0;93m${warning}\u001b[m`);
+        expect(output.warn).toHaveBeenCalledWith(warning);
+        for (const [severity, level] of [['V', 'debug'], ['I', 'info'], ['E', 'error'], ['F', 'error']] as const) {
+            const text = `[${severity}:onnxruntime:Default] diagnostic`;
+            write(text);
+            expect(output[level]).toHaveBeenCalledWith(text);
+        }
+        expect(output.error).toHaveBeenCalledTimes(2);
+    });
+
+    it('仅把已知 LSTM 旧参数和分辨率提示降为 debug，未知警告与失败保持可见', () => {
+        const {output, write} = createLog();
+        for (const parameter of ['language_model_ngram_on', 'segsearch_max_char_wh_ratio', 'language_model_ngram_space_delimited_language', 'language_model_ngram_scale_factor', 'language_model_use_sigmoidal_certainty', 'language_model_ngram_nonmatch_score', 'classify_integer_matcher_multiplier', 'assume_fixed_pitch_char_segment', 'chop_enable', 'allow_blob_division']) {
+            write(`Warning: Parameter not found: ${parameter}`);
+        }
+        write('Estimating resolution as 225');
+        expect(output.debug).toHaveBeenCalledTimes(11);
+        write('Warning: Parameter not found: future_required_parameter');
+        expect(output.warn).toHaveBeenCalledWith('Warning: Parameter not found: future_required_parameter');
+        for (const text of [
+            'Error opening data file eng.traineddata',
+            'Aborted(out of memory)',
+            'Warning: Parameter not found: allow_blob_division\nFailed loading language',
+            'Estimating resolution as 225\nError loading model',
+            'unexpected [W:onnxruntime:Default] failure',
+            '[W:onnxruntime:Default] warning\nError loading model',
+        ]) {
+            write(text);
+            expect(output.error).toHaveBeenCalledWith(text);
+        }
+        expect(output.error).toHaveBeenCalledTimes(6);
+    });
+
+    it('在引擎闭包内适配 stderr，不替换外部 console，拒绝陌生 glue 格式', async () => {
+        const glue = 'var core = async function(moduleArg = {}) { const stderr = console.error.bind(console); stderr(moduleArg.message); return moduleArg; }; core;';
+        const output = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()};
+        const error = output.error;
+        const core = runInNewContext(instrumentWasmDiagnostics(glue, 'onnx', adapter), {console: output});
+        const args = {message: '[W:onnxruntime:Default] warning', wasmBinary: new Uint8Array([0, 97, 115, 109])};
+        expect(await core(args)).toBe(args);
+        expect(output.warn).toHaveBeenCalledWith(args.message);
+        expect(output.error).toBe(error);
+        output.error('outside engine');
+        expect(output.error).toHaveBeenCalledWith('outside engine');
+        expect(() => instrumentWasmDiagnostics('new vendor format', 'onnx', adapter)).toThrow('Unsupported');
+        expect(() => instrumentWasmDiagnostics(`${glue}\n${glue}`, 'onnx', adapter)).toThrow('Unsupported');
+        const ocr = readFileSync(new URL('../public/fluent-read-ocr/core/tesseract-core-simd-lstm.wasm.js', import.meta.url), 'utf8');
+        expect(instrumentWasmDiagnostics(ocr, 'tesseract', adapter)).toContain('n=b.printErr||fluentReadWasmStderr');
+    });
+});

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -7,6 +7,7 @@ import {resolveBrowserCapabilities} from './src/platform/browser/capabilities';
 import {wllamaExtensionWorker} from './scripts/testing/wllama-extension-build';
 import {createUiLanguageBundleFiles} from './src/core/i18n/bundles';
 import {UI_LANGUAGE_BUNDLE_DIRECTORY} from './src/core/i18n/language';
+import {packageWasmDiagnostics} from './scripts/wasm/package-diagnostics';
 
 
 const packageJson = JSON.parse(fs.readFileSync(resolve(__dirname, 'package.json'), 'utf-8'));
@@ -207,11 +208,14 @@ export default defineConfig({
             files.push({absoluteSrc: resolve(__dirname, 'node_modules/@noble/hashes/LICENSE'), relativeDest: 'third-party-notices/noble-hashes-MIT.txt'});
             files.push({absoluteSrc: resolve(__dirname, 'node_modules/@wllama/wllama/esm/wasm/wllama.wasm'), relativeDest: 'fluent-read-ai/wllama.wasm'});
             const opusOrtDist = resolvePnpmDependencyDist('node_modules/@huggingface/transformers', 'onnxruntime-web');
-            files.push({absoluteSrc: resolve(opusOrtDist, 'ort-wasm-simd-threaded.jsep.mjs'), relativeDest: 'fluent-read-ai/ort-wasm-simd-threaded.jsep.mjs'});
+            files.push({absoluteSrc: packageWasmDiagnostics(__dirname, resolve(opusOrtDist, 'ort-wasm-simd-threaded.jsep.mjs'), 'ort-wasm-simd-threaded.jsep.mjs', 'onnx'), relativeDest: 'fluent-read-ai/ort-wasm-simd-threaded.jsep.mjs'});
             files.push({absoluteSrc: createCompressedWasmAsset(resolve(opusOrtDist, 'ort-wasm-simd-threaded.jsep.wasm'), 'ort-wasm-simd-threaded.jsep.wasm.gz'), relativeDest: 'fluent-read-ai/ort-wasm-simd-threaded.jsep.wasm.gz'});
             const ttsOrtDist = resolvePnpmDependencyDist('node_modules/@huggingface/transformers-kokoro', 'onnxruntime-web');
-            files.push({absoluteSrc: resolve(ttsOrtDist, 'ort-wasm-simd-threaded.asyncify.mjs'), relativeDest: 'fluent-read-ai/tts-ort-wasm-simd-threaded.asyncify.mjs'});
+            files.push({absoluteSrc: packageWasmDiagnostics(__dirname, resolve(ttsOrtDist, 'ort-wasm-simd-threaded.asyncify.mjs'), 'tts-ort-wasm-simd-threaded.asyncify.mjs', 'onnx'), relativeDest: 'fluent-read-ai/tts-ort-wasm-simd-threaded.asyncify.mjs'});
             files.push({absoluteSrc: createCompressedWasmAsset(resolve(ttsOrtDist, 'ort-wasm-simd-threaded.asyncify.wasm'), 'tts-ort-wasm-simd-threaded.asyncify.wasm.gz'), relativeDest: 'fluent-read-ai/tts-ort-wasm-simd-threaded.asyncify.wasm.gz'});
+            const ocrCore = files.find(file => file.relativeDest === 'fluent-read-ocr/core/tesseract-core-simd-lstm.wasm.js');
+            if (!ocrCore || !('absoluteSrc' in ocrCore)) throw new Error('Missing packaged OCR core');
+            ocrCore.absoluteSrc = packageWasmDiagnostics(__dirname, ocrCore.absoluteSrc, 'tesseract-core-simd-lstm.wasm.js', 'tesseract');
         },
     },
 


### PR DESCRIPTION
本地模型正常初始化时，ONNX 的 `[W:onnxruntime]` 警告经 Emscripten stderr 被记成 `console.error`；CJK OCR 语言包保留的旧引擎参数和分辨率估算也会反复出现在控制台。

本次仅在打包时适配引擎内部的 stderr 出口：保留 ONNX 原始日志级别，将已核对的 LSTM 无效旧参数和分辨率提示转为 debug，未知参数仍为 warning，真实错误仍为 error。不覆盖全局 console，不更改模型、执行后端、缓存、识别逻辑或 WASM 二进制。底层 glue 格式不匹配时构建会明确失败。

验证：

- 54 项针对性测试通过；类型检查、测试审计、Chrome 和 Firefox 生产构建通过。
- 隔离 Edge 使用生产产物：两套 ORT runtime × CPU/WebGPU 共 4 种组合均完成真实 Identity 图推理及会话重建；未使用 initializer 触发的原生警告均为 warning，无误记为 error 的情况。
- 真实 Tesseract SIMD LSTM 使用本地 chi_sim + eng 测试语言包：原始和适配后的 core 均连续两次识别出“流畅阅读 FluentRead 123”，置信度均为 91；8 条旧参数 warning 转为 debug。临时 Worker 缺失语言文件时请求仍拒绝，4 条真实错误保留。
- 浏览器使用独立临时 profile、第二屏正常窗口和不抢前台的启动方式；Firefox 本轮只验证构建。微型 ONNX 图及印刷文本样本不代表完整模型性能、真实网页或手写识别质量。

复现入口：`run-ort-runtime-smoke.cjs --diagnostics`；`run-ocr-diagnostics-smoke.cjs --language-dir <含 chi_sim.traineddata 和 eng.traineddata 的测试目录>`。两者均支持 `--extension-dir` 和 `--artifacts-dir`。
